### PR TITLE
docs: #9 align superteam marketplace root package

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,9 +7,8 @@
     {
       "name": "superteam",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/patinaproject/superteam.git",
-        "path": "./plugins/superteam",
         "ref": "main"
       },
       "policy": {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 
 ## Current plugin
 
-- `superteam`: installed from `patinaproject/superteam` using a `git-subdir` source that targets `./plugins/superteam` on `main`
+- `superteam`: installed from the root-packaged `patinaproject/superteam` plugin repository on `main`
 
 ## Install Surfaces
 
@@ -14,8 +14,10 @@ It is a marketplace catalog, not the source repo for every plugin. Marketplace e
 - `patinaproject/superteam` is the source of truth for the upstream plugin package
 - Codex marketplace metadata lives in `.agents/plugins/marketplace.json`
 - Claude marketplace metadata lives in `.claude-plugin/marketplace.json`
-- Codex installs `superteam` through the marketplace entry that targets `./plugins/superteam` in `patinaproject/superteam`
+- Codex installs `superteam` from the repository root in `patinaproject/superteam`
+- The upstream Codex manifest lives at `.codex-plugin/plugin.json`
 - The Claude plugin packaging and install surface live in the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
+- The upstream `superteam` skill content lives at `skills/superteam/`
 
 ## How it works
 
@@ -26,9 +28,15 @@ In this repo, the marketplace is named `patinaproject-skills` and exposed in the
 The current `superteam` entry does not vendor plugin files in this repository. Instead, it tells Codex to fetch the plugin package from the `patinaproject/superteam` repository:
 
 - repo: `patinaproject/superteam`
-- source type: `git-subdir`
-- plugin path: `./plugins/superteam`
+- source type: `url`
+- plugin root: `.`
 - ref: `main`
+
+In the upstream repository, the active install surfaces are:
+
+- Codex manifest: `.codex-plugin/plugin.json`
+- Claude manifest: `.claude-plugin/plugin.json`
+- Skill directory: `skills/superteam/`
 
 That keeps the marketplace catalogs isolated while allowing plugin source repos to stay independent.
 
@@ -57,7 +65,7 @@ For a direct setup in Claude Code today, add `superteam` as a custom subagent. A
 Create a project subagent file at `.claude/agents/superteam.md` with `/agents`, or create it manually and copy in the contents of:
 
 ```text
-https://github.com/patinaproject/superteam/blob/main/plugins/superteam/skills/superteam/SKILL.md
+https://github.com/patinaproject/superteam/blob/main/skills/superteam/SKILL.md
 ```
 
 Claude Code loads project subagents from `.claude/agents/`, so after adding that file you can use prompts such as:

--- a/docs/superpowers/plans/2026-04-23-9-align-the-marketplace-repository-structure-with-obrasuperpowers-marketplace-plan.md
+++ b/docs/superpowers/plans/2026-04-23-9-align-the-marketplace-repository-structure-with-obrasuperpowers-marketplace-plan.md
@@ -1,0 +1,218 @@
+# Align The Marketplace Repository Structure With Obra/Superpowers Marketplace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update this repository's marketplace metadata and contributor docs so `superteam` points at the root-packaged `patinaproject/superteam` plugin surface instead of the removed `./plugins/superteam` subdirectory.
+
+**Architecture:** Keep the change confined to catalog-and-doc surfaces owned by `patinaproject/skills`. Switch the Codex marketplace entry from the subdirectory-backed source model to the root-package source model documented in [docs/file-structure.md](/Users/tlmader/.codex/worktrees/0778/skills/docs/file-structure.md), then refresh README guidance so it consistently describes the upstream root manifests and `skills/superteam/` layout without blurring the source-of-truth boundary.
+
+**Tech Stack:** JSON marketplace manifests, Markdown documentation, `rg`, `sed`, `pnpm exec commitlint`
+
+---
+
+### Task 1: Update the Codex marketplace entry for the root-packaged upstream plugin
+
+**Files:**
+- Modify: `/Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json`
+- Reference only: `/Users/tlmader/.codex/worktrees/0778/skills/docs/file-structure.md`
+- Test: `/Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json`
+
+- [ ] **Step 1: Confirm the current entry still uses the stale subdirectory source model**
+
+Run:
+
+```bash
+sed -n '1,200p' /Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json
+```
+
+Expected: the `superteam` entry shows `"source": "git-subdir"`, `"url": "https://github.com/patinaproject/superteam.git"`, `"path": "./plugins/superteam"`, and `"ref": "main"`.
+
+- [ ] **Step 2: Re-read the repository guidance for root-packaged upstream plugins**
+
+Run:
+
+```bash
+sed -n '1,200p' /Users/tlmader/.codex/worktrees/0778/skills/docs/file-structure.md
+```
+
+Expected: the marketplace workflow section says root-level upstream plugins use `source: "url"` and subdirectory-backed plugins use `source: "git-subdir"`.
+
+- [ ] **Step 3: Replace the subdirectory source object with the root-package source model**
+
+Update `/Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json` so the `superteam` entry becomes:
+
+```json
+{
+  "name": "superteam",
+  "source": {
+    "source": "url",
+    "url": "https://github.com/patinaproject/superteam.git",
+    "ref": "main"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Productivity"
+}
+```
+
+Keep the plugin name, URL, policy, category, and explicit ref unchanged. Remove the stale `"path": "./plugins/superteam"` field entirely.
+
+- [ ] **Step 4: Verify the metadata now matches the approved root-package model**
+
+Run:
+
+```bash
+rg -n '"source": "url"|"url": "https://github.com/patinaproject/superteam.git"|"ref": "main"|git-subdir|plugins/superteam' /Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json
+```
+
+Expected:
+- one match for `"source": "url"`
+- one match for the upstream GitHub URL
+- one match for `"ref": "main"`
+- no matches for `git-subdir`
+- no matches for `plugins/superteam`
+
+- [ ] **Step 5: Record the marketplace-only change before moving to docs**
+
+Run:
+
+```bash
+git diff -- /Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json
+```
+
+Expected: the diff shows only the source-model change from `git-subdir` plus `path` to `url` without unrelated edits.
+
+### Task 2: Refresh README install guidance to match the upstream root layout
+
+**Files:**
+- Modify: `/Users/tlmader/.codex/worktrees/0778/skills/README.md`
+- Reference only: `/Users/tlmader/.codex/worktrees/0778/skills/.claude-plugin/marketplace.json`
+- Test: `/Users/tlmader/.codex/worktrees/0778/skills/README.md`
+
+- [ ] **Step 1: Capture the stale README statements that still teach the deleted plugin path**
+
+Run:
+
+```bash
+rg -n 'git-subdir|plugins/superteam|\\.codex-plugin/plugin.json|\\.claude-plugin/plugin.json|skills/superteam' /Users/tlmader/.codex/worktrees/0778/skills/README.md
+```
+
+Expected: matches include the old `git-subdir` explanation, the `./plugins/superteam` install path, and the outdated GitHub blob URL under `plugins/superteam/skills/superteam/SKILL.md`.
+
+- [ ] **Step 2: Confirm the Claude marketplace entry still points at the correct upstream repository**
+
+Run:
+
+```bash
+sed -n '1,200p' /Users/tlmader/.codex/worktrees/0778/skills/.claude-plugin/marketplace.json
+```
+
+Expected: the `superteam` entry continues to use `"repo": "patinaproject/superteam"` with no subdirectory path encoded in the catalog entry.
+
+- [ ] **Step 3: Rewrite the README sections that describe the active install surface**
+
+Update `/Users/tlmader/.codex/worktrees/0778/skills/README.md` so it:
+
+```md
+- describes `superteam` as installed from `patinaproject/superteam` as a root-packaged plugin on `main`
+- explains that `patinaproject/skills` owns marketplace catalogs and contributor docs, while `patinaproject/superteam` owns the installable plugin package
+- states that the upstream Codex manifest lives at `.codex-plugin/plugin.json`
+- states that the upstream Claude manifest lives at `.claude-plugin/plugin.json`
+- states that the upstream skill content lives at `skills/superteam/`
+- removes active-install wording that says Codex targets `./plugins/superteam`
+- updates the direct Claude reference URL from `/blob/main/plugins/superteam/skills/superteam/SKILL.md` to `/blob/main/skills/superteam/SKILL.md`
+```
+
+Preserve the existing marketplace-install commands and the note that this repository does not vendor `superteam` locally.
+
+- [ ] **Step 4: Verify the README now teaches a single current structure**
+
+Run:
+
+```bash
+rg -n 'patinaproject/superteam|\\.codex-plugin/plugin.json|\\.claude-plugin/plugin.json|skills/superteam|plugins/superteam|git-subdir' /Users/tlmader/.codex/worktrees/0778/skills/README.md
+```
+
+Expected:
+- matches for `patinaproject/superteam`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `skills/superteam`
+- no matches for `plugins/superteam`
+- no matches for `git-subdir`
+
+- [ ] **Step 5: Review the README diff for scope discipline**
+
+Run:
+
+```bash
+git diff -- /Users/tlmader/.codex/worktrees/0778/skills/README.md
+```
+
+Expected: the diff is limited to install-surface wording, the source-of-truth boundary explanation, and the updated Claude skill link.
+
+### Task 3: Run repository-level verification for stale path removal and catalog consistency
+
+**Files:**
+- Verify only: `/Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json`
+- Verify only: `/Users/tlmader/.codex/worktrees/0778/skills/.claude-plugin/marketplace.json`
+- Verify only: `/Users/tlmader/.codex/worktrees/0778/skills/README.md`
+
+- [ ] **Step 1: Search the repo for stale active-install references**
+
+Run:
+
+```bash
+rg -n './plugins/superteam|plugins/superteam' /Users/tlmader/.codex/worktrees/0778/skills
+```
+
+Expected:
+- no matches in `/Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json`
+- no matches in `/Users/tlmader/.codex/worktrees/0778/skills/README.md`
+- matches may remain in historical design or plan artifacts under `docs/superpowers/`, which are acceptable because they document prior state rather than active instructions
+
+- [ ] **Step 2: Verify the live catalog and docs agree on the upstream ownership model**
+
+Run:
+
+```bash
+rg -n 'patinaproject/superteam|\\.codex-plugin/plugin.json|\\.claude-plugin/plugin.json|skills/superteam|"source": "url"|git-subdir' /Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json /Users/tlmader/.codex/worktrees/0778/skills/.claude-plugin/marketplace.json /Users/tlmader/.codex/worktrees/0778/skills/README.md
+```
+
+Expected:
+- `.agents/plugins/marketplace.json` shows `"source": "url"` for `superteam`
+- `.claude-plugin/marketplace.json` still points at `patinaproject/superteam`
+- `README.md` describes the root `.codex-plugin/plugin.json`, root `.claude-plugin/plugin.json`, and `skills/superteam/`
+- no live-file matches for `git-subdir`
+
+- [ ] **Step 3: Inspect the final patch set before commit preparation**
+
+Run:
+
+```bash
+git diff -- /Users/tlmader/.codex/worktrees/0778/skills/.agents/plugins/marketplace.json /Users/tlmader/.codex/worktrees/0778/skills/README.md
+```
+
+Expected: only the marketplace metadata and README documentation change, with no drift into plugin package content or unrelated docs.
+
+- [ ] **Step 4: Validate the eventual commit message format before handoff**
+
+Run:
+
+```bash
+printf 'docs: #9 align superteam marketplace root package\n' >/tmp/issue-9-commit-msg.txt && pnpm exec commitlint --edit /tmp/issue-9-commit-msg.txt
+```
+
+Expected: exit code `0`, confirming the proposed issue-tagged conventional commit format is accepted by repo tooling.
+
+- [ ] **Step 5: Prepare the execution handoff notes**
+
+Record in the implementation handoff that:
+
+```text
+Completed scope should be limited to:
+1. .agents/plugins/marketplace.json source-model update for superteam
+2. README.md wording updates for the upstream root-packaged layout
+3. verification evidence showing no active live-file references to ./plugins/superteam remain
+```
+
+Expected: the handoff notes map cleanly to AC-9-1, AC-9-2, and AC-9-3 without expanding the issue boundary.

--- a/docs/superpowers/specs/2026-04-23-9-align-the-marketplace-repository-structure-with-obrasuperpowers-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-23-9-align-the-marketplace-repository-structure-with-obrasuperpowers-marketplace-design.md
@@ -1,0 +1,150 @@
+# Design: Align the marketplace repository structure with obra/superpowers marketplace [#9](https://github.com/patinaproject/skills/issues/9)
+
+## Summary
+
+Update the marketplace metadata and contributor-facing documentation in `patinaproject/skills` so the `superteam` entry matches the current upstream repository layout in `patinaproject/superteam`.
+
+The upstream plugin no longer installs from `./plugins/superteam`. It now exposes its Codex and Claude plugin manifests at the repository root and keeps the skill content under `skills/superteam/`. This issue is the marketplace follow-up in the catalog repo: align this repo's install metadata and docs with that root-based structure without changing plugin ownership, plugin identity, or implementation behavior outside this repository.
+
+## Goals
+
+- Point marketplace metadata at the current root-based upstream install surface for `patinaproject/superteam`
+- Remove repo-doc references that still describe `./plugins/superteam` as the install path
+- Keep the marketplace catalog repo clearly separated from the upstream plugin source repo
+- Preserve the existing plugin name, upstream repository, and source-of-truth ownership boundaries
+
+## Non-Goals
+
+- Editing the upstream `patinaproject/superteam` repository
+- Reworking the `superteam` plugin's content, skills, prompts, or manifests
+- Changing the marketplace slug, display name, or repository ownership model beyond what is required to describe the new root-based install surface
+- Planning or implementing unrelated marketplace cleanup
+
+## Acceptance Criteria
+
+### AC-9-1
+
+Codex marketplace metadata in `patinaproject/skills` points `superteam` at the current upstream install surface in `patinaproject/superteam` instead of the removed `./plugins/superteam` subdirectory.
+
+### AC-9-2
+
+Claude-facing catalog metadata and repository documentation describe `patinaproject/superteam` as a root-packaged plugin repository with root-level plugin manifests and `skills/superteam/`, with no stale references to `./plugins/superteam` as the active upstream install path.
+
+### AC-9-3
+
+Contributor-facing documentation preserves the source-of-truth boundary: `patinaproject/skills` owns marketplace catalogs and docs, while `patinaproject/superteam` owns the installable plugin package.
+
+## Context
+
+This repository is the marketplace catalog, not the source repo for the `superteam` plugin. Today, the live upstream repository layout no longer matches the catalog repo's metadata and docs:
+
+- `.agents/plugins/marketplace.json` still points Codex at `./plugins/superteam` using `git-subdir`
+- `README.md` still explains `./plugins/superteam` as the upstream install path
+- the upstream `patinaproject/superteam` repository now exposes `.codex-plugin/plugin.json` at the root
+- the upstream `patinaproject/superteam` repository now exposes `.claude-plugin/plugin.json` at the root
+- the upstream `patinaproject/superteam` skill now lives at `skills/superteam/`
+- the previous Codex manifest path at `plugins/superteam/.codex-plugin/plugin.json` returns `404`
+
+The repo-local file-structure guidance already distinguishes between subdirectory-backed plugin sources and root-backed plugin sources:
+
+- use `source: "git-subdir"` when the plugin lives in a subdirectory of another repo
+- use `source: "url"` when the plugin lives at the root of another repo
+
+This issue therefore needs a catalog-and-docs alignment pass, not an upstream plugin redesign.
+
+## Approach Options
+
+### Option 1: Minimal metadata correction plus doc refresh
+
+Update the Codex marketplace entry to use the root-package source model for `patinaproject/superteam`, then revise docs so they describe the root manifests and `skills/superteam/` layout.
+
+Pros:
+- Directly matches the current upstream structure
+- Keeps the change limited to the catalog repo surfaces that are currently stale
+- Follows the repository's documented rule for root-packaged upstream plugins
+
+Cons:
+- Requires careful wording so users understand the plugin is owned upstream while the marketplace catalog remains here
+
+### Option 2: Documentation-only correction
+
+Leave marketplace metadata untouched and only revise the docs to explain that the upstream path moved.
+
+Pros:
+- Lowest edit surface
+
+Cons:
+- Leaves the Codex marketplace entry broken or misleading
+- Fails the core requirement to align the install metadata with the real upstream package surface
+
+### Option 3: Vendor or mirror the upstream plugin into this repository
+
+Copy or mirror the root-packaged upstream plugin into `patinaproject/skills` so the catalog can continue using a local or vendored package layout.
+
+Pros:
+- Could reduce cross-repo install indirection
+
+Cons:
+- Conflicts with the current source-of-truth boundary
+- Expands scope into packaging ownership and duplication strategy
+- Unnecessary given the upstream repo already owns the install surface
+
+## Chosen Approach
+
+Use option 1.
+
+The marketplace catalog should describe the upstream plugin the way it exists now: as a root-packaged plugin repository. That means the Codex marketplace entry should stop targeting the deleted `./plugins/superteam` subdirectory, and the docs should stop teaching that outdated path. The catalog repo remains a catalog repo; the upstream plugin repo remains the install source of truth.
+
+## Requirements
+
+1. The Codex marketplace entry for `superteam` must stop referencing `./plugins/superteam` as the source path.
+2. The Codex marketplace entry must use the source model that matches a root-level plugin package, consistent with `docs/file-structure.md`.
+3. The Codex marketplace entry must continue to reference `https://github.com/patinaproject/superteam.git` on an explicit ref.
+4. The `superteam` plugin name must remain `superteam`.
+5. The upstream source repository must remain `patinaproject/superteam`.
+6. Documentation in this repo must describe the upstream install surface as root-level `.codex-plugin/plugin.json`, root-level `.claude-plugin/plugin.json`, and `skills/superteam/`.
+7. Documentation in this repo must remove or replace instructions that describe `./plugins/superteam` as the current upstream install path.
+8. Documentation must preserve the boundary that `patinaproject/skills` owns marketplace catalogs and contributor docs, while `patinaproject/superteam` owns the plugin package itself.
+9. The change must stay limited to marketplace metadata and docs in this repository.
+
+## Affected Surfaces
+
+- `.agents/plugins/marketplace.json`: Codex marketplace install metadata for `superteam`
+- `.claude-plugin/marketplace.json`: Claude catalog metadata that should stay consistent with the upstream repository description
+- `README.md`: user-facing install and maintenance guidance
+- `docs/file-structure.md`: contributor guidance for marketplace source modeling, if needed for clarity or consistency
+
+## Metadata Strategy
+
+The catalog should model `superteam` as an upstream-owned root package.
+
+For Codex, that means the entry should use the marketplace source type intended for plugins that live at the root of another repository rather than the source type intended for subdirectory-backed packages.
+
+For Claude, the existing catalog entry already points at the upstream repository rather than a stale subdirectory path. The main requirement is descriptive consistency: any wording in this repo that explains the Claude install surface should align with the upstream root-level `.claude-plugin/plugin.json` manifest and `skills/superteam/` layout.
+
+## Documentation Strategy
+
+Docs should teach a single, current mental model:
+
+- this repo publishes marketplace catalogs
+- `patinaproject/superteam` is the installable upstream plugin repository
+- Codex and Claude manifests now live at the root of that upstream repository
+- `skills/superteam/` is the relevant skill directory in the upstream repo
+
+The docs should avoid preserving historical path details unless explicitly framed as background. The primary install story should use only the active structure so new contributors are not sent to a deleted path.
+
+## Risks and Guardrails
+
+- Do not change the marketplace slug or plugin slug as part of this issue
+- Do not broaden the issue into upstream repository restructuring
+- Do not introduce conflicting documentation that mixes the deleted `./plugins/superteam` path with the new root-package structure as if both are current
+- Do not vendor duplicate plugin files into this repository to work around the metadata mismatch
+- Keep any metadata change aligned with the repo's own root-vs-subdirectory source guidance
+
+## Verification
+
+- Inspect `.agents/plugins/marketplace.json` to confirm the `superteam` entry no longer references `./plugins/superteam`
+- Inspect `.agents/plugins/marketplace.json` to confirm the source type matches the root-package guidance in `docs/file-structure.md`
+- Inspect `.claude-plugin/marketplace.json` to confirm it still references `patinaproject/superteam`
+- Inspect `README.md` and any updated contributor docs to confirm they describe the active upstream root-package structure and no longer teach `./plugins/superteam` as the current install path
+- Search the repo for `./plugins/superteam` and verify any remaining occurrences are either removed or intentionally framed as historical context rather than active instructions


### PR DESCRIPTION
## Summary
- switch the Codex marketplace entry for `superteam` from the removed subdirectory source to the upstream root package
- refresh README install-surface guidance to describe the root `.codex-plugin/plugin.json`, root `.claude-plugin/plugin.json`, and `skills/superteam/` layout
- add the issue-specific design and plan artifacts for the approved issue-9 workflow

## Validation
- [x] `rg -n 'patinaproject/superteam|\.codex-plugin/plugin.json|\.claude-plugin/plugin.json|skills/superteam|plugins/superteam|git-subdir' README.md .agents/plugins/marketplace.json .claude-plugin/marketplace.json`
- [x] `git diff -- .agents/plugins/marketplace.json README.md docs/superpowers/specs/2026-04-23-9-align-the-marketplace-repository-structure-with-obrasuperpowers-marketplace-design.md docs/superpowers/plans/2026-04-23-9-align-the-marketplace-repository-structure-with-obrasuperpowers-marketplace-plan.md`
- [x] `pnpm install`
- [x] `printf 'docs: #9 align superteam marketplace root package\n' >/tmp/issue-9-commit-msg.txt && pnpm exec commitlint --edit /tmp/issue-9-commit-msg.txt`

## Acceptance Criteria

### AC-9-1
The Codex marketplace metadata now points `superteam` at the upstream root-packaged `patinaproject/superteam` repository instead of the removed `./plugins/superteam` subdirectory.

Verification steps:
- [x] Inspect [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json) and confirm the `superteam` source block uses `"source": "url"` with the upstream Git URL and `ref: "main"`.

### AC-9-2
The live catalog/docs now describe `patinaproject/superteam` as a root-packaged plugin repository with root-level manifests and `skills/superteam/`, with no stale active-install references to `./plugins/superteam`.

Verification steps:
- [x] Inspect [README.md](./README.md) and confirm it documents `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `skills/superteam/`.
- [x] Run the targeted `rg` validation and confirm no live-file matches remain for `plugins/superteam` or `git-subdir` outside historical docs.

### AC-9-3
The source-of-truth boundary remains explicit: `patinaproject/skills` owns marketplace catalogs/docs, while `patinaproject/superteam` owns the installable plugin package.

Verification steps:
- [x] Inspect [README.md](./README.md) and confirm the catalog-vs-plugin ownership split is still documented.

Closes #9 