### PR TITLE
ci: #26 make issue references optional

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
 # Pull Request
 
-PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.
+PR title rule for squash merges: use conventional-commit format for the PR title so the squash commit can be reused unchanged. Issue IDs are optional.
 
-`type: #123 short description`
+`type: short description`
 
 Examples:
 
-- `docs: #12 add bootstrap skill guide`
-- `chore: #34 bootstrap commit hooks`
+- `docs: add bootstrap skill guide`
+- `chore: bootstrap commit hooks`
 
 This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,15 @@
 # Pull Request
 
-PR title rule for squash merges: use conventional-commit format for the PR title so the squash commit can be reused unchanged. Issue IDs are optional.
+PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.
 
-`type: short description`
+`type: #123 short description`
 
 Examples:
 
-- `docs: add bootstrap skill guide`
-- `chore: bootstrap commit hooks`
+- `docs: #12 add bootstrap skill guide`
+- `chore: #34 bootstrap commit hooks`
+
+Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.
 
 This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.
 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,7 +12,6 @@ jobs:
   title-format:
     name: Validate PR title
     runs-on: ubuntu-latest
-    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Enforce ASCII-only title
         env:
@@ -51,8 +50,6 @@ jobs:
               feat: #123 add boot timeline
               fix: #456 restore search
             Scopes are not permitted. See AGENTS.md for conventions.
-          ignoreLabels: |
-            dependencies
 
       - name: Validate bot release bump title
         if: "${{ github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.event.pull_request.head.ref, 'bot/bump-') }}"
@@ -74,7 +71,6 @@ jobs:
   linked-issue:
     name: Require linked issue
     runs-on: ubuntu-latest
-    if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Check for closing keyword in PR body
         env:
@@ -115,7 +111,6 @@ jobs:
   mark-breaking-change:
     name: Mark breaking change
     runs-on: ubuntu-latest
-    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Compare title `!` with body BREAKING CHANGE footer
         env:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -23,7 +23,8 @@ jobs:
             exit 1
           fi
 
-      - name: Validate conventional commit title
+      - name: Validate conventional commits + issue ref
+        if: "${{ github.event.pull_request.user.login != 'github-actions[bot]' || !startsWith(github.event.pull_request.head.ref, 'bot/bump-') }}"
         # amannn/action-semantic-pull-request@v5.5.3
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:
@@ -44,24 +45,45 @@ jobs:
           requireScope: false
           disallowScopes: |
             .+
-          subjectPattern: '^.+$'
+          subjectPattern: '^#\d+ .+$'
           subjectPatternError: |
-            PR title subject cannot be empty.
+            PR title subject must start with a GitHub issue reference. Example:
+              feat: #123 add boot timeline
+              fix: #456 restore search
             Scopes are not permitted. See AGENTS.md for conventions.
           ignoreLabels: |
             dependencies
 
+      - name: Validate bot release bump title
+        if: "${{ github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.event.pull_request.head.ref, 'bot/bump-') }}"
+        # amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+          requireScope: false
+          disallowScopes: |
+            .+
+          subjectPattern: '^bump .+$'
+          subjectPatternError: |
+            Bot release bump PR titles must use: chore: bump <plugin> to <tag>
+            Scopes are not permitted. This no-issue exception is only for github-actions[bot] bot/bump-* PRs.
+
   linked-issue:
-    name: Validate optional linked issue
+    name: Require linked issue
     runs-on: ubuntu-latest
     if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
-      - name: Check optional closing keyword syntax
+      - name: Check for closing keyword in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [ -z "$PR_BODY" ]; then
-            echo "::error::PR body is empty. Fill in the PR template."
+            echo "::error::PR body is empty. Add a GitHub closing keyword such as 'Closes #<issue>'."
             exit 1
           fi
           # Strip HTML comments, fenced code blocks, inline code, strikethrough, blockquotes.
@@ -79,7 +101,16 @@ jobs:
             echo "Closing keyword found."
             exit 0
           fi
-          echo "No closing keyword found; linked issues are optional."
+          if [ "$PR_USER" = "github-actions[bot]" ]; then
+            case "$PR_HEAD_REF" in
+              bot/bump-*)
+                echo "No closing keyword found; allowed for bot-generated release bump PR."
+                exit 0
+                ;;
+            esac
+          fi
+          echo "::error::PR body must contain a GitHub closing keyword (e.g. 'Closes #123') outside code blocks, HTML comments, strikethrough, and blockquotes."
+          exit 1
 
   mark-breaking-change:
     name: Mark breaking change
@@ -104,7 +135,7 @@ jobs:
             exit 1
           fi
           if [ "$body_has_footer" = true ] && [ "$title_has_bang" = false ]; then
-            echo "::error::PR body has a \`BREAKING CHANGE:\` footer but the title is missing the \`!\` marker. Add \`!\` to the type (e.g. \`feat!: add new API\`) so squash-merged commits carry the marker."
+            echo "::error::PR body has a \`BREAKING CHANGE:\` footer but the title is missing the \`!\` marker. Add \`!\` to the type (e.g. \`feat!: #123 ...\`) so squash-merged commits carry the marker."
             exit 1
           fi
           echo "Breaking change markers are consistent."

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -23,7 +23,7 @@ jobs:
             exit 1
           fi
 
-      - name: Validate conventional commits + issue ref
+      - name: Validate conventional commit title
         # amannn/action-semantic-pull-request@v5.5.3
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:
@@ -44,26 +44,24 @@ jobs:
           requireScope: false
           disallowScopes: |
             .+
-          subjectPattern: '^#\d+ .+$'
+          subjectPattern: '^.+$'
           subjectPatternError: |
-            PR title subject must start with a GitHub issue reference. Example:
-              feat: #123 add boot timeline
-              fix: #456 restore search
+            PR title subject cannot be empty.
             Scopes are not permitted. See AGENTS.md for conventions.
           ignoreLabels: |
             dependencies
 
-  closing-keyword:
-    name: Require closing keyword
+  linked-issue:
+    name: Validate optional linked issue
     runs-on: ubuntu-latest
     if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
-      - name: Check for closing keyword in PR body
+      - name: Check optional closing keyword syntax
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           if [ -z "$PR_BODY" ]; then
-            echo "::error::PR body is empty. Add a GitHub closing keyword such as 'Closes #<issue>'."
+            echo "::error::PR body is empty. Fill in the PR template."
             exit 1
           fi
           # Strip HTML comments, fenced code blocks, inline code, strikethrough, blockquotes.
@@ -81,8 +79,7 @@ jobs:
             echo "Closing keyword found."
             exit 0
           fi
-          echo "::error::PR body must contain a GitHub closing keyword (e.g. 'Closes #123') outside code blocks, HTML comments, strikethrough, and blockquotes."
-          exit 1
+          echo "No closing keyword found; linked issues are optional."
 
   mark-breaking-change:
     name: Mark breaking change
@@ -107,7 +104,7 @@ jobs:
             exit 1
           fi
           if [ "$body_has_footer" = true ] && [ "$title_has_bang" = false ]; then
-            echo "::error::PR body has a \`BREAKING CHANGE:\` footer but the title is missing the \`!\` marker. Add \`!\` to the type (e.g. \`feat!: #123 ...\`) so squash-merged commits carry the marker."
+            echo "::error::PR body has a \`BREAKING CHANGE:\` footer but the title is missing the \`!\` marker. Add \`!\` to the type (e.g. \`feat!: add new API\`) so squash-merged commits carry the marker."
             exit 1
           fi
           echo "Breaking change markers are consistent."

--- a/.github/workflows/plugin-release-bump.yml
+++ b/.github/workflows/plugin-release-bump.yml
@@ -112,14 +112,12 @@ jobs:
         with:
           branch: bot/bump-${{ steps.inputs.outputs.plugin }}-${{ steps.inputs.outputs.tag }}
           base: main
-          title: "chore: #12 bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
-          commit-message: "chore: #12 bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
+          title: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
+          commit-message: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
           body: |
             Automated bump from a new tagged release of `${{ steps.inputs.outputs.plugin }}`.
 
             - Plugin: `${{ steps.inputs.outputs.plugin }}`
             - Tag: `${{ steps.inputs.outputs.tag }}`
             - Source repo: `${{ steps.inputs.outputs.repo }}`
