### PR TITLE
feat: #12 pin marketplace plugins to tagged releases

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -3,19 +3,5 @@
   "interface": {
     "displayName": "Patina Project"
   },
-  "plugins": [
-    {
-      "name": "superteam",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/patinaproject/superteam.git",
-        "ref": "main"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "Productivity"
-    }
-  ]
+  "plugins": []
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,15 +7,5 @@
   "metadata": {
     "description": "Marketplace catalog for Patina Project plugins."
   },
-  "plugins": [
-    {
-      "name": "superteam",
-      "description": "Claude Code plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
-      "category": "productivity",
-      "source": {
-        "source": "github",
-        "repo": "patinaproject/superteam"
-      }
-    }
-  ]
+  "plugins": []
 }

--- a/.github/workflows/plugin-release-bump.yml
+++ b/.github/workflows/plugin-release-bump.yml
@@ -1,0 +1,121 @@
+name: Plugin release bump
+
+on:
+  repository_dispatch:
+    types: [plugin-released]
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: Plugin name as it appears in the marketplace manifests
+        required: true
+      tag:
+        description: Release tag to pin (e.g. v1.0.0)
+        required: true
+      repo:
+        description: Plugin source repo (owner/name). Defaults to patinaproject/<plugin>
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        env:
+          DISPATCH_PLUGIN: ${{ github.event.client_payload.plugin }}
+          DISPATCH_TAG: ${{ github.event.client_payload.tag }}
+          DISPATCH_REPO: ${{ github.event.client_payload.repo }}
+          MANUAL_PLUGIN: ${{ inputs.plugin }}
+          MANUAL_TAG: ${{ inputs.tag }}
+          MANUAL_REPO: ${{ inputs.repo }}
+        run: |
+          plugin="${DISPATCH_PLUGIN:-$MANUAL_PLUGIN}"
+          tag="${DISPATCH_TAG:-$MANUAL_TAG}"
+          repo="${DISPATCH_REPO:-$MANUAL_REPO}"
+          if [ -z "$plugin" ] || [ -z "$tag" ]; then
+            echo "plugin and tag are required" >&2
+            exit 1
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tag must match vX.Y.Z, got '$tag'" >&2
+            exit 1
+          fi
+          if [ -z "$repo" ]; then
+            repo="patinaproject/$plugin"
+          fi
+          echo "plugin=$plugin" >>"$GITHUB_OUTPUT"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "repo=$repo" >>"$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+
+      - name: Update marketplace manifests
+        env:
+          PLUGIN: ${{ steps.inputs.outputs.plugin }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+        run: |
+          set -euo pipefail
+          claude=.claude-plugin/marketplace.json
+          codex=.agents/plugins/marketplace.json
+
+          exists_claude=$(jq --arg p "$PLUGIN" '[.plugins[] | select(.name == $p)] | length' "$claude")
+          if [ "$exists_claude" = "0" ]; then
+            jq --arg p "$PLUGIN" --arg t "$TAG" --arg repo "${{ steps.inputs.outputs.repo }}" \
+              '.plugins += [{
+                "name": $p,
+                "description": ("Patina Project plugin: " + $p),
+                "category": "productivity",
+                "source": { "source": "github", "repo": $repo, "ref": $t }
+              }]' "$claude" >"$claude.tmp"
+          else
+            jq --arg p "$PLUGIN" --arg t "$TAG" \
+              '(.plugins[] | select(.name == $p) | .source.ref) = $t' "$claude" >"$claude.tmp"
+          fi
+          mv "$claude.tmp" "$claude"
+
+          exists_codex=$(jq --arg p "$PLUGIN" '[.plugins[] | select(.name == $p)] | length' "$codex")
+          if [ "$exists_codex" = "0" ]; then
+            jq --arg p "$PLUGIN" --arg t "$TAG" --arg repo "${{ steps.inputs.outputs.repo }}" \
+              '.plugins += [{
+                "name": $p,
+                "source": {
+                  "source": "url",
+                  "url": ("https://github.com/" + $repo + ".git"),
+                  "ref": $t
+                },
+                "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+                "category": "Productivity"
+              }]' "$codex" >"$codex.tmp"
+          else
+            jq --arg p "$PLUGIN" --arg t "$TAG" \
+              '(.plugins[] | select(.name == $p) | .source.ref) = $t' "$codex" >"$codex.tmp"
+          fi
+          mv "$codex.tmp" "$codex"
+
+      - name: Apply bootstrap scaffolding (when plugin is bootstrap)
+        if: steps.inputs.outputs.plugin == 'bootstrap'
+        run: |
+          echo "TODO: invoke patinaproject/bootstrap@${{ steps.inputs.outputs.tag }} against this repo"
+          echo "so its scaffolding (commitlint, husky, etc.) is refreshed in the same PR."
+          echo "Implement once bootstrap defines its invocation entrypoint."
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: bot/bump-${{ steps.inputs.outputs.plugin }}-${{ steps.inputs.outputs.tag }}
+          base: main
+          title: "chore: #12 bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
+          commit-message: "chore: #12 bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
+          body: |
+            Automated bump from a new tagged release of `${{ steps.inputs.outputs.plugin }}`.
+
+            - Plugin: `${{ steps.inputs.outputs.plugin }}`
+            - Tag: `${{ steps.inputs.outputs.tag }}`
+            - Source repo: `${{ steps.inputs.outputs.repo }}`
+
+            Closes the marketplace side of patinaproject/skills#12 for this release.
+          delete-branch: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `.agents/plugins/marketplace.json`: repo-local Codex marketplace source of truth
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth
 - `plugins/`: optional vendored plugin packages when this repo carries local copies
