### PR TITLE
ci: #29 sign release bump commits

### DIFF
--- a/.github/workflows/plugin-release-bump.yml
+++ b/.github/workflows/plugin-release-bump.yml
@@ -107,9 +107,10 @@ jobs:
           echo "Implement once bootstrap defines its invocation entrypoint."
 
       - name: Create PR
-        # peter-evans/create-pull-request@v6.1.0
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
+        # peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
+          sign-commits: true
           branch: bot/bump-${{ steps.inputs.outputs.plugin }}-${{ steps.inputs.outputs.tag }}
           base: main
           title: "chore: bump ${{ steps.inputs.outputs.plugin }} to ${{ steps.inputs.outputs.tag }}"

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -17,6 +17,8 @@ Current member plugins tracked by this flow:
 
 New plugins are added by the same flow: the workflow inserts an entry if the plugin isn't already listed, so the first tagged release of a plugin is also what publishes it.
 
+The release-bump PR workflow enables commit signing in `peter-evans/create-pull-request`, so commits are expected to be signed and verified as `github-actions[bot]` when the workflow uses the repository's default `GITHUB_TOKEN`. Do not switch this workflow to a PAT while expecting bot signature verification; PAT-created PRs are not the supported path for this signing mode.
+
 ## Required setup in each member plugin repo
 
 Each plugin repo needs a workflow on `release: published` that fires the dispatch:

