### PR TITLE
fix: #35 rename github flows marketplace entry

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -31,10 +31,10 @@
       "category": "Productivity"
     },
     {
-      "name": "github-flows",
+      "name": "using-github",
       "source": {
         "source": "url",
-        "url": "https://github.com/patinaproject/github-flows.git",
+        "url": "https://github.com/patinaproject/using-github.git",
         "ref": "v1.1.0"
       },
       "policy": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,12 +29,12 @@
       }
     },
     {
-      "name": "github-flows",
-      "description": "Patina Project plugin: github-flows",
+      "name": "using-github",
+      "description": "Patina Project plugin: using-github",
       "category": "productivity",
       "source": {
         "source": "github",
-        "repo": "patinaproject/github-flows",
+        "repo": "patinaproject/using-github",
         "ref": "v1.1.0"
       }
     }

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -6,7 +6,7 @@ Current member plugins tracked by this flow:
 
 - `patinaproject/bootstrap` — repo scaffolding skill. Also **consumed by this repo** (see [Consuming bootstrap](#consuming-bootstrap) below), so a bootstrap release both updates the marketplace entry and refreshes this repo's own scaffolding.
 - `patinaproject/superteam` — issue-driven orchestration skill.
-- `patinaproject/github-flows` — agent ergonomics for GitHub workflows (`/edit-issue`, `/new-issue`, `/new-branch`).
+- `patinaproject/using-github` — agent ergonomics for GitHub workflows (`/edit-issue`, `/new-issue`, `/new-branch`).
 
 ## Lifecycle
 

--- a/docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
+++ b/docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
@@ -1,0 +1,248 @@
+# Accommodate using-github Repository Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace current `github-flows` marketplace and release-flow source-of-truth references with `using-github`.
+
+**Architecture:** This is a targeted catalog/documentation update across the two marketplace manifests and the release-flow documentation. Verification is inspection-driven: parse edited JSON, inspect edited Markdown, and audit remaining old-slug references to confirm they are historical rather than current install or release configuration.
+
+**Tech Stack:** JSON marketplace manifests, Markdown documentation, `node`, `rg`, `pnpm` repository tooling.
+
+---
+
+## File Structure
+
+- Modify: `.agents/plugins/marketplace.json`
+  - Rename the Codex marketplace plugin entry from `github-flows` to `using-github`.
+  - Change its source URL from `https://github.com/patinaproject/github-flows.git` to `https://github.com/patinaproject/using-github.git`.
+  - Preserve the explicit tagged `ref`.
+- Modify: `.claude-plugin/marketplace.json`
+  - Rename the Claude marketplace plugin entry from `github-flows` to `using-github`.
+  - Change its source repo from `patinaproject/github-flows` to `patinaproject/using-github`.
+  - Update the description to name `using-github`.
+  - Preserve the explicit tagged `ref`.
+- Modify: `docs/release-flow.md`
+  - Replace the current member plugin bullet for `patinaproject/github-flows` with `patinaproject/using-github`.
+  - Keep the human-readable purpose text aligned with GitHub workflow ergonomics.
+
+## Task 1: Add Failing Manifest Verification
+
+**Files:**
+- Inspect: `.agents/plugins/marketplace.json`
+- Inspect: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Run the expected-post-change Codex manifest assertion**
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+const catalog = JSON.parse(fs.readFileSync('.agents/plugins/marketplace.json', 'utf8'));
+const oldEntry = catalog.plugins.find((plugin) => plugin.name === 'github-flows');
+const entry = catalog.plugins.find((plugin) => plugin.name === 'using-github');
+
+if (oldEntry) {
+  throw new Error('Codex marketplace still lists github-flows');
+}
+if (!entry) {
+  throw new Error('Codex marketplace is missing using-github');
+}
+if (entry.source.url !== 'https://github.com/patinaproject/using-github.git') {
+  throw new Error(`Unexpected Codex repository URL: ${entry.source.url}`);
+}
+if (!/^v\d+\.\d+\.\d+$/.test(entry.source.ref)) {
+  throw new Error(`Codex ref is not an explicit semver tag: ${entry.source.ref}`);
+}
+NODE
+```
+
+Expected: FAIL with `Codex marketplace still lists github-flows` or `Codex marketplace is missing using-github`.
+
+- [ ] **Step 2: Run the expected-post-change Claude manifest assertion**
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+const catalog = JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json', 'utf8'));
+const oldEntry = catalog.plugins.find((plugin) => plugin.name === 'github-flows');
+const entry = catalog.plugins.find((plugin) => plugin.name === 'using-github');
+
+if (oldEntry) {
+  throw new Error('Claude marketplace still lists github-flows');
+}
+if (!entry) {
+  throw new Error('Claude marketplace is missing using-github');
+}
+if (entry.description !== 'Patina Project plugin: using-github') {
+  throw new Error(`Unexpected Claude description: ${entry.description}`);
+}
+if (entry.source.repo !== 'patinaproject/using-github') {
+  throw new Error(`Unexpected Claude repository: ${entry.source.repo}`);
+}
+if (!/^v\d+\.\d+\.\d+$/.test(entry.source.ref)) {
+  throw new Error(`Claude ref is not an explicit semver tag: ${entry.source.ref}`);
+}
+NODE
+```
+
+Expected: FAIL with `Claude marketplace still lists github-flows` or `Claude marketplace is missing using-github`.
+
+## Task 2: Update Marketplace Manifests
+
+**Files:**
+- Modify: `.agents/plugins/marketplace.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Update the Codex marketplace entry**
+
+In `.agents/plugins/marketplace.json`, change only the old plugin entry:
+
+```json
+{
+  "name": "using-github",
+  "source": {
+    "source": "url",
+    "url": "https://github.com/patinaproject/using-github.git",
+    "ref": "v1.1.0"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Productivity"
+}
+```
+
+Expected: The `ref` remains the same explicit tag as before the edit.
+
+- [ ] **Step 2: Update the Claude marketplace entry**
+
+In `.claude-plugin/marketplace.json`, change only the old plugin entry:
+
+```json
+{
+  "name": "using-github",
+  "description": "Patina Project plugin: using-github",
+  "category": "productivity",
+  "source": {
+    "source": "github",
+    "repo": "patinaproject/using-github",
+    "ref": "v1.1.0"
+  }
+}
+```
+
+Expected: The `ref` remains the same explicit tag as before the edit.
+
+- [ ] **Step 3: Re-run the Codex manifest assertion**
+
+Run the command from Task 1 Step 1.
+
+Expected: PASS with no output.
+
+- [ ] **Step 4: Re-run the Claude manifest assertion**
+
+Run the command from Task 1 Step 2.
+
+Expected: PASS with no output.
+
+## Task 3: Update Release-Flow Documentation
+
+**Files:**
+- Modify: `docs/release-flow.md`
+
+- [ ] **Step 1: Run the expected-post-change release-flow assertion**
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+const text = fs.readFileSync('docs/release-flow.md', 'utf8');
+
+if (!text.includes('`patinaproject/using-github`')) {
+  throw new Error('release-flow docs do not list patinaproject/using-github');
+}
+const memberList = text.slice(
+  text.indexOf('Current member plugins tracked by this flow:'),
+  text.indexOf('## Lifecycle')
+);
+if (memberList.includes('patinaproject/github-flows')) {
+  throw new Error('release-flow member list still references patinaproject/github-flows');
+}
+NODE
+```
+
+Expected: FAIL with `release-flow docs do not list patinaproject/using-github`.
+
+- [ ] **Step 2: Update the current member plugin bullet**
+
+In `docs/release-flow.md`, replace:
+
+```markdown
+- `patinaproject/github-flows` — agent ergonomics for GitHub workflows (`/edit-issue`, `/new-issue`, `/new-branch`).
+```
+
+with:
+
+```markdown
+- `patinaproject/using-github` — agent ergonomics for GitHub workflows (`/edit-issue`, `/new-issue`, `/new-branch`).
+```
+
+- [ ] **Step 3: Re-run the release-flow assertion**
+
+Run the command from Task 3 Step 1.
+
+Expected: PASS with no output.
+
+## Task 4: Audit Remaining References and Run Repository Checks
+
+**Files:**
+- Inspect: all repository files
+- Modify if needed: only current install, release, cache, or automation source-of-truth files discovered by the audit
+
+- [ ] **Step 1: Parse edited JSON manifests**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('.agents/plugins/marketplace.json', 'utf8')); JSON.parse(require('fs').readFileSync('.claude-plugin/marketplace.json', 'utf8'));"
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 2: Confirm current source-of-truth surfaces no longer contain `github-flows`**
+
+```bash
+rg -n 'github-flows' .agents/plugins/marketplace.json .claude-plugin/marketplace.json docs/release-flow.md
+```
+
+Expected: FAIL/no matches, because `rg` exits 1 when no matches are found.
+
+- [ ] **Step 3: Audit remaining old repository slug references**
+
+```bash
+rg -n 'patinaproject/github-flows' .
+```
+
+Expected: Any remaining matches are confined to historical Superpowers issue artifacts, especially issue #22 design/plan records or the issue #35 design and plan documents that explain the migration.
+
+- [ ] **Step 4: Run Markdown lint if dependencies are installed**
+
+```bash
+pnpm exec markdownlint-cli2 docs/release-flow.md docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
+```
+
+Expected: PASS. If `markdownlint-cli2` is unavailable because dependencies are not installed, run `pnpm install` and retry.
+
+- [ ] **Step 5: Review the final diff**
+
+```bash
+git diff -- .agents/plugins/marketplace.json .claude-plugin/marketplace.json docs/release-flow.md docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
+```
+
+Expected: Diff only contains the approved design/plan artifacts and the targeted manifest/docs rename.
+
+- [ ] **Step 6: Commit the implementation batch**
+
+```bash
+git add .agents/plugins/marketplace.json .claude-plugin/marketplace.json docs/release-flow.md docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
+git commit -m "fix: #35 rename github flows marketplace entry"
+```
+
+Expected: Commit succeeds with a conventional commit message containing the issue tag.

--- a/docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
+++ b/docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md
@@ -28,6 +28,7 @@
 ## Task 1: Add Failing Manifest Verification
 
 **Files:**
+
 - Inspect: `.agents/plugins/marketplace.json`
 - Inspect: `.claude-plugin/marketplace.json`
 
@@ -89,6 +90,7 @@ Expected: FAIL with `Claude marketplace still lists github-flows` or `Claude mar
 ## Task 2: Update Marketplace Manifests
 
 **Files:**
+
 - Modify: `.agents/plugins/marketplace.json`
 - Modify: `.claude-plugin/marketplace.json`
 
@@ -148,6 +150,7 @@ Expected: PASS with no output.
 ## Task 3: Update Release-Flow Documentation
 
 **Files:**
+
 - Modify: `docs/release-flow.md`
 
 - [ ] **Step 1: Run the expected-post-change release-flow assertion**
@@ -195,6 +198,7 @@ Expected: PASS with no output.
 ## Task 4: Audit Remaining References and Run Repository Checks
 
 **Files:**
+
 - Inspect: all repository files
 - Modify if needed: only current install, release, cache, or automation source-of-truth files discovered by the audit
 

--- a/docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md
+++ b/docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md
@@ -4,20 +4,22 @@ Issue: [patinaproject/skills#35](https://github.com/patinaproject/skills/issues/
 
 ## Intent
 
-Update current marketplace and release-flow surfaces so the `github-flows`
-plugin resolves through the renamed canonical repository,
-`patinaproject/using-github`, while preserving the plugin's marketplace name and
-existing tagged release pin.
+Update current marketplace and release-flow surfaces so the renamed plugin is
+published and resolved as `using-github` from the canonical repository
+`patinaproject/using-github`, removing current install-surface references to
+`github-flows`.
 
 ## Context
 
 - The issue says `patinaproject/github-flows` is being renamed to
   `patinaproject/using-github`.
-- Current marketplace manifests still point the `github-flows` plugin at the old
-  repository slug:
+- Current marketplace manifests still list the old `github-flows` plugin name
+  and repository slug:
   - `.agents/plugins/marketplace.json` uses
+    `name: "github-flows"` and
     `https://github.com/patinaproject/github-flows.git`.
-  - `.claude-plugin/marketplace.json` uses `patinaproject/github-flows`.
+  - `.claude-plugin/marketplace.json` uses `name: "github-flows"` and
+    `patinaproject/github-flows`.
 - `docs/release-flow.md` lists `patinaproject/github-flows` as the member plugin
   repository that dispatches release bumps.
 - Historical Superpowers artifacts for issue #22 describe the original
@@ -26,12 +28,12 @@ existing tagged release pin.
 
 ## Requirements
 
-1. Current marketplace install surfaces must use `patinaproject/using-github` as
-   the canonical repository location for the `github-flows` plugin.
+1. Current marketplace install surfaces must use `using-github` as the plugin
+   name and `patinaproject/using-github` as the canonical repository location.
 2. Current release-flow documentation must identify `patinaproject/using-github`
-   as the member plugin repository that publishes `github-flows` releases.
-3. The marketplace plugin name must remain `github-flows` unless a separate
-   issue explicitly changes the install name.
+   as the member plugin repository that publishes `using-github` releases.
+3. The current marketplace and release-flow surfaces must not retain
+   `github-flows` as the plugin name, repository slug, or member-plugin label.
 4. Existing release pins must remain explicit tagged refs and must not be changed
    unless verification shows the rename requires a different tag.
 5. Historical issue artifacts may keep references to
@@ -42,9 +44,9 @@ existing tagged release pin.
 
 ### AC-35-1
 
-Given a marketplace install surface points at the old GitHub repository slug,
-when the catalog is inspected, then the `github-flows` plugin source resolves to
-`patinaproject/using-github`.
+Given a marketplace install surface currently lists the old plugin identity,
+when the catalog is inspected, then the plugin entry is named `using-github` and
+its source resolves to `patinaproject/using-github`.
 
 ### AC-35-2
 
@@ -55,8 +57,9 @@ Given release-flow documentation names the member plugin repository for
 ### AC-35-3
 
 Given marketplace entries for `github-flows` are updated for the repository
-rename, when the manifests are inspected, then the plugin name remains
-`github-flows` and its source `ref` remains an explicit `vX.Y.Z` tag.
+rename, when the manifests are inspected, then no current marketplace entry is
+named `github-flows` and the replacement `using-github` source `ref` remains an
+explicit `vX.Y.Z` tag.
 
 ### AC-35-4
 
@@ -67,12 +70,12 @@ automation source of truth.
 
 ## Approaches Considered
 
-### Recommended: Update current source-of-truth references only
+### Recommended: Rename current source-of-truth identity surfaces
 
 Change the two marketplace manifests and the release-flow member-plugin list to
-use `patinaproject/using-github`, then audit remaining references and document
-why any old-slug references stay. This directly addresses install and release
-resolution without rewriting historical planning records.
+use `using-github` and `patinaproject/using-github`, then audit remaining
+references and document why any old references stay. This directly addresses
+install and release resolution without rewriting historical planning records.
 
 ### Broad rewrite of all historical artifacts
 
@@ -81,38 +84,41 @@ This would reduce search noise, but it would also make historical records less
 accurate and create unnecessary churn in artifacts that are not current sources
 of truth.
 
-### Rename the plugin itself
+### Preserve the plugin name while changing only the repository
 
-Change the marketplace plugin name from `github-flows` to `using-github`. This
-may eventually be desirable, but it would alter the install interface and is
-larger than the issue's requested repository-slug accommodation.
+Keep the marketplace plugin name as `github-flows` and only update repository
+URLs. This would reduce install-surface churn, but it leaves the old name in the
+current catalog after the user clarified that `github-flows` should be removed.
 
 ## Decision
 
-Use the targeted source-of-truth update. The implementation should update:
+Use the targeted source-of-truth identity update. The implementation should
+update:
 
 - `.agents/plugins/marketplace.json`
 - `.claude-plugin/marketplace.json`
 - `docs/release-flow.md`
 
-It should preserve the plugin name `github-flows`, preserve the pinned tag, and
-leave historical Superpowers artifacts unchanged unless a remaining reference is
-found to affect active install, release, cache, or automation behavior.
+It should remove `github-flows` from current install and release-flow surfaces,
+preserve the pinned tag, and leave historical Superpowers artifacts unchanged
+unless a remaining reference is found to affect active install, release, cache,
+or automation behavior.
 
 ## Verification
 
-- Inspect both marketplace manifests to confirm `github-flows` points to
+- Inspect both marketplace manifests to confirm `using-github` points to
   `patinaproject/using-github` and still pins an explicit `vX.Y.Z` ref.
 - Inspect `docs/release-flow.md` to confirm the current member plugin list uses
   `patinaproject/using-github`.
 - Search the repository for `patinaproject/github-flows` and classify remaining
   matches as historical or actionable.
+- Search current marketplace and release-flow surfaces for `github-flows` to
+  confirm the old name is removed there.
 - Run Markdown lint for edited Markdown files and JSON parsing for edited
   manifests.
 
 ## Out of Scope
 
-- Renaming the marketplace plugin from `github-flows` to `using-github`.
 - Updating old issue #22 planning artifacts that describe the original
   `github-flows` repository before the rename.
 - Cutting or changing upstream plugin releases.

--- a/docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md
+++ b/docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md
@@ -1,0 +1,123 @@
+# Design: Accommodate using-github repository rename
+
+Issue: [patinaproject/skills#35](https://github.com/patinaproject/skills/issues/35)
+
+## Intent
+
+Update current marketplace and release-flow surfaces so the `github-flows`
+plugin resolves through the renamed canonical repository,
+`patinaproject/using-github`, while preserving the plugin's marketplace name and
+existing tagged release pin.
+
+## Context
+
+- The issue says `patinaproject/github-flows` is being renamed to
+  `patinaproject/using-github`.
+- Current marketplace manifests still point the `github-flows` plugin at the old
+  repository slug:
+  - `.agents/plugins/marketplace.json` uses
+    `https://github.com/patinaproject/github-flows.git`.
+  - `.claude-plugin/marketplace.json` uses `patinaproject/github-flows`.
+- `docs/release-flow.md` lists `patinaproject/github-flows` as the member plugin
+  repository that dispatches release bumps.
+- Historical Superpowers artifacts for issue #22 describe the original
+  `github-flows` addition. Those files are records of past design and planning
+  decisions, not current install or release configuration.
+
+## Requirements
+
+1. Current marketplace install surfaces must use `patinaproject/using-github` as
+   the canonical repository location for the `github-flows` plugin.
+2. Current release-flow documentation must identify `patinaproject/using-github`
+   as the member plugin repository that publishes `github-flows` releases.
+3. The marketplace plugin name must remain `github-flows` unless a separate
+   issue explicitly changes the install name.
+4. Existing release pins must remain explicit tagged refs and must not be changed
+   unless verification shows the rename requires a different tag.
+5. Historical issue artifacts may keep references to
+   `patinaproject/github-flows` when they are describing past work rather than a
+   current repository location.
+
+## Acceptance Criteria
+
+### AC-35-1
+
+Given a marketplace install surface points at the old GitHub repository slug,
+when the catalog is inspected, then the `github-flows` plugin source resolves to
+`patinaproject/using-github`.
+
+### AC-35-2
+
+Given release-flow documentation names the member plugin repository for
+`github-flows`, when the documentation is inspected, then it uses
+`patinaproject/using-github`.
+
+### AC-35-3
+
+Given marketplace entries for `github-flows` are updated for the repository
+rename, when the manifests are inspected, then the plugin name remains
+`github-flows` and its source `ref` remains an explicit `vX.Y.Z` tag.
+
+### AC-35-4
+
+Given the repository still contains old-slug references after implementation,
+when those references are audited, then each remaining reference is either
+historical context or otherwise not a current install, release, cache, or
+automation source of truth.
+
+## Approaches Considered
+
+### Recommended: Update current source-of-truth references only
+
+Change the two marketplace manifests and the release-flow member-plugin list to
+use `patinaproject/using-github`, then audit remaining references and document
+why any old-slug references stay. This directly addresses install and release
+resolution without rewriting historical planning records.
+
+### Broad rewrite of all historical artifacts
+
+Update every `patinaproject/github-flows` mention across old specs and plans.
+This would reduce search noise, but it would also make historical records less
+accurate and create unnecessary churn in artifacts that are not current sources
+of truth.
+
+### Rename the plugin itself
+
+Change the marketplace plugin name from `github-flows` to `using-github`. This
+may eventually be desirable, but it would alter the install interface and is
+larger than the issue's requested repository-slug accommodation.
+
+## Decision
+
+Use the targeted source-of-truth update. The implementation should update:
+
+- `.agents/plugins/marketplace.json`
+- `.claude-plugin/marketplace.json`
+- `docs/release-flow.md`
+
+It should preserve the plugin name `github-flows`, preserve the pinned tag, and
+leave historical Superpowers artifacts unchanged unless a remaining reference is
+found to affect active install, release, cache, or automation behavior.
+
+## Verification
+
+- Inspect both marketplace manifests to confirm `github-flows` points to
+  `patinaproject/using-github` and still pins an explicit `vX.Y.Z` ref.
+- Inspect `docs/release-flow.md` to confirm the current member plugin list uses
+  `patinaproject/using-github`.
+- Search the repository for `patinaproject/github-flows` and classify remaining
+  matches as historical or actionable.
+- Run Markdown lint for edited Markdown files and JSON parsing for edited
+  manifests.
+
+## Out of Scope
+
+- Renaming the marketplace plugin from `github-flows` to `using-github`.
+- Updating old issue #22 planning artifacts that describe the original
+  `github-flows` repository before the rename.
+- Cutting or changing upstream plugin releases.
+- Relying on GitHub redirects as the catalog's canonical repository location.
+
+## Concerns
+
+No approval-relevant concerns remain.


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add bootstrap skill guide`
- `chore: #34 bootstrap commit hooks`

Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Renames the marketplace plugin entry from `github-flows` to `using-github` in both Codex and Claude catalogs.
- Points both catalogs at `patinaproject/using-github` while preserving the explicit `v1.1.0` tag.
- Updates release-flow docs to track `patinaproject/using-github` as the member plugin repository.

## Linked issue

- Closes #35

## Acceptance criteria

### AC-35-1

The marketplace install surfaces now expose `using-github` and resolve to `patinaproject/using-github`.

- [x] Codex + Claude catalog assertion — Codex CLI | local node v24.14.1 | @tlmader | 2026-04-27T08:59:17Z
- [ ] Manual test: 1. Inspect `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`; 2. Confirm the plugin entry is named `using-github`; 3. Confirm the source points to `patinaproject/using-github`.

### AC-35-2

The release-flow documentation now names `patinaproject/using-github` as the member plugin repository.

- [x] Release-flow assertion — Codex CLI | local node v24.14.1 | @tlmader | 2026-04-27T08:59:17Z
- [ ] Manual test: 1. Open `docs/release-flow.md`; 2. Confirm the current member plugin list includes `patinaproject/using-github`; 3. Confirm it does not include `patinaproject/github-flows`.

### AC-35-3

The old current marketplace entry name is removed and the replacement `using-github` entry keeps the explicit `v1.1.0` tag.

- [x] Manifest tag assertion — Codex CLI | local node v24.14.1 | @tlmader | 2026-04-27T08:59:17Z
- [ ] Manual test: 1. Inspect both marketplace manifests; 2. Confirm there is no current `github-flows` plugin entry; 3. Confirm the `using-github` entry uses `ref: v1.1.0`.

### AC-35-4

Remaining old-slug references are limited to historical or migration-context Superpowers artifacts, not current install or release-flow sources of truth.

- [x] Repository reference audit — Codex CLI | local rg | @tlmader | 2026-04-27T08:59:17Z
- [ ] Manual test: 1. Run `rg -n 'github-flows' .agents/plugins/marketplace.json .claude-plugin/marketplace.json docs/release-flow.md`; 2. Confirm it returns no matches; 3. Run `rg -n 'patinaproject/github-flows' .`; 4. Confirm remaining matches are historical issue artifacts or this migration's design/plan.

## Validation

- `node` assertions for both marketplace manifests.
- `node` assertion for `docs/release-flow.md`.
- `rg -n 'github-flows' .agents/plugins/marketplace.json .claude-plugin/marketplace.json docs/release-flow.md` returned no matches.
- `rg -n 'patinaproject/github-flows' .` showed remaining matches only in historical or migration-context Superpowers artifacts.
- `pnpm exec markdownlint-cli2 docs/release-flow.md docs/superpowers/specs/2026-04-27-35-accommodate-using-github-repository-rename-design.md docs/superpowers/plans/2026-04-27-35-accommodate-using-github-repository-rename-plan.md` reported `0 error(s)`.
- `pnpm lint:md` reported `0 error(s)` for repository docs outside `docs/superpowers/**`.
- `git diff --check` completed with no whitespace errors.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR