### PR TITLE
chore: #22 add github-flows to tracked plugins and pin author url

### DIFF
--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -6,6 +6,7 @@ Current member plugins tracked by this flow:
 
 - `patinaproject/bootstrap` — repo scaffolding skill. Also **consumed by this repo** (see [Consuming bootstrap](#consuming-bootstrap) below), so a bootstrap release both updates the marketplace entry and refreshes this repo's own scaffolding.
 - `patinaproject/superteam` — issue-driven orchestration skill.
+- `patinaproject/github-flows` — agent ergonomics for GitHub workflows (`/edit-issue`, `/new-issue`, `/new-branch`).
 
 ## Lifecycle
 

--- a/docs/superpowers/plans/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-plan.md
+++ b/docs/superpowers/plans/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-plan.md
@@ -1,0 +1,39 @@
+# Plan: Add `patinaproject/github-flows` to the marketplace
+
+Issue: [patinaproject/skills#22](https://github.com/patinaproject/skills/issues/22)
+Design: [2026-04-26-22-...-design.md](../specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md)
+
+## Summary
+
+Per design: defer the actual marketplace manifest entry to the automated bump PR fired on `github-flows` `v0.1.0`. This PR delivers documentation + author metadata only.
+
+## Workstreams
+
+Single linear workstream — all changes are independent file edits.
+
+### Tasks
+
+- **T1** (R1): Update [docs/release-flow.md](../../release-flow.md) "Current member plugins tracked by this flow" list to include `patinaproject/github-flows — agent ergonomics for GitHub workflows.`
+- **T2** (R5): Update [package.json](../../../package.json) `author` block to add `"url": "https://github.com/tlmader"`. Keep `name` and `email` unchanged.
+- **T3** (R3, R4): No code change — verification artifact captured in PR description. Confirm by inspection that `.github/workflows/plugin-release-bump.yml` `exists_claude=0` / `exists_codex=0` branches construct entries matching the canonical shape of existing `bootstrap`/`superteam` entries.
+
+### ATDD verification
+
+- **V1** (T1): `grep -F "patinaproject/github-flows" docs/release-flow.md` returns the new bullet.
+- **V2** (T2): `jq '.author' package.json` returns the three-field object including `url`.
+- **V3** (T2): `pnpm exec commitlint --edit` accepts the commit message format `chore: #22 ...`.
+- **V4** (T3, manual inspection in Reviewer): re-read `.github/workflows/plugin-release-bump.yml` to confirm both `exists_*=0` branches emit the canonical entry shape.
+
+### Lint / format gates
+
+- `pnpm lint:md` must pass for the changed `docs/release-flow.md`.
+
+## Blockers
+
+None.
+
+## Out of scope
+
+- Adding a `github-flows` entry to either marketplace manifest (deferred to bump PR on first release).
+- Modifying `plugin-release-bump.yml` (already supports new plugins).
+- Cutting `patinaproject/github-flows` `v0.1.0` (upstream).

--- a/docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
@@ -1,0 +1,51 @@
+# Design: Add `patinaproject/github-flows` to the marketplace
+
+Issue: [patinaproject/skills#22](https://github.com/patinaproject/skills/issues/22)
+
+## Intent
+
+Register a new member plugin, `patinaproject/github-flows`, in both marketplace manifests so users can install it via the standard `patinaproject/skills` flow, and confirm the existing release-bump automation already covers it without changes.
+
+## Context
+
+- Two marketplace manifests are the source of truth:
+  - [.claude-plugin/marketplace.json](../../../.claude-plugin/marketplace.json) (Claude Code)
+  - [.agents/plugins/marketplace.json](../../../.agents/plugins/marketplace.json) (Codex)
+- Existing entries (`bootstrap`, `superteam`) are the shape contract.
+- [.github/workflows/plugin-release-bump.yml](../../../.github/workflows/plugin-release-bump.yml) already handles **insert-if-missing** for any plugin name — no workflow change is required to support a new plugin.
+- [docs/release-flow.md](../../../docs/release-flow.md) hard-codes an invariant: *every plugin entry pins an explicit `vX.Y.Z` ref; branch refs are not allowed; an untagged plugin is not listed at all.*
+
+## Decision
+
+**Wait for the first tagged release.** Do not add a `main`-tracking entry, because that violates the repo's invariant. Once `patinaproject/github-flows` cuts `v0.1.0`, the existing `plugin-release-bump.yml` workflow will receive the dispatch and open the marketplace bump PR automatically — which is precisely the third acceptance criterion (AC-22-2) of the issue.
+
+This issue therefore resolves with **no manifest change in this PR**. What this PR delivers instead:
+
+1. A `docs/release-flow.md` update adding `patinaproject/github-flows` to the "Current member plugins tracked by this flow" list, so the catalog of expected dispatchers is current.
+2. Verification notes confirming the existing automation already covers `github-flows` insert-on-first-release without code changes.
+
+When the upstream `release.yml` in `patinaproject/github-flows` fires `plugin-released` with `v0.1.0`, the bump PR will land the actual marketplace entry.
+
+## Requirements
+
+- R1: `docs/release-flow.md` lists `patinaproject/github-flows` as a tracked member plugin.
+- R2: No manifest change is made until the first tagged release exists.
+- R3: The existing `plugin-release-bump.yml` workflow is verified to handle the new plugin name without modification (its `exists_*=0` branch already constructs new entries with the canonical shape).
+- R4: The PR description records the plan-of-record for the actual marketplace insertion (via the automated bump PR on first release).
+
+## Acceptance criteria mapping
+
+- **AC-22-1** (manifest lists `github-flows` alongside other Patina plugins with the same shape): satisfied by the automated bump PR opened when `v0.1.0` is published, **not by this PR**. This PR documents the contract that the bump PR must fulfill.
+- **AC-22-2** (release dispatch updates the manifest entry to `v0.1.0`): satisfied by existing `plugin-release-bump.yml` — verified, no change required.
+- **AC-22-3** (`/plugin install github-flows@patinaproject-skills` works after install): satisfied transitively once AC-22-1 is satisfied via the bump PR.
+
+## Concerns
+
+- **C1**: Issue body's fallback ("track `main` or the manifest's usual default") directly conflicts with the documented invariant in `docs/release-flow.md`. The design resolves this by deferring the manifest entry to the automated first-release bump PR. **Operator confirmation requested.**
+- **C2**: AC-22-1 is not closed by *this* PR — it is closed by the bump PR. The issue should remain open after this PR merges, or the PR description should explicitly state that AC-22-1 will close on the upstream release. **Operator confirmation requested on whether this PR uses `Closes #22` or a non-closing reference.**
+
+## Out of scope
+
+- Authoring `github-flows` skills (tracked upstream).
+- Changes to `plugin-release-bump.yml` (already handles new plugins).
+- Cutting the upstream `v0.1.0` release.

--- a/docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
@@ -32,6 +32,7 @@ When the upstream `release.yml` in `patinaproject/github-flows` fires `plugin-re
 - R2: No manifest change is made until the first tagged release exists.
 - R3: The existing `plugin-release-bump.yml` workflow is verified to handle the new plugin name without modification (its `exists_*=0` branch already constructs new entries with the canonical shape).
 - R4: The PR description records the plan-of-record for the actual marketplace insertion (via the automated bump PR on first release).
+- R5: `package.json` `author` block adds the missing `url` field (`https://github.com/tlmader`), keeping `name` and `email` unchanged. Marketplace manifests remain attributed to Patina Project via the existing top-level `owner` block — no per-plugin or per-marketplace `author` field is added.
 
 ## Acceptance criteria mapping
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Marketplace catalog for Patina Project plugins and packaged skills (Codex + Claude)",
   "author": {
     "name": "Ted Mader",
-    "email": "ted@patinaproject.com"
+    "email": "ted@patinaproject.com",
+    "url": "https://github.com/tlmader"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.33.2",


### PR DESCRIPTION
## Summary

- Documents `patinaproject/github-flows` as a tracked member plugin in `docs/release-flow.md`. The actual marketplace manifest entry is intentionally deferred: per the repo's tagged-only invariant, an untagged plugin is not listed, so the entry will land via the existing `plugin-release-bump.yml` automation when upstream cuts `v0.1.0`.
- Adds `url` (`https://github.com/tlmader`) to the `package.json` `author` block. Marketplace attribution stays Patina Project via the existing `owner` block.
- Verified that `.github/workflows/plugin-release-bump.yml` already supports a new `github-flows` plugin name unchanged: its `exists_*=0` branches construct entries matching the canonical `bootstrap`/`superteam` shape for both Claude and Codex manifests.

## Linked issue

- Closes #22

## Acceptance criteria

### AC-22-1

Manifest lists `github-flows` alongside other Patina plugins with the same shape.

- [x] Verified by inspection — `.github/workflows/plugin-release-bump.yml` lines 60–88 emit the canonical entry shape for both `.claude-plugin/marketplace.json` (`name`, `description`, `category: "productivity"`, `source.source: "github"`, `source.repo`, `source.ref`) and `.agents/plugins/marketplace.json` (`name`, `source.source: "url"`, `source.url`, `source.ref`, `policy`, `category: "Productivity"`).
- [ ] ⚠️ E2E gap: the manifest entry itself is not added by this PR. It lands when `patinaproject/github-flows` cuts its first tag and the `plugin-released` dispatch runs. Reviewer should accept that AC-22-1 closes on the upstream-triggered bump PR, not on this PR's diff.
- [ ] Manual test: 1) wait for `patinaproject/github-flows` to publish `v0.1.0`. 2) confirm `plugin-release-bump.yml` opens a bump PR titled `chore: #12 bump github-flows to v0.1.0`. 3) inspect the resulting diff in both manifest files for the canonical shape.

### AC-22-2

Release dispatch updates the manifest entry to `v0.1.0` automatically.

- [x] Verified by inspection — workflow accepts `repository_dispatch.types: [plugin-released]` with `client_payload.{plugin,tag,repo}`, validates `vX.Y.Z`, and updates `source.ref` for existing entries or inserts new ones.
- [ ] Manual test: 1) `patinaproject/github-flows` publishes `v0.1.0`. 2) `Notify marketplace` workflow there fires `repository_dispatch`. 3) bump PR opens here automatically.

### AC-22-3

`/plugin install github-flows@patinaproject-skills` loads the three skills.

- [ ] ⚠️ E2E gap: depends on AC-22-1 closing via upstream bump PR.
- [ ] Manual test: after the bump PR merges, run `/plugin marketplace add patinaproject/skills` and `/plugin install github-flows@patinaproject-skills` in Claude Code; confirm `/edit-issue`, `/new-issue`, and `/new-branch` are discoverable.

## Validation

- `pnpm lint:md` — 0 errors across 10 files.
- `jq '.author' package.json` — returns the three-field object including `url`.
- `grep` — confirms `github-flows` line in `docs/release-flow.md`.
- Conventional-commit + husky pre-commit hook accepted all four commits.
- Marketplace shapes verified against canonical Claude docs (https://code.claude.com/docs/en/plugin-marketplaces) and Codex `MarketplacePlugin` source struct.

## Docs updated

- [x] Updated in this PR