-
-            Closes the marketplace side of patinaproject/skills#12 for this release.
           delete-branch: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ For Superpowers-generated design and planning artifacts, use issue-based filenam
 ## Build, Test, and Development Commands
 
 - `pnpm install`: install dev tooling and initialize Husky
-- `pnpm commit`: create a guided conventional commit
+- `pnpm commit`: create a guided conventional commit with issue tagging
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `sed -n '1,200p' .agents/plugins/marketplace.json`: inspect marketplace entries
@@ -82,18 +82,20 @@ The marketplace only publishes tagged (`vX.Y.Z`) plugin releases. Every plugin e
 
 ## Commit & Pull Request Guidelines
 
-Commits must use conventional commit types with no scopes. GitHub issue tags are optional:
+Commits must use conventional commit types, no scopes, and a required GitHub issue tag:
 
-`type: short description`
+`type: #123 short description`
 
 Examples:
 
-- `chore: bootstrap marketplace repo`
-- `feat: add superteam marketplace entry`
+- `chore: #1 bootstrap marketplace repo`
+- `feat: #12 add superteam marketplace entry`
 
 For squash-and-merge workflows, PR titles must match the commitlint commit format:
 
-`type: short description`
+`type: #123 short description`
+
+Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.
 
 When an issue defines acceptance criteria, include an `Acceptance Criteria` section in the PR description.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ For Superpowers-generated design and planning artifacts, use issue-based filenam
 ## Build, Test, and Development Commands
 
 - `pnpm install`: install dev tooling and initialize Husky
-- `pnpm commit`: create a guided conventional commit with issue tagging
+- `pnpm commit`: create a guided conventional commit
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `sed -n '1,200p' .agents/plugins/marketplace.json`: inspect marketplace entries
@@ -82,18 +82,18 @@ The marketplace only publishes tagged (`vX.Y.Z`) plugin releases. Every plugin e
 
 ## Commit & Pull Request Guidelines
 
-Commits must use conventional commit types, no scopes, and a required GitHub issue tag:
+Commits must use conventional commit types with no scopes. GitHub issue tags are optional:
 
-`type: #123 short description`
+`type: short description`
 
 Examples:
 
-- `chore: #1 bootstrap marketplace repo`
-- `feat: #12 add superteam marketplace entry`
+- `chore: bootstrap marketplace repo`
+- `feat: add superteam marketplace entry`
 
 For squash-and-merge workflows, PR titles must match the commitlint commit format:
 
