### PR TITLE
feat: #2 add Claude marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,15 +10,7 @@
   "plugins": [
     {
       "name": "superteam",
-      "version": "0.1.0",
       "description": "Claude Code plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
-      "author": {
-        "name": "Patina Project",
-        "url": "https://github.com/patinaproject"
-      },
-      "homepage": "https://github.com/patinaproject/superteam",
-      "repository": "https://github.com/patinaproject/superteam",
-      "license": "MIT",
       "category": "productivity",
       "source": {
         "source": "github",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "patinaproject-skills",
+  "owner": {
+    "name": "Patina Project",
+    "url": "https://github.com/patinaproject"
+  },
+  "plugins": [
+    {
+      "name": "superteam",
+      "version": "0.1.0",
+      "description": "Claude Code plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
+      "author": {
+        "name": "Patina Project",
+        "url": "https://github.com/patinaproject"
+      },
+      "homepage": "https://github.com/patinaproject/superteam",
+      "repository": "https://github.com/patinaproject/superteam",
+      "license": "MIT",
+      "category": "productivity",
+      "source": {
+        "source": "github",
+        "repo": "patinaproject/superteam"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,6 +4,9 @@
     "name": "Patina Project",
     "url": "https://github.com/patinaproject"
   },
+  "metadata": {
+    "description": "Marketplace catalog for Patina Project Claude Code plugins and skills."
+  },
   "plugins": [
     {
       "name": "superteam",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ This repository is the marketplace surface for Patina Project plugins and relate
 
 For Superpowers-generated design and planning artifacts, use issue-based filenames and the following acceptance criteria format:
 
-- `docs/superpowers/specs/YYYY-MM-DD-<issue-number>-<topic>-design.md`
-- `docs/superpowers/plans/YYYY-MM-DD-<issue-number>-<topic>-plan.md`
+- `docs/superpowers/specs/YYYY-MM-DD-<issue-number>-<issue-title>-design.md`
+- `docs/superpowers/plans/YYYY-MM-DD-<issue-number>-<issue-title>-plan.md`
 - Acceptance criteria IDs: `AC-<issue-number>-<integer>`
 
 ## Build, Test, and Development Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 
 - `.agents/plugins/marketplace.json`: repo-local marketplace source of truth
 - `plugins/`: optional vendored plugin packages when this repo carries local copies
-- `docs/`: contributor docs plus planning artifacts such as `docs/file-structure.md` and `docs/superpowers/`
+- `docs/`: contributor docs plus planning artifacts; use paths such as `docs/file-structure.md` and, when present, `docs/superpowers/`
 - If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
 - root config: `package.json`, `commitizen.config.js`, `commitlint.config.js`, and `.husky/`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,19 @@
 
 ## Project Structure & Module Organization
 
-This repo is the marketplace surface for Patina Project Codex plugins.
+This repository is the marketplace surface for Patina Project plugins and related install documentation.
 
-- `.agents/plugins/marketplace.json`: source of truth for plugin registration
-- `plugins/`: optional vendored plugins when the marketplace carries local packaged copies
-- `docs/`: marketplace and maintenance docs
-- root tooling: `pnpm`, Commitizen, commitlint, and Husky
+- `.agents/plugins/marketplace.json`: repo-local marketplace source of truth
+- `plugins/`: optional vendored plugin packages when this repo carries local copies
+- `docs/`: contributor docs plus planning artifacts such as `docs/file-structure.md` and `docs/superpowers/`
+- If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
+- root config: `package.json`, `commitizen.config.js`, `commitlint.config.js`, and `.husky/`
+
+For Superpowers-generated design and planning artifacts, use issue-based filenames and the following acceptance criteria format:
+
+- `docs/superpowers/specs/YYYY-MM-DD-<issue-number>-<topic>-design.md`
+- `docs/superpowers/plans/YYYY-MM-DD-<issue-number>-<topic>-plan.md`
+- Acceptance criteria IDs: `AC-<issue-number>-<integer>`
 
 ## Build, Test, and Development Commands
 
@@ -40,3 +47,13 @@ Commits must use conventional commit types, no scopes, and a required GitHub iss
 Examples:
 - `chore: #1 bootstrap marketplace repo`
 - `feat: #12 add superteam marketplace entry`
+
+For squash-and-merge workflows, PR titles must match the commitlint commit format:
+
+`type: #123 short description`
+
+When an issue defines acceptance criteria, include an `Acceptance Criteria` section in the PR description.
+
+- Use one `### AC-<issue>-<n>` heading per relevant AC
+- Put a short outcome summary directly under each heading
+- Put verification steps under the AC they validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 
 This repository is the marketplace surface for Patina Project plugins and related install documentation.
 
-- `.agents/plugins/marketplace.json`: repo-local marketplace source of truth
+- `.agents/plugins/marketplace.json`: repo-local Codex marketplace source of truth
+- `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth
 - `plugins/`: optional vendored plugin packages when this repo carries local copies
 - `docs/`: contributor docs plus planning artifacts; use paths such as `docs/file-structure.md` and, when present, `docs/superpowers/`
 - If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+See [AGENTS.md](./AGENTS.md) for the repository instructions and contributor workflow.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 
 - `superteam`: installed from `patinaproject/superteam` using a `git-subdir` source that targets `./plugins/superteam` on `main`
 
+## Install Surfaces
+
+- `patinaproject/skills` is the marketplace catalog
+- `patinaproject/superteam` is the source-of-truth plugin repository
+- Codex installs `superteam` through the marketplace entry that targets `./plugins/superteam` in `patinaproject/superteam`
+- Claude-compatible installation is owned by the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
+
 ## How it works
 
 Codex reads the marketplace definition from `.agents/plugins/marketplace.json`.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 ## Install Surfaces
 
 - `patinaproject/skills` is the marketplace catalog
-- `patinaproject/superteam` is the source-of-truth plugin repository
+- `patinaproject/superteam` is the source of truth for the upstream plugin package
 - Codex installs `superteam` through the marketplace entry that targets `./plugins/superteam` in `patinaproject/superteam`
-- Claude-compatible installation is owned by the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
+- The Claude plugin packaging and install surface live in the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Patina Project Skills
 
-This repository is the Codex marketplace for Patina Project plugins.
+This repository carries the Patina Project marketplace catalogs for both Codex and Claude plugins.
 
 It is a marketplace catalog, not the source repo for every plugin. Marketplace entries can point at plugins packaged in this repo, or at Git-backed plugin sources maintained in other Patina Project repositories.
 
@@ -10,14 +10,16 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 
 ## Install Surfaces
 
-- `patinaproject/skills` is the marketplace catalog
+- `patinaproject/skills` owns the marketplace catalogs and contributor docs
 - `patinaproject/superteam` is the source of truth for the upstream plugin package
+- Codex marketplace metadata lives in `.agents/plugins/marketplace.json`
+- Claude marketplace metadata lives in `.claude-plugin/marketplace.json`
 - Codex installs `superteam` through the marketplace entry that targets `./plugins/superteam` in `patinaproject/superteam`
 - The Claude plugin packaging and install surface live in the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
 
 ## How it works
 
-Codex reads the marketplace definition from `.agents/plugins/marketplace.json`.
+Codex reads the marketplace definition from `.agents/plugins/marketplace.json`, and Claude reads the companion marketplace definition from `.claude-plugin/marketplace.json`.
 
 In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project Skills`.
 
@@ -28,7 +30,7 @@ The current `superteam` entry does not vendor plugin files in this repository. I
 - plugin path: `./plugins/superteam`
 - ref: `main`
 
-That keeps the marketplace isolated while allowing plugin source repos to stay independent.
+That keeps the marketplace catalogs isolated while allowing plugin source repos to stay independent.
 
 ## Install In Codex
 
@@ -72,7 +74,7 @@ Use $superteam to coordinate an implementation plan for issue #123.
 
 ## Maintenance Notes
 
-- Update marketplace entries in `.agents/plugins/marketplace.json`
+- Update marketplace entries in `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`
 - Keep Git-backed entries pinned to an explicit `ref` or commit
 - Maintain plugin source and packaging in the owning source repository
 - For `superteam`, the source-of-truth repo is `patinaproject/superteam`

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,10 +1,11 @@
 # Repository File Structure
 
-This repository is the org-level Codex marketplace repo for Patina Project.
+This repository carries the Patina Project marketplace catalogs and contributor docs for both Codex and Claude.
 
 ## Top level
 
-- `.agents/plugins/marketplace.json`: the marketplace catalog Codex reads
+- `.agents/plugins/marketplace.json`: the Codex marketplace catalog
+- `.claude-plugin/marketplace.json`: the Claude marketplace catalog
 - `plugins/`: optional packaged Codex plugins when this repo vendors local plugin copies
 - `docs/`: contributor-facing docs for marketplace maintenance
 - `package.json`, `commitizen.config.js`, `commitlint.config.js`: repo tooling
@@ -12,7 +13,7 @@ This repository is the org-level Codex marketplace repo for Patina Project.
 
 ## Marketplace workflow
 
-- Register each plugin in `.agents/plugins/marketplace.json`
+- Register each plugin in `.agents/plugins/marketplace.json` for Codex and `.claude-plugin/marketplace.json` for Claude
 - Use `source: "git-subdir"` for plugins that live in subdirectories of other repos
 - Use `source: "url"` for plugins that live at the root of other repos
 - Keep marketplace entries pointed at the owning repository for packaged plugin assets

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -20,4 +20,4 @@ This repository is the org-level Codex marketplace repo for Patina Project.
 - Vendor a plugin under `plugins/<plugin-name>/` only when this repo should carry the package directly
 - Keep plugin names, folder names, and manifest names aligned
 - Use GitHub issue-tagged conventional commits with no scopes
-- Use `AC-<issue>-<n>` identifiers for issue acceptance criteria in specs and plans, and use `AC-<issue>-<n>` headings in PR descriptions where required
+- Use `AC-<issue>-<n>` identifiers for issue acceptance criteria in specs and plans, and use an `Acceptance Criteria` section with one `### AC-<issue>-<n>` heading per relevant AC in PR descriptions

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -20,4 +20,4 @@ This repository is the org-level Codex marketplace repo for Patina Project.
 - Vendor a plugin under `plugins/<plugin-name>/` only when this repo should carry the package directly
 - Keep plugin names, folder names, and manifest names aligned
 - Use GitHub issue-tagged conventional commits with no scopes
-- Use `AC-<issue>-<n>` headings for issue acceptance criteria in specs, plans, and PR descriptions
+- Use `AC-<issue>-<n>` identifiers for issue acceptance criteria in specs and plans, and use `AC-<issue>-<n>` headings in PR descriptions where required

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -15,6 +15,9 @@ This repository is the org-level Codex marketplace repo for Patina Project.
 - Register each plugin in `.agents/plugins/marketplace.json`
 - Use `source: "git-subdir"` for plugins that live in subdirectories of other repos
 - Use `source: "url"` for plugins that live at the root of other repos
+- Keep marketplace entries pointed at the owning repository for packaged plugin assets
+- Do not vendor a duplicate Claude plugin package here when the upstream repository already owns that install surface
 - Vendor a plugin under `plugins/<plugin-name>/` only when this repo should carry the package directly
 - Keep plugin names, folder names, and manifest names aligned
 - Use GitHub issue-tagged conventional commits with no scopes
+- Use `AC-<issue>-<n>` headings for issue acceptance criteria in specs, plans, and PR descriptions

--- a/docs/superpowers/plans/2026-04-22-2-claude-marketplace-support-for-patinaprojectskills-plan.md
+++ b/docs/superpowers/plans/2026-04-22-2-claude-marketplace-support-for-patinaprojectskills-plan.md
@@ -1,0 +1,229 @@
+# Claude Marketplace Support For Patinaproject/Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Copy the `patinaproject/superteam` project standards into this marketplace repo and add the marketplace metadata and docs needed for Claude Marketplace support without duplicating the upstream plugin package.
+
+**Architecture:** Keep `patinaproject/skills` as the marketplace catalog and contributor-docs repo, while `patinaproject/superteam` remains the source of truth for the installable Claude plugin surface. Implement the change through documentation updates plus a targeted marketplace entry update that continues to point at the upstream repository.
+
+**Tech Stack:** Markdown, JSON, pnpm repo tooling, Husky, commitlint
+
+---
+
+### Task 1: Align Root Contributor Standards
+
+**Files:**
+- Create: `CLAUDE.md`
+- Modify: `AGENTS.md`
+- Test: `AGENTS.md`
+
+- [ ] **Step 1: Write the failing content check for missing Claude instructions**
+
+```bash
+test -f CLAUDE.md
+```
+
+Expected: non-zero exit status because `CLAUDE.md` does not exist yet.
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run: `test -f CLAUDE.md`
+Expected: exit status `1`
+
+- [ ] **Step 3: Add the Claude instruction pointer and expand `AGENTS.md`**
+
+```md
+# Claude Instructions
+
+See [AGENTS.md](./AGENTS.md) for the repository instructions and contributor workflow.
+```
+
+Add these concepts to `AGENTS.md` in repo-specific wording:
+
+```md
+## Project Structure & Module Organization
+
+This repository is the marketplace surface for Patina Project plugins and related install documentation.
+
+- `.agents/plugins/marketplace.json`: repo-local marketplace source of truth
+- `plugins/`: optional vendored plugin packages when this repo carries local copies
+- `docs/`: contributor docs plus planning artifacts such as `docs/file-structure.md` and `docs/superpowers/`
+- If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
+- root config: `package.json`, `commitizen.config.js`, `commitlint.config.js`, and `.husky/`
+
+For Superpowers-generated design and planning artifacts, use issue-based filenames and the following acceptance criteria format:
+
+- `docs/superpowers/specs/YYYY-MM-DD-<issue-number>-<topic>-design.md`
+- `docs/superpowers/plans/YYYY-MM-DD-<issue-number>-<topic>-plan.md`
+- Acceptance criteria IDs: `AC-<issue-number>-<integer>`
+```
+
+Also add these repo-specific standards:
+
+```md
+## Commit & Pull Request Guidelines
+
+For squash-and-merge workflows, PR titles must match the commitlint commit format:
+
+`type: #123 short description`
+
+When an issue defines acceptance criteria, include an `Acceptance Criteria` section in the PR description.
+
+- Use one `### AC-<issue>-<n>` heading per relevant AC
+- Put a short outcome summary directly under each heading
+- Put verification steps under the AC they validate
+```
+
+- [ ] **Step 4: Run content checks to verify the standards are present**
+
+Run: `rg -n 'Claude Instructions|AC-<issue-number>-<integer>|Acceptance Criteria' CLAUDE.md AGENTS.md`
+Expected: matches for the Claude pointer and the AC ID standard
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md AGENTS.md
+git commit -m "docs: #2 align project standards with superteam"
+```
+
+### Task 2: Update Contributor Docs For Install Surfaces
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/file-structure.md`
+- Test: `README.md`
+
+- [ ] **Step 1: Write the failing doc check for missing Claude marketplace language**
+
+```bash
+rg -n 'Claude|install surface|source of truth' README.md docs/file-structure.md
+```
+
+Expected: either no matches for Claude-specific wording or matches that do not yet explain the upstream Claude install surface.
+
+- [ ] **Step 2: Run the doc check to verify the gap**
+
+Run: `rg -n 'Claude|install surface|source of truth' README.md docs/file-structure.md`
+Expected: missing or incomplete Claude install-surface guidance
+
+- [ ] **Step 3: Update the docs with repo-specific install-surface ownership**
+
+Add content like this to `README.md`:
+
+```md
+## Install Surfaces
+
+- `patinaproject/skills` is the marketplace catalog
+- `patinaproject/superteam` is the source-of-truth plugin repository
+- Codex installs `superteam` through the marketplace entry that targets `./plugins/superteam` in `patinaproject/superteam`
+- Claude-compatible installation is owned by the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
+```
+
+Add content like this to `docs/file-structure.md`:
+
+```md
+## Marketplace workflow
+
+- Register each plugin in `.agents/plugins/marketplace.json`
+- Keep marketplace entries pointed at the owning repository for packaged plugin assets
+- Do not vendor a duplicate Claude plugin package here when the upstream repository already owns that install surface
+- Use `AC-<issue>-<n>` headings for issue acceptance criteria in specs, plans, and PR descriptions
+```
+
+- [ ] **Step 4: Run doc verification**
+
+Run: `rg -n 'Claude|source-of-truth|AC-<issue>-<n>' README.md docs/file-structure.md`
+Expected: lines showing the Claude install-surface explanation and the AC ID standard
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/file-structure.md
+git commit -m "docs: #2 document marketplace and Claude install surfaces"
+```
+
+### Task 3: Extend Marketplace Metadata For Claude Compatibility
+
+**Files:**
+- Modify: `.agents/plugins/marketplace.json`
+- Test: `.agents/plugins/marketplace.json`
+
+- [ ] **Step 1: Write the failing metadata inspection**
+
+```bash
+sed -n '1,240p' .agents/plugins/marketplace.json
+```
+
+Expected: the `superteam` entry only describes the Codex `git-subdir` source and does not yet expose any Claude-oriented compatibility metadata or description.
+
+- [ ] **Step 2: Run the inspection to verify the current shape**
+
+Run: `sed -n '1,240p' .agents/plugins/marketplace.json`
+Expected: a single `superteam` entry with `source.source` set to `git-subdir`
+
+- [ ] **Step 3: Add the smallest supported Claude-compatible metadata that still points at `patinaproject/superteam`**
+
+Update `.agents/plugins/marketplace.json` to preserve the existing source block:
+
+```json
+{
+  "name": "superteam",
+  "source": {
+    "source": "git-subdir",
+    "url": "https://github.com/patinaproject/superteam.git",
+    "path": "./plugins/superteam",
+    "ref": "main"
+  }
+}
+```
+
+Add a Claude-oriented metadata block only if the marketplace schema supports it. The block must reference the upstream repository and its root plugin surface instead of adding local package files. If the schema does not support a Claude-specific block, add a supported description or metadata field that documents the upstream Claude install path and keep the JSON valid.
+
+- [ ] **Step 4: Verify the marketplace entry still targets the upstream repo**
+
+Run: `rg -n 'patinaproject/superteam|git-subdir|claude|Claude' .agents/plugins/marketplace.json`
+Expected: matches showing the upstream repo reference remains intact and any Claude-related metadata points upstream
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .agents/plugins/marketplace.json
+git commit -m "feat: #2 add Claude marketplace metadata for superteam"
+```
+
+### Task 4: Verify The Full Change Set
+
+**Files:**
+- Modify: none
+- Test: `CLAUDE.md`
+- Test: `AGENTS.md`
+- Test: `README.md`
+- Test: `docs/file-structure.md`
+- Test: `.agents/plugins/marketplace.json`
+
+- [ ] **Step 1: Verify the upstream Claude manifest still exists**
+
+Run: `test -f /var/folders/rk/kh6tqml520393n45f7hsg4yw0000gn/T/tmp.xjoQWsSc6d/superteam/.claude-plugin/plugin.json`
+Expected: exit status `0`
+
+- [ ] **Step 2: Verify documentation and standards content**
+
+Run: `rg -n 'Claude Instructions|AC-2-|AC-<issue>|source of truth|install surface' CLAUDE.md AGENTS.md README.md docs/file-structure.md`
+Expected: matches showing the standards copy, explicit AC conventions, and install-surface ownership
+
+- [ ] **Step 3: Verify the final marketplace JSON**
+
+Run: `sed -n '1,240p' .agents/plugins/marketplace.json`
+Expected: valid JSON with the `superteam` entry still pointing at `https://github.com/patinaproject/superteam.git`
+
+- [ ] **Step 4: Inspect git status**
+
+Run: `git status --short`
+Expected: clean working tree after the planned commits, or only intentionally uncommitted plan/spec artifacts if those are left out of the commit sequence
+
+- [ ] **Step 5: Commit any final documentation adjustments if needed**
+
+```bash
+git add CLAUDE.md AGENTS.md README.md docs/file-structure.md .agents/plugins/marketplace.json
+git commit -m "docs: #2 finalize Claude marketplace support docs"
+```

--- a/docs/superpowers/specs/2026-04-22-2-claude-marketplace-support-for-patinaprojectskills-design.md
+++ b/docs/superpowers/specs/2026-04-22-2-claude-marketplace-support-for-patinaprojectskills-design.md
@@ -1,0 +1,122 @@
+# Design: Claude Marketplace support for patinaproject/skills [#2](https://github.com/patinaproject/skills/issues/2)
+
+## Summary
+
+Add Claude Marketplace support to `patinaproject/skills` while copying the contributor-facing project standards established in `patinaproject/superteam`.
+
+The repository should remain a marketplace catalog, not a second source of truth for plugin payloads. Claude installability stays owned by `patinaproject/superteam`; this repo owns marketplace metadata, catalog documentation, and contributor standards for maintaining that metadata.
+
+## Goals
+
+- Copy the project standards pattern from `patinaproject/superteam` into this repository
+- Extend `patinaproject/skills` so the marketplace can represent Claude-compatible consumption for `superteam`
+- Keep `patinaproject/superteam` as the source of truth for the installable Claude plugin package
+- Document the install surfaces and maintenance workflow clearly for contributors
+
+## Non-Goals
+
+- Creating a local Claude plugin package in `patinaproject/skills`
+- Duplicating `superteam` plugin payloads into this repository
+- Reworking marketplace ownership so this repo becomes the package source of truth
+- Generalizing a new publishing system for every Patina Project repository
+
+## Acceptance Criteria
+
+### AC-2-1
+
+`patinaproject/skills` adopts the project-standards layer used in `patinaproject/superteam`, with repo-specific wording for this marketplace catalog.
+
+### AC-2-2
+
+The marketplace catalog contains the metadata needed for Claude Marketplace support while continuing to reference `patinaproject/superteam` as the source repository.
+
+### AC-2-3
+
+Contributor and installation documentation explain the repo responsibilities and the Claude-related consumption path without implying that this repo owns the plugin package.
+
+## Repository Ownership
+
+### `patinaproject/superteam`
+
+Owns the installable plugin package and Claude-native metadata, including the root `.claude-plugin/plugin.json` manifest and any direct-install documentation tied to that plugin package.
+
+### `patinaproject/skills`
+
+Owns the marketplace catalog, contributor standards for maintaining the catalog, and docs that explain how marketplace consumers reach the upstream install surfaces.
+
+## Approach Options
+
+### Option 1: Minimal standards parity plus marketplace metadata updates
+
+Copy the structure and expectations of the `superteam` standards files into this repo, but keep the content marketplace-specific. Update the catalog and docs to reference the upstream Claude plugin surface.
+
+Pros:
+- Keeps the repo-specific truth accurate
+- Avoids copying `superteam`-specific packaging rules that do not belong here
+- Solves both the standards request and issue `#2` without adding duplicate assets
+
+Cons:
+- Requires careful wording instead of a direct file transplant
+
+### Option 2: Near-verbatim standards transplant
+
+Copy `superteam` standards files almost as-is and replace a few repository names.
+
+Pros:
+- Fastest initial edit path
+
+Cons:
+- Likely to import incorrect assumptions about local skill authoring and packaged plugin copies
+- Makes this marketplace repo look like a plugin source repo when it is not
+
+### Option 3: Metadata-only Claude support
+
+Leave current project standards mostly unchanged and only update the marketplace catalog plus minimal docs.
+
+Pros:
+- Lowest implementation surface
+
+Cons:
+- Does not satisfy the request to copy project standards
+- Leaves contributor guidance inconsistent with the upstream repository pattern
+
+## Chosen Approach
+
+Use option 1.
+
+Copy the standards pattern from `superteam` into `patinaproject/skills` by updating `AGENTS.md`, adding `CLAUDE.md`, and tightening supporting docs. In the same change, extend the marketplace catalog and documentation so Claude Marketplace support is represented through metadata that points at `patinaproject/superteam`, which remains the package source of truth.
+
+## File Responsibilities
+
+- `AGENTS.md`: contributor workflow, repo structure, validation commands, commit and PR standards, including the `AC-<issue>-<n>` convention
+- `CLAUDE.md`: Claude-facing pointer to the root contributor instructions
+- `README.md`: installation surfaces, marketplace behavior, and source-of-truth boundaries
+- `docs/file-structure.md`: concise map of the repo and the marketplace workflow
+- `.agents/plugins/marketplace.json`: marketplace entry updates for Claude Marketplace compatibility
+
+## Data and Metadata Strategy
+
+The `superteam` entry should continue to target `https://github.com/patinaproject/superteam.git` as the remote source. Any Claude-specific representation added here should describe or route to that upstream install surface rather than vendoring a second copy in `patinaproject/skills`.
+
+This preserves a single plugin source of truth:
+
+- `superteam` owns the installable plugin package
+- `skills` owns discovery metadata and catalog documentation
+
+## Error Handling and Guardrails
+
+- Do not add `.claude-plugin/plugin.json` to this repository
+- Do not change the existing Codex installation path away from the `git-subdir` source unless the marketplace format requires a separate Claude-specific field
+- If the marketplace schema lacks a supported Claude-specific field, document the upstream Claude install surface and keep the catalog update limited to supported metadata
+- Keep documentation explicit about which repository owns which install surface
+
+## Verification
+
+- Inspect edited docs with `sed -n '1,200p'`
+- Search for standards references and AC IDs with `rg`
+- Review `.agents/plugins/marketplace.json` to confirm the `superteam` entry still points at the upstream repo and includes the intended compatibility metadata
+- Verify the upstream Claude manifest exists at `patinaproject/superteam:.claude-plugin/plugin.json`
+
+## Open Question Resolved
+
+The issue dependency on `patinaproject/superteam#5` is treated as resolved for this work. The implementation can therefore update `patinaproject/skills` to reference the upstream Claude install surface now.


### PR DESCRIPTION
## Summary
- add a Claude marketplace manifest for `superteam` while preserving the existing Codex marketplace catalog
- copy the `superteam` project standards pattern into this repo with repo-specific contributor guidance
- document both marketplace surfaces and add the issue design/plan artifacts under `docs/superpowers/`

## Linked Issue
- Closes #2

## Acceptance Criteria
### AC-2-1
`patinaproject/skills` now adopts the project-standards layer used in `patinaproject/superteam`, with repo-specific wording for this marketplace catalog.
- [x] Added `CLAUDE.md` as the Claude-facing pointer to `AGENTS.md`
- [x] Expanded `AGENTS.md` with project structure, AC ID, and PR guidance standards
- [x] Added the approved spec and implementation plan under `docs/superpowers/`

### AC-2-2
The marketplace catalog now contains the metadata needed for Claude Marketplace support while continuing to reference `patinaproject/superteam` as the source repository.
- [x] Added `.claude-plugin/marketplace.json` with a `superteam` entry that points to `patinaproject/superteam`
- [x] Kept `.agents/plugins/marketplace.json` intact for Codex
- [x] Reduced duplicated Claude metadata so `patinaproject/superteam` remains the plugin-package source of truth

### AC-2-3
Contributor and installation documentation now explain the repo responsibilities and the Claude-related consumption path without implying that this repo owns the plugin package.
- [x] Updated `README.md` to describe Codex and Claude marketplace surfaces
- [x] Updated `docs/file-structure.md` to document both catalogs and their maintenance workflow
- [x] Aligned contributor docs so future updates account for both marketplace manifests

## Test Plan
- [x] Run `claude plugin validate .`
- [x] Verify the upstream Claude plugin manifest exists in `patinaproject/superteam`
- [x] Verify marketplace and ownership references in `CLAUDE.md`, `AGENTS.md`, `README.md`, and `docs/file-structure.md`
- [x] Inspect `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json` for the expected upstream source references