-- `docs/`: contributor docs plus planning artifacts; use paths such as `docs/file-structure.md` and, when present, `docs/superpowers/`
+- `docs/`: contributor docs plus planning artifacts; use paths such as `docs/file-structure.md`, `docs/release-flow.md`, and, when present, `docs/superpowers/`
 - If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
 - root config: `package.json`, `commitizen.config.js`, `commitlint.config.js`, and `.husky/`
 
@@ -39,6 +39,10 @@ For Superpowers-generated design and planning artifacts, use issue-based filenam
 - Review manifest files with `sed -n '1,200p' <file>`
 - Review Git-backed marketplace entries in `.agents/plugins/marketplace.json`
 - Run the relevant plugin validator when a packaged skill includes one
+
+## Plugin Releases
+
+The marketplace only publishes tagged (`vX.Y.Z`) plugin releases. Every plugin entry in both manifests must pin an explicit tag `ref` — branch refs such as `main` are not allowed. New releases of member plugins (`bootstrap`, `superteam`) propagate here via `repository_dispatch` into `.github/workflows/plugin-release-bump.yml`, which opens a bump PR. See [docs/release-flow.md](./docs/release-flow.md).
 
 ## Commit & Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ This repository carries the Patina Project marketplace catalogs for both Codex a
 
 It is a marketplace catalog, not the source repo for every plugin. Marketplace entries can point at plugins packaged in this repo, or at Git-backed plugin sources maintained in other Patina Project repositories.
 
-## Current plugin
+## Current plugins
 