-`type: #123 short description`
+`type: short description`
 
 When an issue defines acceptance criteria, include an `Acceptance Criteria` section in the PR description.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,18 +12,18 @@ This installs dev tooling and registers the Husky hooks (`commit-msg` + `pre-com
 
 ## Commit messages
 
-Commits must follow Conventional Commits with no scope. GitHub issue tags are optional:
+Commits must follow Conventional Commits with no scope and a required GitHub issue tag:
 
 ```text
-type: short description
+type: #123 short description
 ```
 
 Examples:
 
-- `feat: add a feature`
-- `docs: clarify install steps`
+- `feat: #42 add a feature`
+- `docs: #17 clarify install steps`
 
-The `commit-msg` hook enforces the conventional-commit format. PR titles follow the same format so the squash commit can be reused verbatim.
+The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
 
 ## Markdown
 
@@ -37,7 +37,8 @@ pnpm lint:md
 
 - Keep the PR title in commitlint format.
 - Fill in the [PR template](./.github/pull_request_template.md).
-- Include an `Acceptance Criteria` section when a linked issue defines ACs.
+- Include an `Acceptance Criteria` section when the linked issue defines ACs.
+- Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.
 
 ## Further reading
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,18 +12,18 @@ This installs dev tooling and registers the Husky hooks (`commit-msg` + `pre-com
 
 ## Commit messages
 
-Commits must follow Conventional Commits with no scope and a required GitHub issue tag:
+Commits must follow Conventional Commits with no scope. GitHub issue tags are optional:
 
 ```text
-type: #123 short description
+type: short description
 ```
 
 Examples:
 
-- `feat: #42 add a feature`
-- `docs: #17 clarify install steps`
+- `feat: add a feature`
+- `docs: clarify install steps`
 
-The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
+The `commit-msg` hook enforces the conventional-commit format. PR titles follow the same format so the squash commit can be reused verbatim.
 
 ## Markdown
 
@@ -37,7 +37,7 @@ pnpm lint:md
 
 - Keep the PR title in commitlint format.
 - Fill in the [PR template](./.github/pull_request_template.md).
-- Include an `Acceptance Criteria` section when the linked issue defines ACs.
+- Include an `Acceptance Criteria` section when a linked issue defines ACs.
 
 ## Further reading
 

--- a/commitizen.config.js
+++ b/commitizen.config.js
@@ -27,17 +27,16 @@ module.exports = {
   allowCustomScopes: false,
   allowBreakingChanges: ["feat", "fix"],
   allowTicketNumber: true,
-  isTicketNumberRequired: true,
+  isTicketNumberRequired: false,
   ticketNumberPrefix: "",
   ticketNumberRegExp: "#\\d+",
   prependTicketToHead: false,
   skipQuestions: ["scope", "body", "footer"],
   messages: {
     type: "Select the type of change you're committing:",
-    ticketNumber: "Enter the GitHub issue reference (e.g. #1):\n",
+    ticketNumber: "Enter the GitHub issue reference, if any (e.g. #1):\n",
     subject: "Write a short description of the change:\n",
     confirmCommit: "Are you sure you want to proceed with the commit above?"
   },
   subjectLimit: 72
 };
-

--- a/commitizen.config.js
+++ b/commitizen.config.js
@@ -27,14 +27,14 @@ module.exports = {
   allowCustomScopes: false,
   allowBreakingChanges: ["feat", "fix"],
   allowTicketNumber: true,
-  isTicketNumberRequired: false,
+  isTicketNumberRequired: true,
   ticketNumberPrefix: "",
   ticketNumberRegExp: "#\\d+",
   prependTicketToHead: false,
   skipQuestions: ["scope", "body", "footer"],
   messages: {
     type: "Select the type of change you're committing:",
-    ticketNumber: "Enter the GitHub issue reference, if any (e.g. #1):\n",
+    ticketNumber: "Enter the GitHub issue reference (e.g. #1):\n",
     subject: "Write a short description of the change:\n",
     confirmCommit: "Are you sure you want to proceed with the commit above?"
   },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,30 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  plugins: [
+    {
+      rules: {
+        "ticket-required": (parsed) => {
+          const { subject } = parsed;
+          if (!subject) {
+            return [false, "Subject cannot be empty"];
+          }
+
+          if (!/^#\d+\s+/.test(subject)) {
+            return [
+              false,
+              "Subject must start with a GitHub issue reference. Use `type: #123 description`."
+            ];
+          }
+
+          return [true, ""];
+        }
+      }
+    }
+  ],
   rules: {
     "scope-empty": [2, "always"],
     "subject-case": [0],
-    "subject-empty": [2, "never"],
-    "subject-max-length": [2, "always", 72]
+    "subject-max-length": [2, "always", 72],
+    "ticket-required": [2, "always"]
   }
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,31 +1,9 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
-  plugins: [
-    {
-      rules: {
-        "ticket-required": (parsed) => {
-          const { subject } = parsed;
-          if (!subject) {
-            return [false, "Subject cannot be empty"];
-          }
-
-          if (!/^#\d+\s+/.test(subject)) {
-            return [
-              false,
-              "Subject must start with a GitHub issue reference. Use `type: #123 description`."
-            ];
-          }
-
-          return [true, ""];
-        }
-      }
-    }
-  ],
   rules: {
     "scope-empty": [2, "always"],
     "subject-case": [0],
-    "subject-max-length": [2, "always", 72],
-    "ticket-required": [2, "always"]
+    "subject-empty": [2, "never"],
+    "subject-max-length": [2, "always", 72]
   }
 };
-

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -12,7 +12,7 @@ Current member plugins tracked by this flow:
 
 1. A member plugin repo (for example `patinaproject/superteam`) uses `release-please` on its default branch. Merging the standing Release PR tags a new semver release and publishes a GitHub Release.
 2. A workflow in that plugin repo fires a `repository_dispatch` into `patinaproject/skills` with event type `plugin-released` and payload `{ plugin, tag, repo }`.
-3. [`.github/workflows/plugin-release-bump.yml`](../.github/workflows/plugin-release-bump.yml) receives the dispatch, updates both marketplace manifests, and opens a bump PR titled `chore: bump <plugin> to <tag>`.
+3. [`.github/workflows/plugin-release-bump.yml`](../.github/workflows/plugin-release-bump.yml) receives the dispatch, updates both marketplace manifests, and opens a bot-generated bump PR titled `chore: bump <plugin> to <tag>`. These bot-generated `bot/bump-*` PRs are the only PRs that may omit an issue ID.
 4. A marketplace maintainer reviews and merges the PR. The new version becomes the one users get on install.
 
 New plugins are added by the same flow: the workflow inserts an entry if the plugin isn't already listed, so the first tagged release of a plugin is also what publishes it.
@@ -50,7 +50,7 @@ jobs:
 
 If automation is down, a maintainer can run the workflow directly via **Actions → Plugin release bump → Run workflow**, supplying `plugin` and `tag` (and optionally `repo`). The workflow produces the same PR.
 
-For a fully manual bump, edit `source.ref` for the plugin entry in both [.claude-plugin/marketplace.json](../.claude-plugin/marketplace.json) and [.agents/plugins/marketplace.json](../.agents/plugins/marketplace.json), then open a PR with `chore: bump <plugin> to <tag>`.
+For a fully manual bump, edit `source.ref` for the plugin entry in both [.claude-plugin/marketplace.json](../.claude-plugin/marketplace.json) and [.agents/plugins/marketplace.json](../.agents/plugins/marketplace.json), then open a PR with `chore: #<issue> bump <plugin> to <tag>`.
 
 ## Consuming bootstrap
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -12,7 +12,7 @@ Current member plugins tracked by this flow:
 
 1. A member plugin repo (for example `patinaproject/superteam`) uses `release-please` on its default branch. Merging the standing Release PR tags a new semver release and publishes a GitHub Release.
 2. A workflow in that plugin repo fires a `repository_dispatch` into `patinaproject/skills` with event type `plugin-released` and payload `{ plugin, tag, repo }`.
-3. [`.github/workflows/plugin-release-bump.yml`](../.github/workflows/plugin-release-bump.yml) receives the dispatch, updates both marketplace manifests, and opens a bump PR titled `chore: #12 bump <plugin> to <tag>`.
+3. [`.github/workflows/plugin-release-bump.yml`](../.github/workflows/plugin-release-bump.yml) receives the dispatch, updates both marketplace manifests, and opens a bump PR titled `chore: bump <plugin> to <tag>`.
 4. A marketplace maintainer reviews and merges the PR. The new version becomes the one users get on install.
 
 New plugins are added by the same flow: the workflow inserts an entry if the plugin isn't already listed, so the first tagged release of a plugin is also what publishes it.
@@ -50,7 +50,7 @@ jobs:
 
 If automation is down, a maintainer can run the workflow directly via **Actions → Plugin release bump → Run workflow**, supplying `plugin` and `tag` (and optionally `repo`). The workflow produces the same PR.
 
-For a fully manual bump, edit `source.ref` for the plugin entry in both [.claude-plugin/marketplace.json](../.claude-plugin/marketplace.json) and [.agents/plugins/marketplace.json](../.agents/plugins/marketplace.json), then open a PR with `chore: #<issue> bump <plugin> to <tag>`.
+For a fully manual bump, edit `source.ref` for the plugin entry in both [.claude-plugin/marketplace.json](../.claude-plugin/marketplace.json) and [.agents/plugins/marketplace.json](../.agents/plugins/marketplace.json), then open a PR with `chore: bump <plugin> to <tag>`.
 
 ## Consuming bootstrap
 

--- a/docs/superpowers/plans/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-plan.md
+++ b/docs/superpowers/plans/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-plan.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make issue references optional for release bump PRs and repo commit/PR policy while preserving conventional commit hygiene.
+**Goal:** Limit no-issue PR and commit wording to bot-generated release bump PRs while preserving issue-ID requirements for human commits and PRs.
 
-**Architecture:** Update the release-bump workflow output first, then relax the shared validation paths that currently enforce issue IDs. Finish by aligning contributor-facing docs and templates so humans see the same policy that automation enforces.
+**Architecture:** Keep the release-bump workflow output issue-free, then restore human-facing commit and PR validation to require issue references. Add a narrow PR lint exception keyed to `github-actions[bot]` and `bot/bump-*` branches, and document that exception only in release-bump guidance.
 
 **Tech Stack:** GitHub Actions YAML, `peter-evans/create-pull-request`, `amannn/action-semantic-pull-request`, commitlint, Commitizen, Markdown docs, `pnpm`, `actionlint`.
 
@@ -13,15 +13,15 @@
 ## File Structure
 
 - `.github/workflows/plugin-release-bump.yml`: generated release bump PR title, commit message, and body.
-- `.github/workflows/lint-pr.yml`: PR title/body policy enforced in CI.
-- `commitlint.config.js`: local commit-message policy enforced by Husky and `pnpm exec commitlint`.
-- `commitizen.config.js`: guided commit prompt behavior.
-- `.github/pull_request_template.md`: contributor-facing PR title and linked-issue guidance.
+- `.github/workflows/lint-pr.yml`: PR title/body policy, including the bot bump exception.
+- `commitlint.config.js`: local commit-message policy for human commits.
+- `commitizen.config.js`: guided human commit prompts.
+- `.github/pull_request_template.md`: human PR title and linked-issue guidance.
 - `AGENTS.md`: canonical agent repository rules.
 - `CONTRIBUTING.md`: contributor-facing commit and PR rules.
-- `docs/release-flow.md`: plugin release flow documentation.
+- `docs/release-flow.md`: release-bump exception documentation.
 
-## Task 1: Update Generated Release Bump PR Output
+## Task 1: Keep Bot Release Bump Output Issue-Free
 
 **Files:**
 
@@ -35,13 +35,15 @@ Run:
 sed -n '108,130p' .github/workflows/plugin-release-bump.yml
 ```
 
-Expected: output shows `title`, `commit-message`, and body text containing the hardcoded issue #12 release reference.
+Expected: the `Create PR` block is visible.
 
-- [ ] **Step 2: Remove the generated hardcoded issue references**
+- [ ] **Step 2: Ensure generated bot bump PRs omit issue references**
 
-In `.github/workflows/plugin-release-bump.yml`, replace the `Create PR` `with:` block values so they match:
+In `.github/workflows/plugin-release-bump.yml`, keep the `Create PR` values as:
 
 ```yaml
+          branch: bot/bump-${{ steps.inputs.outputs.plugin }}-${{ steps.inputs.outputs.tag }}
+          base: main
           title: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
           commit-message: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
           body: |
@@ -50,10 +52,9 @@ In `.github/workflows/plugin-release-bump.yml`, replace the `Create PR` `with:` 
             - Plugin: `${{ steps.inputs.outputs.plugin }}`
             - Tag: `${{ steps.inputs.outputs.tag }}`
             - Source repo: `${{ steps.inputs.outputs.repo }}`
-          delete-branch: true
 ```
 
-- [ ] **Step 3: Verify AC-26-1 by searching for removed generated text**
+- [ ] **Step 3: Verify AC-26-1**
 
 Run:
 
@@ -63,7 +64,7 @@ rg -n "Closes the marketplace side|#12 bump|patinaproject/skills#12" .github/wor
 
 Expected: command exits with no matches.
 
-- [ ] **Step 4: Commit Task 1**
+- [ ] **Step 4: Commit Task 1 if changed**
 
 Run:
 
@@ -72,113 +73,72 @@ git add .github/workflows/plugin-release-bump.yml
 git commit -m "ci: #26 remove release bump issue reference"
 ```
 
-Expected: commit succeeds.
+Expected: commit succeeds if the workflow changed; skip if already committed.
 
-## Task 2: Relax Commit and PR Validation Policy
+## Task 2: Restore Human Commit Policy
 
 **Files:**
 
 - Modify: `commitlint.config.js`
 - Modify: `commitizen.config.js`
-- Modify: `.github/workflows/lint-pr.yml`
 
-- [ ] **Step 1: Update commitlint to require only conventional commits with non-empty subjects**
+- [ ] **Step 1: Restore commitlint issue-ID enforcement**
 
-Replace the custom `ticket-required` plugin in `commitlint.config.js` with built-in subject validation:
+Set `commitlint.config.js` to:
 
 ```js
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  plugins: [
+    {
+      rules: {
+        "ticket-required": (parsed) => {
+          const { subject } = parsed;
+          if (!subject) {
+            return [false, "Subject cannot be empty"];
+          }
+
+          if (!/^#\d+\s+/.test(subject)) {
+            return [
+              false,
+              "Subject must start with a GitHub issue reference. Use `type: #123 description`."
+            ];
+          }
+
+          return [true, ""];
+        }
+      }
+    }
+  ],
   rules: {
     "scope-empty": [2, "always"],
     "subject-case": [0],
-    "subject-empty": [2, "never"],
-    "subject-max-length": [2, "always", 72]
+    "subject-max-length": [2, "always", 72],
+    "ticket-required": [2, "always"]
   }
 };
 ```
 
-- [ ] **Step 2: Make Commitizen ticket entry optional**
+- [ ] **Step 2: Restore Commitizen required ticket prompt**
 
-In `commitizen.config.js`, set the ticket requirement to false and update the prompt:
+In `commitizen.config.js`, set:
 
 ```js
   allowTicketNumber: true,
