### PR TITLE
chore: #6 rename marketplace display names to Patina Project

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "patinaproject-skills",
   "interface": {
-    "displayName": "Patina Project Skills"
+    "displayName": "Patina Project"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/patinaproject"
   },
   "metadata": {
-    "description": "Marketplace catalog for Patina Project Claude Code plugins and skills."
+    "description": "Marketplace catalog for Patina Project plugins."
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Patina Project Skills
+# Patina Project
 
 This repository carries the Patina Project marketplace catalogs for both Codex and Claude plugins.
 
@@ -21,7 +21,7 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 
 Codex reads the marketplace definition from `.agents/plugins/marketplace.json`, and Claude reads the companion marketplace definition from `.claude-plugin/marketplace.json`.
 
-In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project Skills`.
+In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project`.
 
 The current `superteam` entry does not vendor plugin files in this repository. Instead, it tells Codex to fetch the plugin package from the `patinaproject/superteam` repository:
 
@@ -46,7 +46,7 @@ Refresh tracked marketplaces:
 codex plugin marketplace upgrade
 ```
 
-Then open the Codex Plugin Directory, find `Patina Project Skills`, and install `superteam`.
+Then open the Codex Plugin Directory, find `Patina Project`, and install `superteam`.
 
 ## Install From A Local Checkout
 

--- a/docs/superpowers/plans/2026-04-22-6-rename-marketplace-display-names-to-patina-project-plan.md
+++ b/docs/superpowers/plans/2026-04-22-6-rename-marketplace-display-names-to-patina-project-plan.md
@@ -1,0 +1,215 @@
+# Rename Marketplace Display Names To Patina Project Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finalize the approved issue `#6` branding change so Codex and Claude surfaces show `Patina Project` publicly while `patinaproject-skills` remains the internal marketplace slug.
+
+**Architecture:** Keep the existing marketplace catalogs as the source of truth and limit edits to presentation metadata plus README clarification. Treat the current branch changes in `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, and `README.md` as the intended implementation surface, then verify they preserve all non-goal fields unchanged. For Claude specifically, plan against the actual branch fact pattern: `owner.name` already reads `Patina Project` before this issue, so issue `#6` work there is consistency-preserving metadata cleanup and verification rather than a new user-facing rename.
+
+**Tech Stack:** JSON, Markdown, `rg`, `sed`, Git
+
+---
+
+### Task 1: Confirm Codex Marketplace Branding Metadata
+
+**Files:**
+- Modify: `.agents/plugins/marketplace.json`
+- Test: `.agents/plugins/marketplace.json`
+
+- [ ] **Step 1: Inspect the current Codex marketplace entry**
+
+```bash
+sed -n '1,220p' .agents/plugins/marketplace.json
+```
+
+Expected: the top-level `"name"` is still `"patinaproject-skills"` and the interface metadata exposes `"displayName": "Patina Project"`.
+
+- [ ] **Step 2: Verify the approved branding split is present**
+
+Run: `rg -n '"name": "patinaproject-skills"|"displayName": "Patina Project"' .agents/plugins/marketplace.json`
+Expected: one match for the internal slug and one match for the public display name.
+
+- [ ] **Step 3: Normalize the file to the approved minimal shape if needed**
+
+```json
+{
+  "name": "patinaproject-skills",
+  "interface": {
+    "displayName": "Patina Project"
+  },
+  "plugins": [
+    {
+      "name": "superteam",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/patinaproject/superteam.git",
+        "path": "./plugins/superteam",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Verify no source or slug regression was introduced**
+
+Run: `rg -n 'patinaproject-skills|Patina Project|patinaproject/superteam|git-subdir|./plugins/superteam|"ref": "main"' .agents/plugins/marketplace.json`
+Expected: matches confirming the display name change landed without changing the catalog slug or upstream plugin source.
+
+- [ ] **Step 5: Commit the Codex metadata update**
+
+```bash
+git add .agents/plugins/marketplace.json
+git commit -m "chore: #6 rename Codex marketplace display name"
+```
+
+### Task 2: Preserve Claude Marketplace Branding And Align Description Metadata
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+- Test: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Inspect the current Claude marketplace entry and the actual branch diff**
+
+```bash
+git diff -- .claude-plugin/marketplace.json && printf '\n---WORKTREE---\n' && sed -n '1,220p' .claude-plugin/marketplace.json
+```
+
+Expected: the diff changes `metadata.description`, while the catalog identifier remains `"patinaproject-skills"` and the owner metadata already shows `"name": "Patina Project"`.
+
+- [ ] **Step 2: Verify the approved Claude-facing branding is preserved and the issue diff is concrete**
+
+Run: `rg -n '"name": "patinaproject-skills"|"name": "Patina Project"|"description": "Marketplace catalog for Patina Project plugins\\."|"repo": "patinaproject/superteam"' .claude-plugin/marketplace.json`
+Expected: matches showing the internal catalog identifier, the pre-existing public owner name, the updated Patina Project description text, and the unchanged upstream source repository.
+
+- [ ] **Step 3: Normalize the file to the approved minimal shape if needed**
+
+```json
+{
+  "name": "patinaproject-skills",
+  "owner": {
+    "name": "Patina Project",
+    "url": "https://github.com/patinaproject"
+  },
+  "metadata": {
+    "description": "Marketplace catalog for Patina Project plugins."
+  },
+  "plugins": [
+    {
+      "name": "superteam",
+      "description": "Claude Code plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
+      "category": "productivity",
+      "source": {
+        "source": "github",
+        "repo": "patinaproject/superteam"
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Verify this issue does not introduce a new Claude owner rename or any upstream reference change**
+
+Run: `git diff -- .claude-plugin/marketplace.json && rg -n 'patinaproject-skills|Patina Project|Marketplace catalog for Patina Project plugins\\.|patinaproject/superteam|"source": "github"' .claude-plugin/marketplace.json`
+Expected: the diff is limited to the description line, and the catalog identifier, existing owner name, and plugin source all stay stable.
+
+- [ ] **Step 5: Commit the Claude metadata update**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "chore: #6 align Claude marketplace branding metadata"
+```
+
+### Task 3: Clarify The Public Name Versus Internal Slug In README
+
+**Files:**
+- Modify: `README.md`
+- Test: `README.md`
+
+- [ ] **Step 1: Inspect the current README wording**
+
+```bash
+sed -n '1,260p' README.md
+```
+
+Expected: the README describes `patinaproject/skills` as the marketplace repo and includes a sentence explaining that the marketplace is internally named `patinaproject-skills` but displayed as `Patina Project`.
+
+- [ ] **Step 2: Verify the documentation covers the approved distinction**
+
+Run: `rg -n 'Patina Project|patinaproject-skills|source of truth|\\.claude-plugin/plugin.json|\\.agents/plugins/marketplace.json|\\.claude-plugin/marketplace.json' README.md`
+Expected: matches showing the public-name versus internal-slug distinction and the existing source-of-truth boundary for `patinaproject/superteam`.
+
+- [ ] **Step 3: Normalize the key README language if needed**
+
+```md
+# Patina Project
+
+This repository carries the Patina Project marketplace catalogs for both Codex and Claude plugins.
+
+It is a marketplace catalog, not the source repo for every plugin. Marketplace entries can point at plugins packaged in this repo, or at Git-backed plugin sources maintained in other Patina Project repositories.
+
+## Install Surfaces
+
+- `patinaproject/skills` owns the marketplace catalogs and contributor docs
+- `patinaproject/superteam` is the source of truth for the upstream plugin package
+- Codex marketplace metadata lives in `.agents/plugins/marketplace.json`
+- Claude marketplace metadata lives in `.claude-plugin/marketplace.json`
+
+## How it works
+
+Codex reads the marketplace definition from `.agents/plugins/marketplace.json`, and Claude reads the companion marketplace definition from `.claude-plugin/marketplace.json`.
+
+In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project`.
+```
+
+- [ ] **Step 4: Verify the README does not imply any slug or source migration**
+
+Run: `rg -n 'rename the repository|change the slug|patinaproject/superteam|git-subdir|Patina Project|patinaproject-skills' README.md`
+Expected: matches for the approved naming split and upstream source repo, with no wording that suggests a repository rename or plugin-source move.
+
+- [ ] **Step 5: Commit the README clarification**
+
+```bash
+git add README.md
+git commit -m "docs: #6 clarify marketplace display name and slug split"
+```
+
+### Task 4: Run Cross-Surface Verification For AC-6
+
+**Files:**
+- Modify: none
+- Test: `.agents/plugins/marketplace.json`
+- Test: `.claude-plugin/marketplace.json`
+- Test: `README.md`
+
+- [ ] **Step 1: Verify all approved surfaces carry the new public-facing name**
+
+Run: `rg -n 'Patina Project' .agents/plugins/marketplace.json .claude-plugin/marketplace.json README.md`
+Expected: matches in all three files, with Claude matches coming from preserved owner metadata plus the updated description text.
+
+- [ ] **Step 2: Verify the internal slug remains stable everywhere it should**
+
+Run: `rg -n 'patinaproject-skills' .agents/plugins/marketplace.json .claude-plugin/marketplace.json README.md`
+Expected: matches showing the slug is still preserved in the catalogs and documented in README.
+
+- [ ] **Step 3: Verify upstream source references remain unchanged**
+
+Run: `rg -n 'patinaproject/superteam|./plugins/superteam|"ref": "main"|\\.claude-plugin/plugin.json' .agents/plugins/marketplace.json .claude-plugin/marketplace.json README.md`
+Expected: matches showing the same upstream plugin repository, Codex subdirectory path, Git ref, and Claude install-surface note.
+
+- [ ] **Step 4: Inspect the final diff and working tree with a Claude-specific guardrail**
+
+Run: `git diff -- .agents/plugins/marketplace.json .claude-plugin/marketplace.json README.md && git diff --word-diff -- .claude-plugin/marketplace.json && git status --short`
+Expected: only the approved issue `#6` surfaces are changed before the final commit, and the Claude diff shows the description wording cleanup without any owner-name, slug, or source-reference churn.
+
+- [ ] **Step 5: Create the final issue commit**
+
+```bash
+git add .agents/plugins/marketplace.json .claude-plugin/marketplace.json README.md
+git commit -m "chore: #6 rename marketplace display names to Patina Project"
+```

--- a/docs/superpowers/specs/2026-04-22-6-rename-marketplace-display-names-to-patina-project-design.md
+++ b/docs/superpowers/specs/2026-04-22-6-rename-marketplace-display-names-to-patina-project-design.md
@@ -1,0 +1,125 @@
+# Design: Rename marketplace display names to Patina Project [#6](https://github.com/patinaproject/skills/issues/6)
+
+## Summary
+
+Update the public-facing marketplace display names in `patinaproject/skills` so the marketplace is presented as `Patina Project` in Codex and Claude surfaces, while keeping the internal catalog slug `patinaproject-skills` unchanged.
+
+This issue is limited to marketplace presentation metadata and supporting documentation. It does not change plugin ownership, install sources, repository slugs, or package layout.
+
+## Goals
+
+- Present the marketplace consistently as `Patina Project` anywhere user-facing marketplace metadata is shown
+- Preserve `patinaproject-skills` as the internal marketplace identifier for compatibility
+- Keep the catalog documentation aligned with the display-name change so contributors understand the intentional split between public label and internal slug
+
+## Non-Goals
+
+- Renaming the repository
+- Renaming the marketplace slug from `patinaproject-skills`
+- Changing the `superteam` plugin slug, source repository, install path, or ref
+- Reworking marketplace structure, packaging, or source-of-truth boundaries beyond the display-name copy update
+
+## Acceptance Criteria
+
+### AC-6-1
+
+Codex marketplace metadata exposes the marketplace to users as `Patina Project` without changing the top-level marketplace slug `patinaproject-skills`.
+
+### AC-6-2
+
+Claude marketplace metadata exposes the owning catalog as `Patina Project` without changing the underlying marketplace identifier or upstream plugin source references.
+
+### AC-6-3
+
+Contributor-facing documentation explains that `Patina Project` is the public-facing marketplace name while `patinaproject-skills` remains the internal catalog slug for this repository.
+
+## Context
+
+The current approved direction is to rename only the public-facing marketplace display names to `Patina Project`. Existing local edits already point at that outcome in `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, and `README.md`.
+
+This design formalizes that scope so execution stays intentionally narrow:
+
+- presentation metadata changes are in scope
+- internal slugs and source references are not
+- docs should explain the distinction instead of hiding it
+
+## Approach Options
+
+### Option 1: Update user-facing labels only
+
+Change only the fields that appear as marketplace-facing names or owner labels, and update docs to explain the distinction between display name and slug.
+
+Pros:
+- Matches the approved scope exactly
+- Minimizes compatibility risk
+- Avoids accidental downstream effects on install commands or internal identifiers
+
+Cons:
+- Leaves the internal slug and public label intentionally different, which needs clear documentation
+
+### Option 2: Rename public labels and internal slug together
+
+Change display names and also rename `patinaproject-skills` to `Patina Project`-aligned identifiers everywhere.
+
+Pros:
+- Removes the visible mismatch between label and slug
+
+Cons:
+- Out of scope for the approved direction
+- Higher compatibility risk for existing references and install surfaces
+- Would require broader validation and likely follow-up migration work
+
+### Option 3: Documentation-only clarification
+
+Keep marketplace metadata unchanged and only explain the intended branding in docs.
+
+Pros:
+- Lowest edit surface
+
+Cons:
+- Fails to deliver the actual public-facing rename
+- Leaves user-visible marketplace naming inconsistent across surfaces
+
+## Chosen Approach
+
+Use option 1.
+
+Rename only the public-facing marketplace display metadata to `Patina Project` and document that the repository still uses `patinaproject-skills` as its internal catalog slug. This satisfies the branding goal while preserving current install and compatibility behavior.
+
+## Requirements
+
+1. The Codex marketplace catalog must keep `"name": "patinaproject-skills"` and set the user-visible marketplace label to `Patina Project`.
+2. The Claude marketplace catalog must keep its current marketplace identifier and upstream plugin source references while presenting the owning catalog as `Patina Project`.
+3. Documentation must explicitly state that `Patina Project` is the public-facing marketplace name and `patinaproject-skills` remains the internal slug.
+4. Documentation must continue to describe `patinaproject/superteam` as the source of truth for the upstream plugin package.
+5. No change in this issue may alter plugin slugs, source URLs, source types, install paths, refs, or packaging ownership.
+
+## Affected Surfaces
+
+- `.agents/plugins/marketplace.json`: Codex-facing marketplace presentation metadata
+- `.claude-plugin/marketplace.json`: Claude-facing marketplace presentation metadata
+- `README.md`: contributor and user-facing explanation of label versus slug behavior
+
+## Data and Metadata Strategy
+
+The marketplace will continue to use `patinaproject-skills` as the stable internal identifier. Public-facing fields that drive presentation should use `Patina Project`.
+
+This split is intentional:
+
+- the slug preserves compatibility and existing references
+- the display name aligns the marketplace with the Patina Project brand
+- the upstream plugin source remains `patinaproject/superteam`
+
+## Risks and Guardrails
+
+- Do not rename the top-level marketplace `name` field away from `patinaproject-skills`
+- Do not change the `superteam` plugin name or its source configuration
+- Do not expand the issue into a repository rebrand or catalog schema refactor
+- Keep docs explicit about why the label and slug differ so the mismatch is understood as deliberate rather than accidental
+
+## Verification
+
+- Inspect `.agents/plugins/marketplace.json` to confirm the display metadata is `Patina Project` while the marketplace `name` remains `patinaproject-skills`
+- Inspect `.claude-plugin/marketplace.json` to confirm the public-facing owner/catalog naming reflects `Patina Project` without changing plugin source references
+- Inspect `README.md` to confirm it explains the public-name versus internal-slug distinction and preserves the existing source-of-truth boundary for `superteam`
+- Search the edited surfaces for `patinaproject-skills` and `Patina Project` to confirm the intended split is documented consistently


### PR DESCRIPTION
## Summary
- rename the Codex marketplace display name from `Patina Project Skills` to `Patina Project`
- align marketplace docs so the public label is `Patina Project` while the internal slug remains `patinaproject-skills`
- simplify the Claude marketplace description to match the broader Patina Project branding without changing package ownership or source references

## Branch state
- Latest pushed branch state: `6-chore-rename-marketplace-display-names-to-patina-project@c252ba1`
- Review state: no open local findings after re-review
- CI state: not run in GitHub yet

## Acceptance Criteria
### AC-6-1
Codex marketplace metadata exposes the marketplace to users as `Patina Project` without changing the top-level marketplace slug `patinaproject-skills`.
- [x] Verification: `.agents/plugins/marketplace.json` keeps `"name": "patinaproject-skills"` and sets `interface.displayName` to `Patina Project`

### AC-6-2
Claude marketplace metadata preserves the owning catalog as `Patina Project` and aligns issue `#6` metadata changes without changing the underlying marketplace identifier or upstream plugin source references.
- [x] Verification: `.claude-plugin/marketplace.json` keeps `"name": "patinaproject-skills"`, preserves `owner.name: "Patina Project"`, and limits the branch diff to the description cleanup

### AC-6-3
Contributor-facing documentation explains that `Patina Project` is the public-facing marketplace name while `patinaproject-skills` remains the internal catalog slug for this repository.
- [x] Verification: `README.md` now states the public-name/internal-slug split and updates install guidance to refer to `Patina Project`

## Test plan
- [x] Parsed `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json` successfully with Node JSON parsing
- [x] Verified `Patina Project` appears across the approved surfaces with `rg`
- [x] Verified `patinaproject-skills` remains unchanged where required with `rg`
- [x] Verified upstream `patinaproject/superteam` references, install path, and ref remain unchanged with `rg`
- [x] Inspected `git diff` and `git diff --word-diff -- .claude-plugin/marketplace.json` to confirm the branch scope and Claude-side description-only change

## Review follow-up
- Local reviewer state: no remaining findings after plan correction
- External feedback state: no open review threads yet
- Branch-state-aware next action: wait for PR review and CI status

## Notes
- This PR also includes the issue design and implementation plan artifacts under `docs/superpowers/` for issue `#6`.
- Residual risk: Claude-side verification is based on manifest state and branch diff evidence rather than a live in-product UI rendering check.