-- `superteam`: installed from the root-packaged `patinaproject/superteam` plugin repository on `main`
+The marketplace only lists plugins that have published a tagged release (`vX.Y.Z`). See [docs/release-flow.md](docs/release-flow.md) for how releases propagate here.
+
+Tracked member plugins:
+
+- `patinaproject/bootstrap` — repo scaffolding skill (pending first tagged release; also consumed by this repo)
+- `patinaproject/superteam` — issue-driven orchestration skill (pending first tagged release, tracked in [patinaproject/superteam#32](https://github.com/patinaproject/superteam/issues/32))
 
 ## Install Surfaces
 
@@ -25,12 +30,7 @@ Codex reads the marketplace definition from `.agents/plugins/marketplace.json`, 
 
 In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project`.
 
-The current `superteam` entry does not vendor plugin files in this repository. Instead, it tells Codex to fetch the plugin package from the `patinaproject/superteam` repository:
-
-- repo: `patinaproject/superteam`
-- source type: `url`
-- plugin root: `.`
-- ref: `main`
+Plugin entries do not vendor plugin files in this repository. Each entry points at a Git-backed plugin source repo (for example `patinaproject/superteam`) pinned to an explicit release tag (`vX.Y.Z`). Branch refs such as `main` are not allowed — see [docs/release-flow.md](docs/release-flow.md).
 
 In the upstream repository, the active install surfaces are:
 
@@ -103,6 +103,8 @@ Use $superteam to coordinate an implementation plan for issue #123.
 ## Maintenance Notes
 
 - Update marketplace entries in `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`
-- Keep Git-backed entries pinned to an explicit `ref` or commit
+- Keep Git-backed entries pinned to an explicit tag `ref` (`vX.Y.Z`). Branch refs are not allowed.
 - Maintain plugin source and packaging in the owning source repository
 - For `superteam`, the source-of-truth repo is `patinaproject/superteam`
+- For `bootstrap`, the source-of-truth repo is `patinaproject/bootstrap`
+- See [docs/release-flow.md](docs/release-flow.md) for how plugin releases propagate into the marketplace

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -1,0 +1,63 @@
+# Plugin Release Flow
+
+The Patina Project marketplace only publishes **tagged releases** (`vX.Y.Z`) of member plugins. The manifests in this repo never reference a branch — every plugin entry pins an explicit `ref`.
+
+Current member plugins tracked by this flow:
+
+- `patinaproject/bootstrap` — repo scaffolding skill. Also **consumed by this repo** (see [Consuming bootstrap](#consuming-bootstrap) below), so a bootstrap release both updates the marketplace entry and refreshes this repo's own scaffolding.
+- `patinaproject/superteam` — issue-driven orchestration skill.
+
+## Lifecycle
+
+1. A member plugin repo (for example `patinaproject/superteam`) uses `release-please` on its default branch. Merging the standing Release PR tags a new semver release and publishes a GitHub Release.
+2. A workflow in that plugin repo fires a `repository_dispatch` into `patinaproject/skills` with event type `plugin-released` and payload `{ plugin, tag, repo }`.
+3. [`.github/workflows/plugin-release-bump.yml`](../.github/workflows/plugin-release-bump.yml) receives the dispatch, updates both marketplace manifests, and opens a bump PR titled `chore: #12 bump <plugin> to <tag>`.
+4. A marketplace maintainer reviews and merges the PR. The new version becomes the one users get on install.
+
+New plugins are added by the same flow: the workflow inserts an entry if the plugin isn't already listed, so the first tagged release of a plugin is also what publishes it.
+
+## Required setup in each member plugin repo
+
+Each plugin repo needs a workflow on `release: published` that fires the dispatch:
+
+```yaml
+name: Notify marketplace
+on:
+  release:
+    types: [published]
+permissions: {}
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MARKETPLACE_DISPATCH_TOKEN }}
+          repository: patinaproject/skills
+          event-type: plugin-released
+          client-payload: |
+            {
+              "plugin": "${{ github.event.repository.name }}",
+              "tag": "${{ github.event.release.tag_name }}",
+              "repo": "${{ github.repository }}"
+            }
+```
+
+`MARKETPLACE_DISPATCH_TOKEN` must be a PAT or GitHub App token with `repo` scope on `patinaproject/skills`.
+
+## Manual fallback
+
+If automation is down, a maintainer can run the workflow directly via **Actions → Plugin release bump → Run workflow**, supplying `plugin` and `tag` (and optionally `repo`). The workflow produces the same PR.
+
+For a fully manual bump, edit `source.ref` for the plugin entry in both [.claude-plugin/marketplace.json](../.claude-plugin/marketplace.json) and [.agents/plugins/marketplace.json](../.agents/plugins/marketplace.json), then open a PR with `chore: #<issue> bump <plugin> to <tag>`.
+
+## Consuming bootstrap
+
+`patinaproject/skills` dogfoods `patinaproject/bootstrap`: the same tag that publishes bootstrap to the marketplace also drives an update of this repo's own scaffolding (commitlint config, husky hooks, issue templates, etc.). On a bootstrap release, the marketplace bump PR is opened as described above, and — in the same workflow run — the bootstrap skill is applied against this repo and any resulting scaffolding changes are committed to the same PR branch. Reviewing the PR therefore covers both the marketplace entry change and the scaffolding refresh in one place.
+
+Other Patina Project repos that want to consume bootstrap this way should subscribe to its `repository_dispatch` the same way this repo does.
+
+## Invariants
+
+- Every plugin entry in both manifests has an explicit `ref` matching `vX.Y.Z`. Branches (`main`, `trunk`, etc.) are not allowed.
+- An untagged plugin is not listed in the marketplace at all. The first tagged release is what introduces it.


### PR DESCRIPTION
## Summary

Closes #12. Move the marketplace to only publishing tagged plugin releases.

- Empty `plugins[]` in both `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` — no member plugin has a tagged release yet, so nothing is offered. Entries come back via the bump PR flow once each plugin tags its first release.
- Add `.github/workflows/plugin-release-bump.yml` — triggered by `repository_dispatch` (event `plugin-released`) or manual `workflow_dispatch`. Updates `source.ref` for the matching plugin in both manifests (inserting the entry if new), then opens a bump PR titled `chore: #12 bump <plugin> to <tag>`.
- Add `docs/release-flow.md` documenting the end-to-end flow, required setup in each plugin repo, the manual fallback, and the bootstrap-consumption dogfood note.
- Update `README.md` and `AGENTS.md` to reflect the tag-only policy and link to the release flow doc.

## Follow-ups (out of scope)

- [patinaproject/superteam#32](https://github.com/patinaproject/superteam/issues/32) — bootstrap superteam repo and cut v1.
- Analogous issue on `patinaproject/bootstrap` to cut its first release and add the `repository_dispatch` workflow (to be filed).
- Implement the "apply bootstrap scaffolding" step in `plugin-release-bump.yml` once bootstrap defines its invocation entrypoint (currently a TODO placeholder).

## Acceptance Criteria

### AC-12-1
Marketplace only offers tagged plugin releases, not whatever is on the default branch.

- Both manifests now have `plugins: []`; the bump workflow and docs only allow pinning entries by `vX.Y.Z` tag (regex-enforced in the workflow).
- Verify: `jq '.plugins' .claude-plugin/marketplace.json .agents/plugins/marketplace.json` shows `[]`.

### AC-12-2
When a member plugin tags a new release, the marketplace surfaces the new version within one merge or automatically.

- Plugin repo fires `repository_dispatch` (payload documented in `docs/release-flow.md`); `.github/workflows/plugin-release-bump.yml` opens a single bump PR. One merge to publish.
- Verify: from Actions → Plugin release bump → Run workflow with `plugin=superteam`, `tag=v1.0.0`, `repo=patinaproject/superteam` and confirm a PR is opened with the correct ref updates.

### AC-12-3
A contributor doc documents how plugin releases propagate into the marketplace.

- [docs/release-flow.md](docs/release-flow.md) covers lifecycle, plugin-side workflow snippet, manual fallback, bootstrap consumption, and invariants. Linked from `README.md` and `AGENTS.md`.

## Test plan

- [ ] `jq . .claude-plugin/marketplace.json` and `jq . .agents/plugins/marketplace.json` succeed
- [ ] Workflow YAML parses (`actionlint` or GitHub UI)
- [ ] Manual `workflow_dispatch` run produces a bump PR with the expected title and diff
- [ ] `docs/release-flow.md` renders and all relative links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)