-  isTicketNumberRequired: false,
+  isTicketNumberRequired: true,
   ticketNumberPrefix: "",
   ticketNumberRegExp: "#\\d+",
   prependTicketToHead: false,
   skipQuestions: ["scope", "body", "footer"],
   messages: {
     type: "Select the type of change you're committing:",
-    ticketNumber: "Enter the GitHub issue reference, if any (e.g. #1):\n",
+    ticketNumber: "Enter the GitHub issue reference (e.g. #1):\n",
     subject: "Write a short description of the change:\n",
     confirmCommit: "Are you sure you want to proceed with the commit above?"
   },
 ```
 
-- [ ] **Step 3: Relax PR title linting**
-
-In `.github/workflows/lint-pr.yml`, update the semantic PR title step so the step name and subject pattern no longer require an issue reference:
-
-```yaml
-      - name: Validate conventional commit title
-        # amannn/action-semantic-pull-request@v5.5.3
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            docs
-            chore
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            revert
-          requireScope: false
-          disallowScopes: |
-            .+
-          subjectPattern: '^.+$'
-          subjectPatternError: |
-            PR title subject cannot be empty.
-            Scopes are not permitted. See AGENTS.md for conventions.
-          ignoreLabels: |
-            dependencies
-```
-
-- [ ] **Step 4: Relax PR body closing-keyword linting**
-
-In `.github/workflows/lint-pr.yml`, rename the closing-keyword job and keep only the non-empty body requirement. The end of the script should say:
-
-```bash
-          if printf '%s' "$sanitized" | grep -qiE \
-            '(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[ \t]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[1-9][0-9]*([^0-9A-Za-z_]|$)'; then
-            echo "Closing keyword found."
-            exit 0
-          fi
-          echo "No closing keyword found; linked issues are optional."
-```
-
-Also change the empty-body error to:
-
-```bash
-            echo "::error::PR body is empty. Fill in the PR template."
-```
-
-- [ ] **Step 5: Update the breaking-change example**
-
-In `.github/workflows/lint-pr.yml`, replace the example `feat!: #123 ...` with:
-
-```bash
-feat!: add new API
-```
-
-- [ ] **Step 6: Verify AC-26-2 with a no-issue commit message**
+- [ ] **Step 3: Verify AC-26-2 human no-issue commits fail**
 
 Run:
 
@@ -187,9 +147,9 @@ printf 'chore: bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-no-issue
 pnpm exec commitlint --edit /tmp/skills-commit-msg-no-issue
 ```
 
-Expected: command exits 0.
+Expected: command exits non-zero with `ticket-required`.
 
-- [ ] **Step 7: Verify issue references still work when meaningful**
+- [ ] **Step 4: Verify issue-tagged commits still pass**
 
 Run:
 
@@ -200,7 +160,89 @@ pnpm exec commitlint --edit /tmp/skills-commit-msg-with-issue
 
 Expected: command exits 0.
 
-- [ ] **Step 8: Verify workflow syntax**
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add commitlint.config.js commitizen.config.js
+git commit -m "ci: #26 restore human issue reference commits"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Narrow PR Lint Exception to Bot Bumps
+
+**Files:**
+
+- Modify: `.github/workflows/lint-pr.yml`
+
+- [ ] **Step 1: Restore normal PR title issue-ID enforcement**
+
+In `.github/workflows/lint-pr.yml`, the normal semantic PR step should run unless the PR is from `github-actions[bot]` on a `bot/bump-*` branch:
+
+```yaml
+      - name: Validate conventional commits + issue ref
+        if: "${{ github.event.pull_request.user.login != 'github-actions[bot]' || !startsWith(github.event.pull_request.head.ref, 'bot/bump-') }}"
+```
+
+Its subject pattern and error should be:
+
+```yaml
+          subjectPattern: '^#\d+ .+$'
+          subjectPatternError: |
+            PR title subject must start with a GitHub issue reference. Example:
+              feat: #123 add boot timeline
+              fix: #456 restore search
+            Scopes are not permitted. See AGENTS.md for conventions.
+```
+
+- [ ] **Step 2: Add the bot release bump title exception**
+
+Add a second semantic PR step:
+
+```yaml
+      - name: Validate bot release bump title
+        if: "${{ github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.event.pull_request.head.ref, 'bot/bump-') }}"
+        # amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+          requireScope: false
+          disallowScopes: |
+            .+
+          subjectPattern: '^bump .+$'
+          subjectPatternError: |
+            Bot release bump PR titles must use: chore: bump <plugin> to <tag>
+            Scopes are not permitted. This no-issue exception is only for github-actions[bot] bot/bump-* PRs.
+```
+
+- [ ] **Step 3: Restore normal PR body closing-keyword enforcement**
+
+The PR body job should reject non-bot-bump PRs without a closing keyword and allow only `github-actions[bot]` `bot/bump-*` PRs to omit one:
+
+```bash
+          if printf '%s' "$sanitized" | grep -qiE \
+            '(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[ \t]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[1-9][0-9]*([^0-9A-Za-z_]|$)'; then
+            echo "Closing keyword found."
+            exit 0
+          fi
+          if [ "$PR_USER" = "github-actions[bot]" ]; then
+            case "$PR_HEAD_REF" in
+              bot/bump-*)
+                echo "No closing keyword found; allowed for bot-generated release bump PR."
+                exit 0
+                ;;
+            esac
+          fi
+          echo "::error::PR body must contain a GitHub closing keyword (e.g. 'Closes #123') outside code blocks, HTML comments, strikethrough, and blockquotes."
+          exit 1
+```
+
+- [ ] **Step 4: Verify workflow syntax**
 
 Run:
 
@@ -210,18 +252,18 @@ actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.y
 
 Expected: command exits 0.
 
-- [ ] **Step 9: Commit Task 2**
+- [ ] **Step 5: Commit Task 3**
 
 Run:
 
 ```bash
-git add commitlint.config.js commitizen.config.js .github/workflows/lint-pr.yml
-git commit -m "ci: #26 make issue references optional"
+git add .github/workflows/lint-pr.yml
+git commit -m "ci: #26 limit issue exception to bot bumps"
 ```
 
 Expected: commit succeeds.
 
-## Task 3: Align Contributor Docs and Templates
+## Task 4: Align Documentation With Narrow Exception
 
 **Files:**
 
@@ -230,96 +272,54 @@ Expected: commit succeeds.
 - Modify: `CONTRIBUTING.md`
 - Modify: `docs/release-flow.md`
 
-- [ ] **Step 1: Update the PR template title examples**
+- [ ] **Step 1: Restore human PR title examples**
 
-In `.github/pull_request_template.md`, make the opening title guidance read:
+In `.github/pull_request_template.md`, use:
 
 ```markdown