--- a/docs/superpowers/plans/2026-04-27-29-sign-automation-commits-for-release-bump-prs-plan.md
+++ b/docs/superpowers/plans/2026-04-27-29-sign-automation-commits-for-release-bump-prs-plan.md
@@ -1,0 +1,149 @@
+# Sign Automation Commits for Release Bump PRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the plugin release-bump workflow so automated PR commits are signed with supported bot credentials, and document the token expectations.
+
+**Architecture:** Keep the existing release-bump workflow and manifest update logic intact. Upgrade only the `peter-evans/create-pull-request` action reference to a pinned release that supports `sign-commits`, enable that input, and add a short release-flow note explaining the supported signing path.
+
+**Tech Stack:** GitHub Actions YAML, Markdown docs, `pnpm`, `markdownlint-cli2`, `gh`, `git`.
+
+---
+
+## Task 1: Enable Signed Commits in the Release-Bump Workflow
+
+**Files:**
+
+- Modify: `.github/workflows/plugin-release-bump.yml`
+
+- [ ] **Step 1: Confirm the pinned action SHA for the target action release**
+
+Run:
+
+```bash
+git ls-remote --tags --sort='v:refname' https://github.com/peter-evans/create-pull-request.git 'refs/tags/v8.1.1'
+```
+
+Expected: one line whose SHA is exactly:
+
+```text
+5f6978faf089d4d20b00c7766989d076bb2fc7f1 refs/tags/v8.1.1
+```
+
+- [ ] **Step 2: Update the create-pull-request action comment and pinned SHA**
+
+In `.github/workflows/plugin-release-bump.yml`, replace:
+
+```yaml
+        # peter-evans/create-pull-request@v6.1.0
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
+```
+
+with:
+
+```yaml
+        # peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+```
+
+- [ ] **Step 3: Enable bot commit signing**
+
+In the same `with:` block, add `sign-commits: true` before the branch
+configuration:
+
+```yaml
+          sign-commits: true
+          branch: bot/bump-${{ steps.inputs.outputs.plugin }}-${{ steps.inputs.outputs.tag }}
+```
+
+- [ ] **Step 4: Inspect the workflow for conflicting identity inputs**
+
+Run:
+
+```bash
+rg -n "sign-commits|author:|committer:" .github/workflows/plugin-release-bump.yml
+```
+
+Expected: `sign-commits: true` is present, and no `author:` or `committer:`
+inputs are present in the `Create PR` step.
+
+## Task 2: Document Bot Signing Expectations
+
+**Files:**
+
+- Modify: `docs/release-flow.md`
+
+- [ ] **Step 1: Add a release-flow note after the lifecycle list**
+
+After the lifecycle paragraph that explains maintainer review and merge, add:
+
+```markdown
+The release-bump PR workflow enables commit signing in
+`peter-evans/create-pull-request`, so commits are expected to be signed and
+verified as `github-actions[bot]` when the workflow uses the repository's
+default `GITHUB_TOKEN`. Do not switch this workflow to a PAT while expecting
+bot signature verification; PAT-created PRs are not the supported path for this
+signing mode.
+```
+
+- [ ] **Step 2: Keep the manual fallback behavior unchanged**
+
+Inspect the manual fallback section:
+
+```bash
+sed -n '/## Manual fallback/,/## Consuming bootstrap/p' docs/release-flow.md
+```
+
+Expected: manual maintainers are still instructed to open PRs normally, and the
+new bot-signing note does not imply manual commits are signed by automation.
+
+## Task 3: Validate, Commit, and Prepare Handoff
+
+**Files:**
+
+- Modify: `.github/workflows/plugin-release-bump.yml`
+- Modify: `docs/release-flow.md`
+
+- [ ] **Step 1: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 2: Verify the workflow action pin is a full SHA**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+text = Path(".github/workflows/plugin-release-bump.yml").read_text()
+match = re.search(r"peter-evans/create-pull-request@([0-9a-f]{40})", text)
+assert match, "create-pull-request action is not pinned to a full 40-character SHA"
+assert "sign-commits: true" in text, "sign-commits input is missing"
+assert "author:" not in text and "committer:" not in text, "custom author/committer inputs conflict with bot signing"
+print(match.group(1))
+PY
+```
+
+Expected:
+
+```text
+5f6978faf089d4d20b00c7766989d076bb2fc7f1
+```
+
+- [ ] **Step 3: Commit the implementation**
+
+Run:
+
+```bash
+git add .github/workflows/plugin-release-bump.yml docs/release-flow.md
+git commit -m "ci: #29 sign release bump commits"
+```
+
+Expected: commit succeeds and Husky hooks pass.

--- a/docs/superpowers/specs/2026-04-27-29-sign-automation-commits-for-release-bump-prs-design.md
+++ b/docs/superpowers/specs/2026-04-27-29-sign-automation-commits-for-release-bump-prs-design.md
@@ -1,0 +1,93 @@
+# Sign Automation Commits for Release Bump PRs
+
+## Problem
+
+The plugin release-bump workflow opens automated marketplace PRs by committing
+manifest updates through `peter-evans/create-pull-request`. The action is pinned
+to `v6.1.0`, and the workflow does not request signed commits. If Patina Project
+enables or inherits a branch protection rule that requires signed commits, these
+automation-created PR branches may fail mergeability checks or require manual
+repair.
+
+## Goals
+
+- Make release-bump workflow commits signed and verified when created with
+  supported bot-generated credentials.
+- Preserve the repository rule that every GitHub Action is pinned to a full
+  40-character commit SHA with a nearby version comment.
+- Document the token behavior clearly enough that maintainers do not
+  accidentally switch the workflow to an unsigned PAT path while expecting
+  verified bot commits.
+
+## Non-Goals
+
+- Introduce a new release-bump workflow or change the marketplace manifest update
+  logic.
+- Configure repository or organization branch protection settings.
+- Add custom GPG signing keys or repository secrets.
+
+## Acceptance Criteria
+
+### AC-29-1
+
+`.github/workflows/plugin-release-bump.yml` uses a version of
+`peter-evans/create-pull-request` that supports `sign-commits`, pins the action
+to a full 40-character SHA, and keeps the version comment aligned with that SHA.
+
+### AC-29-2
+
+The release-bump PR creation step sets `sign-commits: true` without adding custom
+`author` or `committer` inputs that would conflict with bot signature behavior.
+
+### AC-29-3
+
+`docs/release-flow.md` documents that release-bump commits are expected to be
+signed by `github-actions[bot]` when the workflow uses the default
+`GITHUB_TOKEN`, and notes that PAT-created PRs are not the expected path for bot
+commit signature verification.
+
+### AC-29-4
+
+Validation covers the workflow and documentation changes with repository-local
+checks, including Markdown linting and inspection of the pinned action reference.
+
+## Design
+
+Use the action's built-in bot commit signing rather than introducing custom GPG
+key management. The current workflow already uses the default token implicitly,
+which is the simplest supported credential path for signing as
+`github-actions[bot]`. The implementation should update only the
+`peter-evans/create-pull-request` action reference and its inputs:
+
+- bump from the current pinned `v6.1.0` SHA to a current pinned release that
+  includes `sign-commits`;
+- add `sign-commits: true` under the existing `with:` block;
+- avoid setting `author` or `committer`, because the action ignores those inputs
+  when bot signing is enabled and custom identity settings would make the
+  intended signing behavior less obvious.
+
+The release-flow documentation should gain a short note in the automation
+lifecycle or setup area. The note should explain what is guaranteed by the
+workflow configuration, and what is not: supported bot-generated tokens can
+produce verified bot signatures, while PATs are not the intended token type for
+this feature.
+
+## Alternatives Considered
+
+1. **Built-in bot signing on `create-pull-request`**: recommended. It keeps the
+   workflow small, avoids secret management, and matches the existing default
+   token flow.
+2. **Custom GPG signing with a PAT-backed bot account**: rejected for this issue.
+   It requires private key storage and additional secret rotation policy for a
+   workflow that can use platform-managed bot signing.
+3. **Leave automation unsigned**: rejected. It keeps today's behavior but does
+   not satisfy the issue goal or prepare the repo for signed-commit branch
+   protection.
+
+## Verification
+
+- Run `pnpm lint:md`.
+- Inspect `.github/workflows/plugin-release-bump.yml` to confirm the action
+  reference is a full 40-character SHA with the correct version comment.
+- Inspect the PR creation step to confirm `sign-commits: true` is present and no
+  custom `author` or `committer` inputs were added.


### PR DESCRIPTION
## Summary

- Upgrade `peter-evans/create-pull-request` in the plugin release-bump workflow to pinned `v8.1.1`.
- Enable `sign-commits: true` for release-bump PR commits.
- Document the expected `GITHUB_TOKEN` / `github-actions[bot]` signing path and PAT caveat.

## Linked issue

- Closes #29

## Acceptance criteria

### AC-29-1

The release-bump workflow now uses a `create-pull-request` release that supports commit signing, pinned to the full `v8.1.1` SHA with an aligned version comment.

- [x] CLI evidence — Codex local | zsh on macOS | @tlmader | 2026-04-27T05:45:14Z
- [ ] Manual test: 1. Review `.github/workflows/plugin-release-bump.yml`. 2. Confirm the `peter-evans/create-pull-request@v8.1.1` comment sits above the full SHA `5f6978faf089d4d20b00c7766989d076bb2fc7f1`. 3. Confirm the SHA matches the upstream `v8.1.1` tag.

### AC-29-2

The PR creation step sets `sign-commits: true` and does not set custom `author` or `committer` inputs.

- [x] CLI evidence — Codex local | zsh on macOS | @tlmader | 2026-04-27T05:45:14Z
- [ ] Manual test: 1. Review the `Create PR` step. 2. Confirm `sign-commits: true` appears in `with:`. 3. Confirm no `author:` or `committer:` inputs are present.

### AC-29-3

`docs/release-flow.md` now documents expected `github-actions[bot]` signing with the default `GITHUB_TOKEN` and warns that PAT-created PRs are not the supported path for bot signature verification.

- [x] CLI evidence — Codex local | zsh on macOS | @tlmader | 2026-04-27T05:45:14Z
- [ ] Manual test: 1. Review `docs/release-flow.md`. 2. Confirm the release-bump signing note appears after the lifecycle description. 3. Confirm the manual fallback section remains about maintainer-created PRs.

### AC-29-4

Validation covered Markdown linting, GitHub Actions linting, whitespace checks, commit message linting, and a pinned-action/signing inspection.

- [x] CLI evidence — Codex local | zsh on macOS | @tlmader | 2026-04-27T05:45:14Z
- [ ] Manual test: 1. Review this PR's validation section. 2. Confirm all listed local commands have passing outcomes.

## Validation

- `pnpm lint:md`
- `actionlint .github/workflows/plugin-release-bump.yml`
- `git diff --check origin/main...HEAD`
- `pnpm exec commitlint --from origin/main --to HEAD`
- `python3` inspection for full pinned SHA, aligned version comment, `sign-commits: true`, and absence of custom `author` / `committer` inputs
- `git ls-remote --tags --sort='v:refname' https://github.com/peter-evans/create-pull-request.git 'refs/tags/v8.1.1'`

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
