### PR TITLE
docs: #33 use complete company name

### DIFF
--- a/docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
+++ b/docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
@@ -102,18 +102,19 @@ Expected: one match for `other Patina Project plugins` and no match for
 Run:
 
 ```bash
-rg -n '\bPatina\b(?! Project)' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json
+rg -n 'other Patina plugins' docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
 ```
 
-Expected: no output. If the local `rg` build does not support look-around, use
-this fallback:
+Expected: no output. Then run this broader audit:
 
 ```bash
 rg -n '\bPatina\b' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json
 ```
 
-Expected fallback interpretation: every capitalized prose match is either
-`Patina Project` or the phrase in the changed line now reads `Patina Project`.
+Expected broader audit interpretation: capitalized prose matches are either
+complete `Patina Project` wording, issue #33 meta-documentation describing the
+old wording under correction, or already-approved historical design discussion
+whose active target line has been corrected.
 
 - [ ] **Step 3: Confirm identifier uses remain intentionally unchanged**
 

--- a/docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
+++ b/docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
@@ -1,0 +1,176 @@
+# Use Patina Project As The Complete Company Name Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update incomplete public-facing company-name prose from `Patina` to `Patina Project` while preserving all `patina` and `patinaproject` identifiers.
+
+**Architecture:** Keep the change scoped to documentation prose. Use repository-wide text searches as the verification boundary so implementation can prove the known wording is fixed and identifier strings remain intentional.
+
+**Tech Stack:** Markdown documentation, ripgrep, markdownlint-cli2 via `pnpm`.
+
+---
+
+Issue: [patinaproject/skills#33](https://github.com/patinaproject/skills/issues/33)
+Design: [2026-04-27-33-use-patina-project-as-the-complete-company-name-design.md](../specs/2026-04-27-33-use-patina-project-as-the-complete-company-name-design.md)
+
+## File Structure
+
+- Modify: `docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
+  - Responsibility: historical planning artifact containing the known incomplete public-facing phrase.
+- Preserve: `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `package.json`, `README.md`, `AGENTS.md`, and other docs containing intentional identifiers.
+  - Responsibility: provide audit evidence that identifiers and already-complete `Patina Project` prose remain unchanged.
+
+## Workstreams
+
+Single linear workstream: audit, update one prose phrase, verify.
+
+## Tasks
+
+### Task 1: Audit Existing Company-Name And Identifier Matches
+
+**Files:**
+
+- Inspect: `docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
+- Inspect: `docs/`
+- Inspect: `.agents/plugins/marketplace.json`
+- Inspect: `.claude-plugin/marketplace.json`
+- Inspect: `README.md`
+- Inspect: `AGENTS.md`
+- Inspect: `CLAUDE.md`
+- Inspect: `package.json`
+
+- [ ] **Step 1: Search for complete and incomplete company-name wording**
+
+Run:
+
+```bash
+rg -n '\bPatina\b|patina' docs .agents .claude-plugin README.md AGENTS.md CLAUDE.md package.json
+```
+
+Expected: output includes the known incomplete phrase `other Patina plugins` in
+`docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`.
+Other `patina` matches are identifiers such as `patinaproject/skills`,
+`patinaproject-skills`, GitHub URLs, package metadata, domains, or already
+complete `Patina Project` wording.
+
+### Task 2: Update Incomplete Public-Facing Prose
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
+
+- [ ] **Step 1: Replace the known incomplete company-name phrase**
+
+Change this acceptance criteria line:
+
+```markdown
+- **AC-22-1** (manifest lists `github-flows` alongside other Patina plugins with the same shape): satisfied by the automated bump PR opened when `v0.1.0` is published, **not by this PR**. This PR documents the contract that the bump PR must fulfill.
+```
+
+To:
+
+```markdown
+- **AC-22-1** (manifest lists `github-flows` alongside other Patina Project plugins with the same shape): satisfied by the automated bump PR opened when `v0.1.0` is published, **not by this PR**. This PR documents the contract that the bump PR must fulfill.
+```
+
+### Task 3: Verify Acceptance Criteria
+
+**Files:**
+
+- Verify: `docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
+- Verify: `docs/`
+- Verify: `.agents/plugins/marketplace.json`
+- Verify: `.claude-plugin/marketplace.json`
+- Verify: `README.md`
+- Verify: `AGENTS.md`
+- Verify: `CLAUDE.md`
+- Verify: `package.json`
+
+- [ ] **Step 1: Confirm the changed sentence uses the complete company name**
+
+Run:
+
+```bash
+rg -n 'other Patina Project plugins|other Patina plugins' docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
+```
+
+Expected: one match for `other Patina Project plugins` and no match for
+`other Patina plugins`.
+
+- [ ] **Step 2: Confirm remaining `Patina` prose is complete company-name wording**
+
+Run:
+
+```bash
+rg -n '\bPatina\b(?! Project)' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json
+```
+
+Expected: no output. If the local `rg` build does not support look-around, use
+this fallback:
+
+```bash
+rg -n '\bPatina\b' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json
+```
+
+Expected fallback interpretation: every capitalized prose match is either
+`Patina Project` or the phrase in the changed line now reads `Patina Project`.
+
+- [ ] **Step 3: Confirm identifier uses remain intentionally unchanged**
+
+Run:
+
+```bash
+rg -n 'patinaproject|patinaproject-skills|patinaproject\.com' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json
+```
+
+Expected: matches remain as slugs, URLs, package/catalog identifiers, or email
+and domain values. Do not modify them for this issue.
+
+- [ ] **Step 4: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md docs/superpowers/specs/2026-04-27-33-use-patina-project-as-the-complete-company-name-design.md docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+### Task 4: Commit Implementation
+
+**Files:**
+
+- Commit: `docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
+- Commit: `docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md`
+
+- [ ] **Step 1: Review the diff**
+
+Run:
+
+```bash
+git diff -- docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
+```
+
+Expected: diff shows the one wording change plus this implementation plan.
+
+- [ ] **Step 2: Commit the plan and implementation**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md
+git commit -m "docs: #33 use complete company name"
+```
+
+Expected: commit succeeds after lint-staged Markdown checks.
+
+## Blockers
+
+None.
+
+## Out Of Scope
+
+- Renaming GitHub organization or repository slugs.
+- Renaming marketplace identifiers such as `patinaproject-skills`.
+- Renaming package names, URLs, domains, or email addresses.
+- General copyediting of unrelated historical planning artifacts.

--- a/docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md
@@ -36,7 +36,7 @@ When the upstream `release.yml` in `patinaproject/github-flows` fires `plugin-re
 
 ## Acceptance criteria mapping
 
-- **AC-22-1** (manifest lists `github-flows` alongside other Patina plugins with the same shape): satisfied by the automated bump PR opened when `v0.1.0` is published, **not by this PR**. This PR documents the contract that the bump PR must fulfill.
+- **AC-22-1** (manifest lists `github-flows` alongside other Patina Project plugins with the same shape): satisfied by the automated bump PR opened when `v0.1.0` is published, **not by this PR**. This PR documents the contract that the bump PR must fulfill.
 - **AC-22-2** (release dispatch updates the manifest entry to `v0.1.0`): satisfied by existing `plugin-release-bump.yml` — verified, no change required.
 - **AC-22-3** (`/plugin install github-flows@patinaproject-skills` works after install): satisfied transitively once AC-22-1 is satisfied via the bump PR.
 

--- a/docs/superpowers/specs/2026-04-27-33-use-patina-project-as-the-complete-company-name-design.md
+++ b/docs/superpowers/specs/2026-04-27-33-use-patina-project-as-the-complete-company-name-design.md
@@ -1,0 +1,90 @@
+# Design: Use Patina Project as the complete company name
+
+Issue: [patinaproject/skills#33](https://github.com/patinaproject/skills/issues/33)
+
+## Intent
+
+Update public-facing documentation that refers to the company as `Patina` so it
+uses the complete company name, `Patina Project`, while preserving repository
+slugs, URLs, package names, domains, and machine-readable identifiers that
+contain `patina` or `patinaproject`.
+
+## Context
+
+- The repository guidance already describes this repo as the marketplace surface
+  for `Patina Project` plugins and related install documentation.
+- The issue identifies one known affected sentence in
+  [2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md](./2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md).
+- The repo also contains many intentional identifier uses such as
+  `patinaproject/skills`, `patinaproject-skills`, GitHub URLs, package metadata,
+  and email/domain strings. Those are out of scope for renaming.
+
+## Requirements
+
+1. Public-facing prose that names the company as `Patina` must use
+   `Patina Project` instead.
+2. Repository slugs, URLs, package names, marketplace identifiers, email
+   addresses, domains, and other machine-readable identifiers must be preserved.
+3. The change must be limited to documentation wording unless the audit finds a
+   public-facing metadata field with the same incomplete company-name wording.
+4. Verification must include a search that distinguishes prose references from
+   identifier uses.
+
+## Acceptance Criteria
+
+### AC-33-1
+
+Given a public-facing docs sentence refers to the company as `Patina`, when the
+wording is updated, then it uses `Patina Project` instead.
+
+### AC-33-2
+
+Given a repository slug, URL, package name, or identifier contains `patina`, when
+the audit is performed, then that identifier is preserved.
+
+## Approaches Considered
+
+### Recommended: Targeted prose correction plus audit
+
+Update only the incomplete company-name prose discovered by the audit, then
+verify remaining `Patina` and `patina` matches are either already complete
+`Patina Project` wording or intentional identifiers. This best matches the issue
+scope and avoids rewriting historical artifacts unnecessarily.
+
+### Broader historical documentation rewrite
+
+Review and rewrite every historical Superpowers artifact to normalize broader
+branding language. This would increase churn in old planning artifacts without
+improving the specific public-facing sentence identified by the issue.
+
+### Metadata and identifier rename
+
+Rename slugs or identifiers to include the complete company name. This directly
+conflicts with the issue's non-goals and would risk breaking install flows.
+
+## Decision
+
+Use the targeted prose correction plus audit. The implementation should update
+the known `other Patina plugins` phrase to `other Patina Project plugins`, then
+run searches over docs and marketplace surfaces to confirm no incomplete
+company-name prose remains and identifier strings are unchanged.
+
+## Verification
+
+- Search public docs and marketplace surfaces for `Patina` and `patina`.
+- Confirm the changed sentence uses `Patina Project`.
+- Confirm intentional identifiers such as `patinaproject/skills`,
+  `patinaproject-skills`, GitHub URLs, package metadata, and domain/email values
+  remain unchanged.
+- Run Markdown lint for the edited Markdown files.
+
+## Out of Scope
+
+- Renaming GitHub organization or repository slugs.
+- Renaming marketplace identifiers such as `patinaproject-skills`.
+- Renaming package names, URLs, domains, or email addresses.
+- General copyediting of unrelated historical planning artifacts.
+
+## Concerns
+
+No approval-relevant concerns remain.


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add bootstrap skill guide`
- `chore: #34 bootstrap commit hooks`

Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Added issue #33 design and implementation plan artifacts.
- Updated the known historical docs sentence from `other Patina plugins` to `other Patina Project plugins`.
- Verified identifier uses such as `patinaproject/skills`, `patinaproject-skills`, URLs, and domains remain unchanged.

## Linked issue

Closes #33

## Acceptance criteria

### AC-33-1

The affected public-facing docs sentence now uses `Patina Project`.

- [ ] Docs evidence — Codex CLI | local worktree | @tlmader | 2026-04-27T08:26:10Z
- [ ] Manual test: 1. Open `docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`. 2. Confirm the AC-22-1 sentence says `other Patina Project plugins`. 3. Confirm no `other Patina plugins` wording remains in that file.

### AC-33-2

Identifier-bearing `patina` and `patinaproject` strings were audited and preserved.

- [ ] Docs evidence — Codex CLI | local worktree | @tlmader | 2026-04-27T08:26:10Z
- [ ] Manual test: 1. Review the PR diff. 2. Confirm only documentation prose and Superpowers planning artifacts changed. 3. Confirm slugs, URLs, package names, domains, and marketplace identifiers were not renamed.

## Validation

- `rg -n 'other Patina Project plugins|other Patina plugins' docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
- `rg -n 'other Patina plugins' docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md`
- `rg -n '\bPatina\b' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json`
- `rg -n 'patinaproject|patinaproject-skills|patinaproject\.com' docs README.md AGENTS.md CLAUDE.md .agents .claude-plugin package.json`
- `pnpm exec markdownlint-cli2 docs/superpowers/specs/2026-04-26-22-add-patinaprojectgithub-flows-plugin-to-the-marketplace-design.md docs/superpowers/specs/2026-04-27-33-use-patina-project-as-the-complete-company-name-design.md docs/superpowers/plans/2026-04-27-33-use-patina-project-as-the-complete-company-name-plan.md`
- `pnpm lint:md`
- `pnpm exec commitlint --edit /tmp/commit-msg-33`

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