-PR title rule for squash merges: use conventional-commit format for the PR title so the squash commit can be reused unchanged. Issue IDs are optional.
-
-`type: short description`
+`type: #123 short description`
 
 Examples:
 
-- `docs: add bootstrap skill guide`
-- `chore: bootstrap commit hooks`
+- `docs: #12 add bootstrap skill guide`
+- `chore: #34 bootstrap commit hooks`
+
+Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.
 ```
 
-Leave the `## Linked issue` section present and optional with its existing `Omit this section when no issue applies` guidance.
+- [ ] **Step 2: Restore AGENTS.md and CONTRIBUTING.md human issue guidance**
 
-- [ ] **Step 2: Update AGENTS.md commit and PR guidance**
-
-In `AGENTS.md`, update the commit command description and commit/PR examples to:
+Both docs must state that human commits and PR titles require issue tags, and both must mention the only exception:
 
 ```markdown
-- `pnpm commit`: create a guided conventional commit
+Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.
 ```
+
+- [ ] **Step 3: Document bot bump exception in release flow**
+
+In `docs/release-flow.md`, document that automated release bumps use:
 
 ```markdown
-Commits must use conventional commit types with no scopes. GitHub issue tags are optional:
-
-`type: short description`
-
-Examples:
-
-- `chore: bootstrap marketplace repo`
-- `feat: add superteam marketplace entry`
-
-For squash-and-merge workflows, PR titles must match the commitlint commit format:
-
-`type: short description`
+`chore: bump <plugin> to <tag>`
 ```
 
-- [ ] **Step 3: Update CONTRIBUTING.md commit and PR guidance**
-
-In `CONTRIBUTING.md`, update the commit section to:
-
-````markdown
-Commits must follow Conventional Commits with no scope. GitHub issue tags are optional:
-
-```text
-type: short description
-```
-
-Examples:
-
-- `feat: add a feature`
-- `docs: clarify install steps`
-
-The `commit-msg` hook enforces the conventional-commit format. PR titles follow the same format so the squash commit can be reused verbatim.
-````
-
-Also update the PR bullet to:
+and that manual bumps use:
 
 ```markdown
-- Include an `Acceptance Criteria` section when a linked issue defines ACs.
+`chore: #<issue> bump <plugin> to <tag>`
 ```
 
-- [ ] **Step 4: Update release-flow examples**
-
-In `docs/release-flow.md`, update the automated and manual bump examples to:
-
-```markdown
-opens a bump PR titled `chore: bump <plugin> to <tag>`
-```
-
-and:
-
-```markdown
-then open a PR with `chore: bump <plugin> to <tag>`.
-```
-
-- [ ] **Step 5: Verify removed-policy text is gone from active docs and workflows**
+- [ ] **Step 4: Verify active policy text**
 
 Run:
 
 ```bash
-rg -n "Closes the marketplace side|#12 bump|PR title subject must start|must contain a GitHub closing|isTicketNumberRequired: true|ticket-required|feat!: #123" .github AGENTS.md CONTRIBUTING.md docs/release-flow.md commitlint.config.js commitizen.config.js
+rg -n "Issue IDs are optional|GitHub issue tags are optional|No closing keyword found; linked issues are optional|subjectPattern: '\\^\\.\\+\\$'|isTicketNumberRequired: false" .github AGENTS.md CONTRIBUTING.md docs/release-flow.md commitlint.config.js commitizen.config.js
 ```
 
-Expected: command exits with no matches in the active policy surface. Historical design and plan docs are intentionally excluded because they may quote old policy text as context.
+Expected: command exits with no matches.
 
-- [ ] **Step 6: Verify Markdown formatting**
+- [ ] **Step 5: Verify Markdown formatting**
 
 Run:
 
@@ -329,24 +329,24 @@ pnpm lint:md
 
 Expected: command exits 0.
 
-- [ ] **Step 7: Commit Task 3**
+- [ ] **Step 6: Commit Task 4**
 
 Run:
 
 ```bash
 git add .github/pull_request_template.md AGENTS.md CONTRIBUTING.md docs/release-flow.md
-git commit -m "docs: #26 document optional issue references"
+git commit -m "docs: #26 document bot bump issue exception"
 ```
 
 Expected: commit succeeds.
 
-## Task 4: Final Verification
+## Task 5: Final Verification
 
 **Files:**
 
-- Read: all files changed in Tasks 1-3.
+- Read: all files changed in Tasks 1-4.
 
-- [ ] **Step 1: Run all verification commands together**
+- [ ] **Step 1: Run all verification commands**
 
 Run:
 
@@ -357,9 +357,10 @@ printf 'chore: #26 bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-with-issu
 pnpm exec commitlint --edit /tmp/skills-commit-msg-with-issue
 pnpm lint:md
 actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml
+rg -n "Issue IDs are optional|GitHub issue tags are optional|No closing keyword found; linked issues are optional|subjectPattern: '\\^\\.\\+\\$'|isTicketNumberRequired: false" .github AGENTS.md CONTRIBUTING.md docs/release-flow.md commitlint.config.js commitizen.config.js
 ```
 
-Expected: every command exits 0.
+Expected: no-issue commitlint exits non-zero, issue-tagged commitlint exits 0, lint commands exit 0, and the final `rg` exits with no matches.
 
 - [ ] **Step 2: Inspect final diff for scope**
 
@@ -370,21 +371,10 @@ git diff origin/main...HEAD --stat
 git diff origin/main...HEAD -- .github/workflows/plugin-release-bump.yml .github/workflows/lint-pr.yml commitlint.config.js commitizen.config.js .github/pull_request_template.md AGENTS.md CONTRIBUTING.md docs/release-flow.md
 ```
 
-Expected: diff only changes issue-reference policy, release PR generated text, and related docs/templates.
-
-- [ ] **Step 3: Commit any final verification-only fixes**
-
-If Task 4 discovers formatting or wording fixes, commit them:
-
-```bash
-git add .github/workflows/plugin-release-bump.yml .github/workflows/lint-pr.yml commitlint.config.js commitizen.config.js .github/pull_request_template.md AGENTS.md CONTRIBUTING.md docs/release-flow.md
-git commit -m "chore: #26 finalize optional issue reference policy"
-```
-
-Expected: no commit is needed if Tasks 1-3 were clean.
+Expected: release bump output remains no-issue, and all human-facing policy remains issue-required except the documented bot bump exception.
 
 ## Self-Review
 
-- Spec coverage: Tasks 1-3 cover AC-26-1 through AC-26-5. Task 4 repeats the verification evidence for the Executor handoff.
-- Placeholder scan: the plan uses `<plugin>` and `<tag>` only as literal release-flow documentation examples that must appear in the target docs.
+- Spec coverage: Tasks 1-4 cover AC-26-1 through AC-26-5.
+- Placeholder scan: `<plugin>`, `<tag>`, and `#<issue>` are literal documented examples in release-flow and title guidance.
 - Scope check: the plan does not touch marketplace manifests, release dispatch behavior, dependency installation, or label policy.

--- a/docs/superpowers/plans/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-plan.md
+++ b/docs/superpowers/plans/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-plan.md
@@ -314,10 +314,10 @@ then open a PR with `chore: bump <plugin> to <tag>`.
 Run:
 
 ```bash
-rg -n "Closes the marketplace side|#12 bump|PR title subject must start|must contain a GitHub closing|isTicketNumberRequired: true|ticket-required|feat!: #123" .github AGENTS.md CONTRIBUTING.md docs commitlint.config.js commitizen.config.js
+rg -n "Closes the marketplace side|#12 bump|PR title subject must start|must contain a GitHub closing|isTicketNumberRequired: true|ticket-required|feat!: #123" .github AGENTS.md CONTRIBUTING.md docs/release-flow.md commitlint.config.js commitizen.config.js
 ```
 
-Expected: command exits with no matches, except historical design/plan docs may contain intentional examples if they are outside the active policy surface.
+Expected: command exits with no matches in the active policy surface. Historical design and plan docs are intentionally excluded because they may quote old policy text as context.
 
 - [ ] **Step 6: Verify Markdown formatting**
 

