### PR TITLE
fix: #947 show Patina Project in Codex marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "patinaproject-skills",
   "interface": {
-    "displayName": "Patina Project Skills"
+    "displayName": "Patina Project"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Patina Project Skills
+# Patina Project
 
 This repository carries the Patina Project marketplace catalogs for both Codex and Claude plugins.
 
@@ -21,7 +21,7 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 
 Codex reads the marketplace definition from `.agents/plugins/marketplace.json`, and Claude reads the companion marketplace definition from `.claude-plugin/marketplace.json`.
 
-In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project Skills`.
+In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project`.
 
 The current `superteam` entry does not vendor plugin files in this repository. Instead, it tells Codex to fetch the plugin package from the `patinaproject/superteam` repository:
 
@@ -46,7 +46,7 @@ Refresh tracked marketplaces:
 codex plugin marketplace upgrade
 ```
 
-Then open the Codex Plugin Directory, find `Patina Project Skills`, and install `superteam`.
+Then open the Codex Plugin Directory, find `Patina Project`, and install `superteam`.
 
 ## Install From A Local Checkout
 


### PR DESCRIPTION
## Summary
- keep the marketplace slug as `patinaproject-skills`
- update the Codex-facing marketplace label from `Patina Project Skills` to `Patina Project`
- update the local marketplace README so install instructions match the visible Codex label

## Why
The approved design for issue `#947` clarified that `patinaproject-skills` is the correct marketplace identifier. The actual fix is a customer-facing naming correction in Codex, not a slug rename.

Closes patinaproject/patinaproject#947

## Acceptance Criteria
- [x] AC-947-1: Given a Patina Project marketplace-backed plugin entry, when its marketplace identifier is referenced in configuration, then it remains `patinaproject-skills`. [not E2E verified]
  - Verification: `rg -n '"name": "patinaproject-skills"' /Users/tlmader/.claude/plugins/marketplaces/patinaproject-skills/.agents/plugins/marketplace.json /Users/tlmader/.claude/plugins/known_marketplaces.json /Users/tlmader/.claude/plugins/installed_plugins.json`
- [x] AC-947-2: Given developer setup docs or local configuration for Patina Project marketplace plugins, when a teammate follows them, then the customer-facing name they see in Codex is `Patina Project`. [not E2E verified]
  - Verification: `rg -n '"displayName": "Patina Project"|Patina Project' /Users/tlmader/.claude/plugins/marketplaces/patinaproject-skills/.agents/plugins/marketplace.json /Users/tlmader/.claude/plugins/marketplaces/patinaproject-skills/README.md`
  - UI note: catalog metadata and docs were verified locally; direct in-app Plugin Directory observation was not available from automation.

## Test Plan
- [x] `jq empty .agents/plugins/marketplace.json`
- [x] `rg -n '"name": "patinaproject-skills"|"displayName": "Patina Project"' .agents/plugins/marketplace.json`
- [x] `rg -n 'Patina Project|patinaproject-skills|Patina Project Skills' README.md`
- [x] `codex plugin marketplace upgrade`