--- a/docs/superpowers/plans/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-plan.md
+++ b/docs/superpowers/plans/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-plan.md
@@ -1,0 +1,390 @@
+# Make Issue References Optional for Release Bump PRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make issue references optional for release bump PRs and repo commit/PR policy while preserving conventional commit hygiene.
+
+**Architecture:** Update the release-bump workflow output first, then relax the shared validation paths that currently enforce issue IDs. Finish by aligning contributor-facing docs and templates so humans see the same policy that automation enforces.
+
+**Tech Stack:** GitHub Actions YAML, `peter-evans/create-pull-request`, `amannn/action-semantic-pull-request`, commitlint, Commitizen, Markdown docs, `pnpm`, `actionlint`.
+
+---
+
+## File Structure
+
+- `.github/workflows/plugin-release-bump.yml`: generated release bump PR title, commit message, and body.
+- `.github/workflows/lint-pr.yml`: PR title/body policy enforced in CI.
+- `commitlint.config.js`: local commit-message policy enforced by Husky and `pnpm exec commitlint`.
+- `commitizen.config.js`: guided commit prompt behavior.
+- `.github/pull_request_template.md`: contributor-facing PR title and linked-issue guidance.
+- `AGENTS.md`: canonical agent repository rules.
+- `CONTRIBUTING.md`: contributor-facing commit and PR rules.
+- `docs/release-flow.md`: plugin release flow documentation.
+
+## Task 1: Update Generated Release Bump PR Output
+
+**Files:**
+
+- Modify: `.github/workflows/plugin-release-bump.yml`
+
+- [ ] **Step 1: Inspect the current release PR creation block**
+
+Run:
+
+```bash
+sed -n '108,130p' .github/workflows/plugin-release-bump.yml
+```
+
+Expected: output shows `title`, `commit-message`, and body text containing the hardcoded issue #12 release reference.
+
+- [ ] **Step 2: Remove the generated hardcoded issue references**
+
+In `.github/workflows/plugin-release-bump.yml`, replace the `Create PR` `with:` block values so they match:
+
+```yaml
+          title: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
+          commit-message: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"
+          body: |
+            Automated bump from a new tagged release of `${{ steps.inputs.outputs.plugin }}`.
+
+            - Plugin: `${{ steps.inputs.outputs.plugin }}`
+            - Tag: `${{ steps.inputs.outputs.tag }}`
+            - Source repo: `${{ steps.inputs.outputs.repo }}`
+          delete-branch: true
+```
+
+- [ ] **Step 3: Verify AC-26-1 by searching for removed generated text**
+
+Run:
+
+```bash
+rg -n "Closes the marketplace side|#12 bump|patinaproject/skills#12" .github/workflows/plugin-release-bump.yml
+```
+
+Expected: command exits with no matches.
+
+- [ ] **Step 4: Commit Task 1**
+
+Run:
+
+```bash
+git add .github/workflows/plugin-release-bump.yml
+git commit -m "ci: #26 remove release bump issue reference"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Relax Commit and PR Validation Policy
+
+**Files:**
+
+- Modify: `commitlint.config.js`
+- Modify: `commitizen.config.js`
+- Modify: `.github/workflows/lint-pr.yml`
+
+- [ ] **Step 1: Update commitlint to require only conventional commits with non-empty subjects**
+
+Replace the custom `ticket-required` plugin in `commitlint.config.js` with built-in subject validation:
+
+```js
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "scope-empty": [2, "always"],
+    "subject-case": [0],
+    "subject-empty": [2, "never"],
+    "subject-max-length": [2, "always", 72]
+  }
+};
+```
+
+- [ ] **Step 2: Make Commitizen ticket entry optional**
+
+In `commitizen.config.js`, set the ticket requirement to false and update the prompt:
+
+```js
+  allowTicketNumber: true,
+  isTicketNumberRequired: false,
+  ticketNumberPrefix: "",
+  ticketNumberRegExp: "#\\d+",
+  prependTicketToHead: false,
+  skipQuestions: ["scope", "body", "footer"],
+  messages: {
+    type: "Select the type of change you're committing:",
+    ticketNumber: "Enter the GitHub issue reference, if any (e.g. #1):\n",
+    subject: "Write a short description of the change:\n",
+    confirmCommit: "Are you sure you want to proceed with the commit above?"
+  },
+```
+
+- [ ] **Step 3: Relax PR title linting**
+
+In `.github/workflows/lint-pr.yml`, update the semantic PR title step so the step name and subject pattern no longer require an issue reference:
+
+```yaml
+      - name: Validate conventional commit title
+        # amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+          requireScope: false
+          disallowScopes: |
+            .+
+          subjectPattern: '^.+$'
+          subjectPatternError: |
+            PR title subject cannot be empty.
+            Scopes are not permitted. See AGENTS.md for conventions.
+          ignoreLabels: |
+            dependencies
+```
+
+- [ ] **Step 4: Relax PR body closing-keyword linting**
+
+In `.github/workflows/lint-pr.yml`, rename the closing-keyword job and keep only the non-empty body requirement. The end of the script should say:
+
+```bash
+          if printf '%s' "$sanitized" | grep -qiE \
+            '(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[ \t]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[1-9][0-9]*([^0-9A-Za-z_]|$)'; then
+            echo "Closing keyword found."
+            exit 0
+          fi
+          echo "No closing keyword found; linked issues are optional."
+```
+
+Also change the empty-body error to:
+
+```bash
+            echo "::error::PR body is empty. Fill in the PR template."
+```
+
+- [ ] **Step 5: Update the breaking-change example**
+
+In `.github/workflows/lint-pr.yml`, replace the example `feat!: #123 ...` with:
+
+```bash
+feat!: add new API
+```
+
+- [ ] **Step 6: Verify AC-26-2 with a no-issue commit message**
+
+Run:
+
+```bash
+printf 'chore: bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-no-issue
+pnpm exec commitlint --edit /tmp/skills-commit-msg-no-issue
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 7: Verify issue references still work when meaningful**
+
+Run:
+
+```bash
+printf 'chore: #26 bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-with-issue
+pnpm exec commitlint --edit /tmp/skills-commit-msg-with-issue
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 8: Verify workflow syntax**
+
+Run:
+
+```bash
+actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 9: Commit Task 2**
+
+Run:
+
+```bash
+git add commitlint.config.js commitizen.config.js .github/workflows/lint-pr.yml
+git commit -m "ci: #26 make issue references optional"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Align Contributor Docs and Templates
+
+**Files:**
+
+- Modify: `.github/pull_request_template.md`
+- Modify: `AGENTS.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `docs/release-flow.md`
+
+- [ ] **Step 1: Update the PR template title examples**
+
+In `.github/pull_request_template.md`, make the opening title guidance read:
+
+```markdown
+PR title rule for squash merges: use conventional-commit format for the PR title so the squash commit can be reused unchanged. Issue IDs are optional.
+
+`type: short description`
+
+Examples:
+
+- `docs: add bootstrap skill guide`
+- `chore: bootstrap commit hooks`
+```
+
+Leave the `## Linked issue` section present and optional with its existing `Omit this section when no issue applies` guidance.
+
+- [ ] **Step 2: Update AGENTS.md commit and PR guidance**
+
+In `AGENTS.md`, update the commit command description and commit/PR examples to:
+
+```markdown
+- `pnpm commit`: create a guided conventional commit
+```
+
+```markdown
+Commits must use conventional commit types with no scopes. GitHub issue tags are optional:
+
+`type: short description`
+
+Examples:
+
+- `chore: bootstrap marketplace repo`
+- `feat: add superteam marketplace entry`
+
+For squash-and-merge workflows, PR titles must match the commitlint commit format:
+
+`type: short description`
+```
+
+- [ ] **Step 3: Update CONTRIBUTING.md commit and PR guidance**
+
+In `CONTRIBUTING.md`, update the commit section to:
+
+````markdown
+Commits must follow Conventional Commits with no scope. GitHub issue tags are optional:
+
+```text
+type: short description
+```
+
+Examples:
+
+- `feat: add a feature`
+- `docs: clarify install steps`
+
+The `commit-msg` hook enforces the conventional-commit format. PR titles follow the same format so the squash commit can be reused verbatim.
+````
+
+Also update the PR bullet to:
+
+```markdown
+- Include an `Acceptance Criteria` section when a linked issue defines ACs.
+```
+
+- [ ] **Step 4: Update release-flow examples**
+
+In `docs/release-flow.md`, update the automated and manual bump examples to:
+
+```markdown
+opens a bump PR titled `chore: bump <plugin> to <tag>`
+```
+
+and:
+
+```markdown
+then open a PR with `chore: bump <plugin> to <tag>`.
+```
+
+- [ ] **Step 5: Verify removed-policy text is gone from active docs and workflows**
+
+Run:
+
+```bash
+rg -n "Closes the marketplace side|#12 bump|PR title subject must start|must contain a GitHub closing|isTicketNumberRequired: true|ticket-required|feat!: #123" .github AGENTS.md CONTRIBUTING.md docs commitlint.config.js commitizen.config.js
+```
+
+Expected: command exits with no matches, except historical design/plan docs may contain intentional examples if they are outside the active policy surface.
+
+- [ ] **Step 6: Verify Markdown formatting**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add .github/pull_request_template.md AGENTS.md CONTRIBUTING.md docs/release-flow.md
+git commit -m "docs: #26 document optional issue references"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Final Verification
+
+**Files:**
+
+- Read: all files changed in Tasks 1-3.
+
+- [ ] **Step 1: Run all verification commands together**
+
+Run:
+
+```bash
+printf 'chore: bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-no-issue
+pnpm exec commitlint --edit /tmp/skills-commit-msg-no-issue
+printf 'chore: #26 bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-with-issue
+pnpm exec commitlint --edit /tmp/skills-commit-msg-with-issue
+pnpm lint:md
+actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Inspect final diff for scope**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- .github/workflows/plugin-release-bump.yml .github/workflows/lint-pr.yml commitlint.config.js commitizen.config.js .github/pull_request_template.md AGENTS.md CONTRIBUTING.md docs/release-flow.md
+```
+
+Expected: diff only changes issue-reference policy, release PR generated text, and related docs/templates.
+
+- [ ] **Step 3: Commit any final verification-only fixes**
+
+If Task 4 discovers formatting or wording fixes, commit them:
+
+```bash
+git add .github/workflows/plugin-release-bump.yml .github/workflows/lint-pr.yml commitlint.config.js commitizen.config.js .github/pull_request_template.md AGENTS.md CONTRIBUTING.md docs/release-flow.md
+git commit -m "chore: #26 finalize optional issue reference policy"
+```
+
+Expected: no commit is needed if Tasks 1-3 were clean.
+
+## Self-Review
+
+- Spec coverage: Tasks 1-3 cover AC-26-1 through AC-26-5. Task 4 repeats the verification evidence for the Executor handoff.
+- Placeholder scan: the plan uses `<plugin>` and `<tag>` only as literal release-flow documentation examples that must appear in the target docs.
+- Scope check: the plan does not touch marketplace manifests, release dispatch behavior, dependency installation, or label policy.

--- a/docs/superpowers/specs/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-design.md
+++ b/docs/superpowers/specs/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-design.md
@@ -1,0 +1,99 @@
+# Make Issue References Optional for Release Bump PRs Design
+
+## Intent
+
+Issue #26 updates the marketplace maintenance workflow so routine plugin release
+bump PRs no longer imply that each release closes a standing marketplace issue.
+The repo should still support issue references when they are meaningful, but the
+automation, lint rules, and contributor guidance should not require them.
+
+## Problem
+
+The plugin release bump workflow currently hardcodes issue #12 into generated
+PR titles, commit messages, and PR body text. In particular, each generated PR
+body says it closes the marketplace side of issue #12 for that release. That
+wording makes routine release publication look like partial issue closure and
+keeps old issue context attached to unrelated future releases.
+
+The surrounding repo policy also reinforces the same requirement: commitlint,
+Commitizen prompts, PR title linting, PR body linting, the PR template, and
+contributor docs expect an issue reference or closing keyword. That creates two
+problems for marketplace maintenance:
+
+- Automated release bump PRs need synthetic issue references even when no issue
+  applies.
+- Human-authored maintenance PRs cannot omit issue IDs without fighting local
+  and CI policy.
+
+## Proposal
+
+Adopt a single optional-issue-reference policy:
+
+- Generated plugin release bump PRs use titles and commit messages such as
+  `chore: bump <plugin> to <tag>`.
+- Generated plugin release bump PR bodies list the plugin, tag, and source repo,
+  but omit the release-specific `Closes the marketplace side...` sentence.
+- Commitlint continues to require conventional commits with no scopes and
+  non-empty subjects, but no longer requires subjects to start with `#<issue>`.
+- Commitizen continues to allow issue references, but treats the ticket prompt
+  as optional.
+- PR title linting continues to enforce conventional-commit titles and no
+  scopes, but no longer requires the subject to start with an issue reference.
+- PR body linting still requires a non-empty body, but no longer requires a
+  closing keyword.
+- Contributor docs and the PR template describe issue IDs as optional and show
+  no-issue examples.
+
+The repo can still use `Closes #<issue>` or `Related to #<issue>` when a PR
+genuinely completes or relates to an issue.
+
+## Non-Goals / Implementation Notes
+
+- Do not change marketplace manifest contents.
+- Do not remove support for issue references from commits, PR titles, or PR
+  bodies.
+- Do not introduce a special policy only for release-bump PRs; the simpler repo
+  policy is that issue references are optional everywhere unless a specific
+  issue relationship is meaningful.
+- Preserve existing GitHub Actions pinning comments and full SHA action refs.
+
+## Acceptance Criteria
+
+### AC-26-1
+
+Given the plugin release bump workflow opens a generated PR, when the PR title,
+commit message, and body are rendered, then none of those fields contains the
+hardcoded `#12` release-bump reference or the sentence `Closes the marketplace
+side of patinaproject/skills#12 for this release.`
+
+### AC-26-2
+
+Given a commit message such as `chore: bump bootstrap to v1.2.3`, when
+commitlint runs, then it passes without requiring an issue ID.
+
+### AC-26-3
+
+Given a PR title with a conventional-commit type, no scope, and a non-empty
+subject that does not start with an issue reference, when PR title linting runs,
+then the title is accepted.
+
+### AC-26-4
+
+Given a PR body that follows the repository PR template but does not include a
+closing keyword, when PR body linting runs, then the body is accepted as long as
+it is non-empty.
+
+### AC-26-5
+
+Given contributors read the repo guidance, PR template, release flow docs, or
+Commitizen prompt, when they create a maintenance commit or PR, then the
+documented examples and prompts make clear that issue references are optional.
+
+## Context
+
+Relates to #26.
+
+## Out of Scope
+
+This issue does not change release dispatch behavior, marketplace publication
+rules, dependency installation, or GitHub label policy.

--- a/docs/superpowers/specs/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-design.md
+++ b/docs/superpowers/specs/2026-04-26-26-make-issue-references-optional-for-release-bump-prs-design.md
@@ -2,10 +2,10 @@
 
 ## Intent
 
-Issue #26 updates the marketplace maintenance workflow so routine plugin release
-bump PRs no longer imply that each release closes a standing marketplace issue.
-The repo should still support issue references when they are meaningful, but the
-automation, lint rules, and contributor guidance should not require them.
+Issue #26 updates the marketplace maintenance workflow so bot-generated plugin
+release bump PRs no longer imply that each release closes a standing
+marketplace issue. The issue-ID exception is limited to bot-created version bump
+PRs; human-authored commits and PRs continue to require issue references.
 
 ## Problem
 
@@ -15,46 +15,44 @@ body says it closes the marketplace side of issue #12 for that release. That
 wording makes routine release publication look like partial issue closure and
 keeps old issue context attached to unrelated future releases.
 
-The surrounding repo policy also reinforces the same requirement: commitlint,
-Commitizen prompts, PR title linting, PR body linting, the PR template, and
-contributor docs expect an issue reference or closing keyword. That creates two
-problems for marketplace maintenance:
+The surrounding repo policy correctly expects issue references for human work:
+commitlint, Commitizen prompts, PR title linting, PR body linting, the PR
+template, and contributor docs expect an issue reference or closing keyword.
+That policy should remain in place for humans, but bot-generated release bump
+PRs need a narrow exception because no issue necessarily applies to every
+version bump.
 
-- Automated release bump PRs need synthetic issue references even when no issue
-  applies.
-- Human-authored maintenance PRs cannot omit issue IDs without fighting local
-  and CI policy.
+- Automated release bump PRs should not need synthetic issue references when no
+  issue applies.
+- Human-authored maintenance PRs should still include issue IDs.
 
 ## Proposal
 
-Adopt a single optional-issue-reference policy:
+Adopt a narrow bot-release-bump exception:
 
 - Generated plugin release bump PRs use titles and commit messages such as
   `chore: bump <plugin> to <tag>`.
 - Generated plugin release bump PR bodies list the plugin, tag, and source repo,
   but omit the release-specific `Closes the marketplace side...` sentence.
 - Commitlint continues to require conventional commits with no scopes and
-  non-empty subjects, but no longer requires subjects to start with `#<issue>`.
-- Commitizen continues to allow issue references, but treats the ticket prompt
-  as optional.
-- PR title linting continues to enforce conventional-commit titles and no
-  scopes, but no longer requires the subject to start with an issue reference.
-- PR body linting still requires a non-empty body, but no longer requires a
-  closing keyword.
-- Contributor docs and the PR template describe issue IDs as optional and show
-  no-issue examples.
-
-The repo can still use `Closes #<issue>` or `Related to #<issue>` when a PR
-genuinely completes or relates to an issue.
+  subjects that start with `#<issue>`.
+- Commitizen continues to require issue references for guided human commits.
+- PR title linting continues to require issue references for normal PRs, but
+  allows bot-authored release bump PRs from `bot/bump-*` branches to use
+  no-issue titles.
+- PR body linting continues to require a closing keyword for normal PRs, but
+  allows bot-authored release bump PR bodies to omit one while remaining
+  non-empty.
+- Contributor docs and the PR template continue to show issue references as
+  required for human PRs, while release-flow docs document the bot bump
+  exception.
 
 ## Non-Goals / Implementation Notes
 
 - Do not change marketplace manifest contents.
-- Do not remove support for issue references from commits, PR titles, or PR
-  bodies.
-- Do not introduce a special policy only for release-bump PRs; the simpler repo
-  policy is that issue references are optional everywhere unless a specific
-  issue relationship is meaningful.
+- Do not make issue references optional for human-authored commits or PRs.
+- Do not remove support for meaningful `Closes #<issue>` or
+  `Related to #<issue>` references from PR bodies.
 - Preserve existing GitHub Actions pinning comments and full SHA action refs.
 
 ## Acceptance Criteria
@@ -68,26 +66,27 @@ side of patinaproject/skills#12 for this release.`
 
 ### AC-26-2
 
-Given a commit message such as `chore: bump bootstrap to v1.2.3`, when
-commitlint runs, then it passes without requiring an issue ID.
+Given a human-authored commit message such as
+`chore: bump bootstrap to v1.2.3`, when commitlint runs, then it fails because
+the subject does not start with an issue ID.
 
 ### AC-26-3
 
-Given a PR title with a conventional-commit type, no scope, and a non-empty
-subject that does not start with an issue reference, when PR title linting runs,
-then the title is accepted.
+Given a bot-authored release bump PR from a `bot/bump-*` branch with a title
+such as `chore: bump bootstrap to v1.2.3`, when PR title linting runs, then the
+title is accepted without an issue ID.
 
 ### AC-26-4
 
-Given a PR body that follows the repository PR template but does not include a
-closing keyword, when PR body linting runs, then the body is accepted as long as
-it is non-empty.
+Given a human-authored PR title or body without an issue reference, when PR
+linting runs, then the PR is rejected.
 
 ### AC-26-5
 
 Given contributors read the repo guidance, PR template, release flow docs, or
-Commitizen prompt, when they create a maintenance commit or PR, then the
-documented examples and prompts make clear that issue references are optional.
+Commitizen prompt, when they create a maintenance commit or PR, then the docs
+make clear that issue references are required for humans and optional only for
+bot-generated release bump PRs.
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Removes hardcoded issue #12 references from generated plugin release bump PR titles, commit messages, and bodies.
- Keeps human commits and PRs issue-linked while allowing only `github-actions[bot]` `bot/bump-*` release bump PRs to omit issue IDs / closing keywords.
- Updates contributor guidance, the PR template, release-flow docs, and superteam artifacts for issue #26.

## Linked issue

Closes #26

## Acceptance criteria

### AC-26-1

Generated release bump PR title, commit message, and body no longer include the hardcoded #12 release reference or release-specific closing sentence.

- [x] Local evidence — terminal | macOS worktree | @tlmader | 2026-04-27T00:00:00Z
- [ ] Manual test: 1. Inspect `.github/workflows/plugin-release-bump.yml`; 2. Confirm the generated title and commit message are `chore: bump <plugin> to <tag>`; 3. Confirm the body omits `Closes the marketplace side of patinaproject/skills#12 for this release.`

### AC-26-2

Human/local commitlint still requires an issue ID.

- [x] Local evidence — terminal | macOS worktree | @tlmader | 2026-04-27T00:00:00Z
- [ ] Manual test: 1. Run `printf 'chore: bump bootstrap to v1.2.3\n' >/tmp/skills-commit-msg-no-issue`; 2. Run `pnpm exec commitlint --edit /tmp/skills-commit-msg-no-issue`; 3. Confirm it exits nonzero with `ticket-required`; 4. Run the same check with `chore: #26 bump bootstrap to v1.2.3` and confirm exit 0.

### AC-26-3

PR title linting accepts no-issue titles only for `github-actions[bot]` PRs from `bot/bump-*` branches.

- [x] Local evidence — terminal | macOS worktree | @tlmader | 2026-04-27T00:00:00Z
- [ ] Manual test: 1. Inspect `.github/workflows/lint-pr.yml`; 2. Confirm normal PRs use `subjectPattern: '^#\d+ .+$'`; 3. Confirm the no-issue title path is gated by `github-actions[bot]` and `startsWith(..., 'bot/bump-')`.

### AC-26-4

PR body linting requires closing keywords except for bot-generated `bot/bump-*` release bump PRs.

- [x] Local evidence — terminal | macOS worktree | @tlmader | 2026-04-27T00:00:00Z
- [ ] Manual test: 1. Inspect `.github/workflows/lint-pr.yml`; 2. Confirm empty bodies still fail; 3. Confirm non-closing human and Dependabot bodies fail; 4. Confirm only `github-actions[bot]` on `bot/bump-*` may omit the closing keyword.

### AC-26-5

Contributor-facing guidance and prompts show issue IDs are required for human work and optional only for bot-generated release bump PRs.

- [x] Local evidence — terminal | macOS worktree | @tlmader | 2026-04-27T00:00:00Z
- [ ] Manual test: 1. Inspect `.github/pull_request_template.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/release-flow.md`, and `commitizen.config.js`; 2. Confirm human examples include issue IDs; 3. Confirm the only no-issue exception mentioned is bot-generated `bot/bump-*` release bump PRs.

## Validation

- `pnpm exec commitlint --edit /tmp/skills-commit-msg-no-issue` exits nonzero with `ticket-required`.
- `pnpm exec commitlint --edit /tmp/skills-commit-msg-with-issue` exits 0.
- `pnpm lint:md`
- `actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml`
- `rg -n "Issue IDs are optional|GitHub issue tags are optional|No closing keyword found; linked issues are optional|subjectPattern: '^.+$'|isTicketNumberRequired: false|autorelease: pending|dependabot\[bot\]|ignoreLabels|dependencies" .github AGENTS.md CONTRIBUTING.md docs/release-flow.md commitlint.config.js commitizen.config.js` returns no active-surface matches.
- Local PR-body pressure test: bot bump without closing keyword returns 0; Dependabot without closing keyword returns 1; human without closing keyword returns 1; human with `Closes #26` returns 0.
- Local Reviewer rerun found and the branch fixed prior non-bot bypasses.

## Docs updated

- [x] Updated in this PR
