### PR TITLE
fix: #38 repair using-github marketplace entries

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -35,19 +35,6 @@
       "source": {
         "source": "url",
         "url": "https://github.com/patinaproject/using-github.git",
-        "ref": "v1.1.0"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "Productivity"
-    },
-    {
-      "name": "using-github",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/patinaproject/using-github.git",
         "ref": "v2.0.0"
       },
       "policy": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,16 +35,6 @@
       "source": {
         "source": "github",
         "repo": "patinaproject/using-github",
-        "ref": "v1.1.0"
-      }
-    },
-    {
-      "name": "using-github",
-      "description": "Patina Project plugin: using-github",
-      "category": "productivity",
-      "source": {
-        "source": "github",
-        "repo": "patinaproject/using-github",
         "ref": "v2.0.0"
       }
     }

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -9,6 +9,16 @@ permissions:
   pull-requests: read
 
 jobs:
+  marketplace-catalog:
+    name: Validate marketplace catalog
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate marketplace manifests
+        run: node scripts/validate-marketplace.js
+
   title-format:
     name: Validate PR title
     runs-on: ubuntu-latest

--- a/.github/workflows/plugin-release-bump.yml
+++ b/.github/workflows/plugin-release-bump.yml
@@ -99,6 +99,9 @@ jobs:
           fi
           mv "$codex.tmp" "$codex"
 
+      - name: Validate marketplace manifests
+        run: node scripts/validate-marketplace.js
+
       - name: Apply bootstrap scaffolding (when plugin is bootstrap)
         if: steps.inputs.outputs.plugin == 'bootstrap'
         run: |

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ The marketplace only lists plugins that have published a tagged release (`vX.Y.Z
 
 Tracked member plugins:
 
-- `patinaproject/bootstrap` — repo scaffolding skill (pending first tagged release; also consumed by this repo)
-- `patinaproject/superteam` — issue-driven orchestration skill (pending first tagged release, tracked in [patinaproject/superteam#32](https://github.com/patinaproject/superteam/issues/32))
+- `patinaproject/bootstrap` — repo scaffolding skill, currently `v1.2.0`
+- `patinaproject/superteam` — issue-driven orchestration skill, currently `v1.1.0`
+- `patinaproject/using-github` — GitHub workflow skill, currently `v2.0.0`
 
 ## Install Surfaces
 
 - `patinaproject/skills` owns the marketplace catalogs and contributor docs
-- `patinaproject/superteam` is the source of truth for the upstream plugin package
+- `patinaproject/bootstrap`, `patinaproject/superteam`, and `patinaproject/using-github` own their upstream plugin packages
 - Codex marketplace metadata lives in `.agents/plugins/marketplace.json`
 - Claude marketplace metadata lives in `.claude-plugin/marketplace.json`
-- Codex installs `superteam` from the repository root in `patinaproject/superteam`
-- The upstream Codex manifest lives at `.codex-plugin/plugin.json`
-- The Claude plugin packaging and install surface live in the upstream `patinaproject/superteam` repository through its root `.claude-plugin/plugin.json`
-- The upstream `superteam` skill content lives at `skills/superteam/`
+- Codex reads upstream package metadata from `.codex-plugin/plugin.json`
+- Claude reads upstream package metadata from `.claude-plugin/plugin.json`
+- Upstream skill content lives under each plugin repo's `skills/` directory
 
 ## How it works
 
@@ -30,13 +30,13 @@ Codex reads the marketplace definition from `.agents/plugins/marketplace.json`, 
 
 In this repo, the marketplace is named `patinaproject-skills` and exposed in the UI as `Patina Project`.
 
-Plugin entries do not vendor plugin files in this repository. Each entry points at a Git-backed plugin source repo (for example `patinaproject/superteam`) pinned to an explicit release tag (`vX.Y.Z`). Branch refs such as `main` are not allowed — see [docs/release-flow.md](docs/release-flow.md).
+Plugin entries do not vendor plugin files in this repository. Each entry points at a Git-backed plugin source repo pinned to an explicit release tag (`vX.Y.Z`). Branch refs such as `main` are not allowed — see [docs/release-flow.md](docs/release-flow.md).
 
-In the upstream repository, the active install surfaces are:
+In each upstream plugin repository, the active install surfaces are:
 
 - Codex manifest: `.codex-plugin/plugin.json`
 - Claude manifest: `.claude-plugin/plugin.json`
-- Skill directory: `skills/superteam/`
+- Skill directory: `skills/`
 
 That keeps the marketplace catalogs isolated while allowing plugin source repos to stay independent.
 
@@ -54,27 +54,39 @@ Refresh tracked marketplaces:
 codex plugin marketplace upgrade
 ```
 
-Then open the Codex Plugin Directory, find `Patina Project`, and install `superteam`.
+Then open the Codex Plugin Directory, find `Patina Project`, and install the plugin you need: `bootstrap`, `superteam`, or `using-github`.
 
 ## Install In Claude Code
 
-This repository tracks the Claude marketplace catalog entry, but the installable Claude plugin package lives upstream in `patinaproject/superteam`.
-
-For a direct setup in Claude Code today, add `superteam` as a custom subagent. Anthropic's official Claude Code docs describe project subagents in `.claude/agents/` and user subagents in `~/.claude/agents/`.
-
-Create a project subagent file at `.claude/agents/superteam.md` with `/agents`, or create it manually and copy in the contents of:
+Register the Patina Project marketplace in Claude Code:
 
 ```text
-https://github.com/patinaproject/superteam/blob/main/skills/superteam/SKILL.md
+/plugin marketplace add patinaproject/skills
 ```
 
-Claude Code loads project subagents from `.claude/agents/`, so after adding that file you can use prompts such as:
+Then install the plugin you need:
 
 ```text
-Use the superteam subagent to take issue #123 from design through review-ready execution.
+/plugin install bootstrap@patinaproject-skills
+/plugin install superteam@patinaproject-skills
+/plugin install using-github@patinaproject-skills
 ```
 
-If you want the workflow available across all projects instead, place the file in `~/.claude/agents/superteam.md`.
+## Use Installed Plugins
+
+After installing a plugin, invoke the relevant skill:
+
+```text
+Use $bootstrap:bootstrap to align this repository with the Patina Project baseline.
+```
+
+```text
+Use $superteam:superteam to take issue #123 from design through review-ready execution.
+```
+
+```text
+Use $using-github for GitHub issue, branch, PR, and changelog work.
+```
 
 ## Install From A Local Checkout
 
@@ -86,25 +98,14 @@ codex plugin marketplace add ./skills
 
 If Codex does not immediately show the updated marketplace catalog, restart Codex and re-open the Plugin Directory.
 
-## Use Superteam
-
-After installing the plugin, invoke the skill in Codex with:
-
-```text
-Use $superteam to take this issue from design through review-ready execution.
-```
-
-You can also use shorter task-specific prompts such as:
-
-```text
-Use $superteam to coordinate an implementation plan for issue #123.
-```
-
 ## Maintenance Notes
 
 - Update marketplace entries in `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`
 - Keep Git-backed entries pinned to an explicit tag `ref` (`vX.Y.Z`). Branch refs are not allowed.
 - Maintain plugin source and packaging in the owning source repository
-- For `superteam`, the source-of-truth repo is `patinaproject/superteam`
 - For `bootstrap`, the source-of-truth repo is `patinaproject/bootstrap`
+- For `superteam`, the source-of-truth repo is `patinaproject/superteam`
+- For `using-github`, the source-of-truth repo is `patinaproject/using-github`
+- Run `pnpm validate:marketplace` before opening marketplace PRs
+- Run `pnpm validate:marketplace:remote` when validating release identity against upstream tags
 - See [docs/release-flow.md](docs/release-flow.md) for how plugin releases propagate into the marketplace

--- a/docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
+++ b/docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
@@ -469,3 +469,13 @@ git commit -m "docs: #38 record marketplace verification plan"
 ```
 
 Expected: commit succeeds if the plan file changed during execution; skip if it did not change.
+
+## Verification Evidence
+
+- `pnpm validate:marketplace`: passed with `Marketplace validation passed for 3 plugin(s).`
+- `pnpm validate:marketplace:remote`: passed with `Marketplace validation passed for 3 plugin(s).`
+- Active repo-local editor/config surface audit found only `.agents`, `.claude`, and `.claude-plugin`.
+- `rg -n 'github-flows|patinaproject/github-flows' .agents .claude-plugin .claude README.md docs/release-flow.md .github/workflows/plugin-release-bump.yml scripts package.json`: no matches.
+- `pnpm lint:md`: passed, linting 10 tracked non-Superpowers Markdown files.
+- `pnpm exec markdownlint-cli2 docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md`: passed.
+- `actionlint .github/workflows/plugin-release-bump.yml`: passed.

--- a/docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
+++ b/docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
@@ -478,4 +478,4 @@ Expected: commit succeeds if the plan file changed during execution; skip if it 
 - `rg -n 'github-flows|patinaproject/github-flows' .agents .claude-plugin .claude README.md docs/release-flow.md .github/workflows/plugin-release-bump.yml scripts package.json`: no matches.
 - `pnpm lint:md`: passed, linting 10 tracked non-Superpowers Markdown files.
 - `pnpm exec markdownlint-cli2 docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md`: passed.
-- `actionlint .github/workflows/plugin-release-bump.yml`: passed.
+- `actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml`: passed.

--- a/docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
+++ b/docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
@@ -1,0 +1,471 @@
+# Fix Duplicate using-github Marketplace Entries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the duplicate `using-github` marketplace entries, refresh marketplace docs, and add validation that catches duplicate or mismatched catalog entries before they ship again.
+
+**Architecture:** Add one focused Node validator under `scripts/` that owns marketplace invariants for both local and CI/release-bump use. Then make the manifests and README match the audited current plugin set, and wire validation into package scripts plus the release-bump workflow.
+
+**Tech Stack:** JSON marketplace manifests, Markdown docs, Node.js CommonJS, GitHub CLI for optional upstream release checks, GitHub Actions, `pnpm`, `markdownlint-cli2`.
+
+---
+
+## File Structure
+
+- Create: `scripts/validate-marketplace.js`
+  - Parse `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`.
+  - Fail on duplicate plugin names, missing cross-manifest entries, mismatched repos or refs, non-`vX.Y.Z` refs, and malformed source blocks.
+  - When run with `--remote`, fetch upstream `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `package.json` with `gh api` and confirm manifest names and versions match the marketplace entry.
+- Modify: `package.json`
+  - Add `validate:marketplace` and `validate:marketplace:remote` scripts.
+- Modify: `.agents/plugins/marketplace.json`
+  - Remove the stale `using-github@v1.1.0` entry and keep `using-github@v2.0.0`.
+- Modify: `.claude-plugin/marketplace.json`
+  - Remove the stale `using-github@v1.1.0` entry and keep `using-github@v2.0.0`.
+- Modify: `.github/workflows/plugin-release-bump.yml`
+  - Run the marketplace validator before creating the automated bump PR.
+- Modify: `.github/workflows/lint-md.yml` or create a new workflow only if needed
+  - Prefer no new workflow; release-bump validation plus local/package validation is sufficient for this issue.
+- Modify: `README.md`
+  - List `bootstrap`, `superteam`, and `using-github` with released refs.
+  - Describe Codex and Claude marketplace installs without `superteam`-only language.
+  - Mention non-plugin editor surfaces only where applicable and avoid old `github-flows` identity as installable marketplace content.
+- Modify: `docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md`
+  - Track implementation completion and verification evidence.
+
+## Task 1: Add Failing Catalog Validation
+
+**Files:**
+
+- Create: `scripts/validate-marketplace.js`
+- Modify: `package.json`
+
+- [ ] **Step 1: Create the validator script**
+
+Add this executable CommonJS script:
+
+```js
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+
+const remote = process.argv.includes("--remote");
+const semverTag = /^v(\d+\.\d+\.\d+)$/;
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function normalizeCodexRepo(plugin) {
+  const source = plugin.source || {};
+  if (source.source !== "url") {
+    fail(`Codex plugin ${plugin.name} must use source=url`);
+  }
+  if (!source.url || !source.url.startsWith("https://github.com/") || !source.url.endsWith(".git")) {
+    fail(`Codex plugin ${plugin.name} has invalid source URL: ${source.url}`);
+  }
+  return source.url.replace("https://github.com/", "").replace(/\.git$/, "");
+}
+
+function normalizeClaudeRepo(plugin) {
+  const source = plugin.source || {};
+  if (source.source !== "github") {
+    fail(`Claude plugin ${plugin.name} must use source=github`);
+  }
+  if (!source.repo || !/^[^/]+\/[^/]+$/.test(source.repo)) {
+    fail(`Claude plugin ${plugin.name} has invalid source repo: ${source.repo}`);
+  }
+  return source.repo;
+}
+
+function assertNoDuplicates(kind, plugins) {
+  const counts = new Map();
+  for (const plugin of plugins) {
+    counts.set(plugin.name, (counts.get(plugin.name) || 0) + 1);
+  }
+  const duplicates = [...counts].filter(([, count]) => count > 1);
+  if (duplicates.length > 0) {
+    fail(`${kind} marketplace has duplicate plugin names: ${duplicates.map(([name]) => name).join(", ")}`);
+  }
+}
+
+function assertRefs(kind, plugins) {
+  for (const plugin of plugins) {
+    if (!semverTag.test(plugin.source?.ref || "")) {
+      fail(`${kind} plugin ${plugin.name} ref is not an explicit vX.Y.Z tag: ${plugin.source?.ref}`);
+    }
+  }
+}
+
+function apiJson(repo, ref, path) {
+  const content = execFileSync(
+    "gh",
+    ["api", "-X", "GET", `repos/${repo}/contents/${path}`, "-f", `ref=${ref}`, "--jq", ".content"],
+    { encoding: "utf8" }
+  );
+  return JSON.parse(Buffer.from(content.replace(/\s/g, ""), "base64").toString("utf8"));
+}
+
+function assertRemoteManifest(plugin, repo, manifestPath, expectedVersion) {
+  const manifest = apiJson(repo, plugin.source.ref, manifestPath);
+  if (manifest.name !== plugin.name) {
+    fail(`${repo}@${plugin.source.ref} ${manifestPath} name=${manifest.name}; expected ${plugin.name}`);
+  }
+  if (manifest.version !== expectedVersion) {
+    fail(`${repo}@${plugin.source.ref} ${manifestPath} version=${manifest.version}; expected ${expectedVersion}`);
+  }
+}
+
+function assertRemotePackage(plugin, repo, expectedVersion) {
+  const pkg = apiJson(repo, plugin.source.ref, "package.json");
+  if (pkg.name !== plugin.name) {
+    fail(`${repo}@${plugin.source.ref} package.json name=${pkg.name}; expected ${plugin.name}`);
+  }
+  if (pkg.version !== expectedVersion) {
+    fail(`${repo}@${plugin.source.ref} package.json version=${pkg.version}; expected ${expectedVersion}`);
+  }
+}
+
+const codex = readJson(".agents/plugins/marketplace.json").plugins;
+const claude = readJson(".claude-plugin/marketplace.json").plugins;
+
+assertNoDuplicates("Codex", codex);
+assertNoDuplicates("Claude", claude);
+assertRefs("Codex", codex);
+assertRefs("Claude", claude);
+
+const codexByName = new Map(codex.map((plugin) => [plugin.name, plugin]));
+const claudeByName = new Map(claude.map((plugin) => [plugin.name, plugin]));
+
+for (const name of new Set([...codexByName.keys(), ...claudeByName.keys()])) {
+  const codexPlugin = codexByName.get(name);
+  const claudePlugin = claudeByName.get(name);
+  if (!codexPlugin || !claudePlugin) {
+    fail(`Plugin ${name} must be present in both Codex and Claude marketplaces`);
+  }
+
+  const codexRepo = normalizeCodexRepo(codexPlugin);
+  const claudeRepo = normalizeClaudeRepo(claudePlugin);
+  if (codexRepo !== claudeRepo) {
+    fail(`Plugin ${name} repo mismatch: Codex=${codexRepo}, Claude=${claudeRepo}`);
+  }
+  if (codexPlugin.source.ref !== claudePlugin.source.ref) {
+    fail(`Plugin ${name} ref mismatch: Codex=${codexPlugin.source.ref}, Claude=${claudePlugin.source.ref}`);
+  }
+
+  if (remote) {
+    const expectedVersion = codexPlugin.source.ref.match(semverTag)[1];
+    assertRemoteManifest(codexPlugin, codexRepo, ".codex-plugin/plugin.json", expectedVersion);
+    assertRemoteManifest(claudePlugin, claudeRepo, ".claude-plugin/plugin.json", expectedVersion);
+    assertRemotePackage(codexPlugin, codexRepo, expectedVersion);
+  }
+}
+
+console.log(`Marketplace validation passed for ${codex.length} plugin(s).`);
+```
+
+- [ ] **Step 2: Add package scripts**
+
+Add these scripts to `package.json`:
+
+```json
+"validate:marketplace": "node scripts/validate-marketplace.js",
+"validate:marketplace:remote": "node scripts/validate-marketplace.js --remote"
+```
+
+Keep existing scripts unchanged.
+
+- [ ] **Step 3: Run local validation and confirm it fails on the current duplicate**
+
+Run:
+
+```bash
+pnpm validate:marketplace
+```
+
+Expected: FAIL with `Codex marketplace has duplicate plugin names: using-github`.
+
+- [ ] **Step 4: Commit the failing validator**
+
+Run:
+
+```bash
+git add scripts/validate-marketplace.js package.json
+git commit -m "test: #38 add marketplace validation"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Repair Marketplace Manifests
+
+**Files:**
+
+- Modify: `.agents/plugins/marketplace.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Remove the stale Codex entry**
+
+In `.agents/plugins/marketplace.json`, delete only the first `using-github`
+entry that has:
+
+```json
+"ref": "v1.1.0"
+```
+
+Keep the later `using-github` entry with:
+
+```json
+"url": "https://github.com/patinaproject/using-github.git",
+"ref": "v2.0.0"
+```
+
+- [ ] **Step 2: Remove the stale Claude entry**
+
+In `.claude-plugin/marketplace.json`, delete only the first `using-github`
+entry that has:
+
+```json
+"ref": "v1.1.0"
+```
+
+Keep the later `using-github` entry with:
+
+```json
+"repo": "patinaproject/using-github",
+"ref": "v2.0.0"
+```
+
+- [ ] **Step 3: Run local validation**
+
+Run:
+
+```bash
+pnpm validate:marketplace
+```
+
+Expected: PASS with `Marketplace validation passed for 3 plugin(s).`
+
+- [ ] **Step 4: Commit the manifest repair**
+
+Run:
+
+```bash
+git add .agents/plugins/marketplace.json .claude-plugin/marketplace.json
+git commit -m "fix: #38 remove stale using-github entries"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Guard Release Bumps With Validation
+
+**Files:**
+
+- Modify: `.github/workflows/plugin-release-bump.yml`
+
+- [ ] **Step 1: Add validation after manifest updates**
+
+After the `Update marketplace manifests` step, add:
+
+```yaml
+      - name: Validate marketplace manifests
+        run: node scripts/validate-marketplace.js
+```
+
+Expected: bot bump PRs fail before PR creation if the generated catalogs contain duplicate plugin names, non-tag refs, repo mismatches, or cross-manifest inconsistencies.
+
+- [ ] **Step 2: Run local workflow validation commands**
+
+Run:
+
+```bash
+node scripts/validate-marketplace.js
+pnpm exec markdownlint-cli2 .github/workflows/plugin-release-bump.yml
+```
+
+Expected: marketplace validation passes. Markdown lint may report no Markdown files for the workflow path; if so, run `pnpm exec markdownlint-cli2 README.md docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md` instead.
+
+- [ ] **Step 3: Commit release-bump guardrail**
+
+Run:
+
+```bash
+git add .github/workflows/plugin-release-bump.yml
+git commit -m "ci: #38 validate release bump catalogs"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Refresh README Marketplace Guidance
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Update current plugin list**
+
+Replace the current `Tracked member plugins` list with:
+
+```markdown
+Tracked member plugins:
+
+- `patinaproject/bootstrap` — repo scaffolding skill, currently `v1.2.0`
+- `patinaproject/superteam` — issue-driven orchestration skill, currently `v1.1.0`
+- `patinaproject/using-github` — GitHub workflow skill, currently `v2.0.0`
+```
+
+- [ ] **Step 2: Update install surfaces**
+
+Replace `superteam`-only install-surface bullets with bullets that describe the marketplace generically:
+
+```markdown
+- `patinaproject/skills` owns the marketplace catalogs and contributor docs
+- `patinaproject/bootstrap`, `patinaproject/superteam`, and `patinaproject/using-github` own their upstream plugin packages
+- Codex marketplace metadata lives in `.agents/plugins/marketplace.json`
+- Claude marketplace metadata lives in `.claude-plugin/marketplace.json`
+- Codex reads upstream package metadata from `.codex-plugin/plugin.json`
+- Claude reads upstream package metadata from `.claude-plugin/plugin.json`
+- Upstream skill content lives under each plugin repo's `skills/` directory
+```
+
+- [ ] **Step 3: Update install examples**
+
+Change the Codex install instruction sentence to:
+
+```markdown
+Then open the Codex Plugin Directory, find `Patina Project`, and install the plugin you need: `bootstrap`, `superteam`, or `using-github`.
+```
+
+Replace the Claude install section with marketplace-oriented language:
+
+````markdown
+Register the Patina Project marketplace in Claude Code:
+
+```text
+/plugin marketplace add patinaproject/skills
+```
+
+Then install the plugin you need:
+
+```text
+/plugin install bootstrap@patinaproject-skills
+/plugin install superteam@patinaproject-skills
+/plugin install using-github@patinaproject-skills
+```
+````
+
+- [ ] **Step 4: Update maintenance notes**
+
+Replace `superteam` and `bootstrap` source-of-truth-only bullets with:
+
+```markdown
+- For `bootstrap`, the source-of-truth repo is `patinaproject/bootstrap`
+- For `superteam`, the source-of-truth repo is `patinaproject/superteam`
+- For `using-github`, the source-of-truth repo is `patinaproject/using-github`
+- Run `pnpm validate:marketplace` before opening marketplace PRs
+- Run `pnpm validate:marketplace:remote` when validating release identity against upstream tags
+```
+
+- [ ] **Step 5: Run README-focused checks**
+
+Run:
+
+```bash
+rg -n 'pending first tagged release|github-flows|superteam` from|plugins/superteam|using-github|bootstrap|superteam' README.md
+pnpm exec markdownlint-cli2 README.md
+```
+
+Expected: no `pending first tagged release`, `github-flows`, `superteam from repository root`, or `plugins/superteam` active install-language matches remain. The current plugin names remain.
+
+- [ ] **Step 6: Commit README refresh**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: #38 refresh marketplace install guidance"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Run Full Verification And Record Evidence
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md`
+
+- [ ] **Step 1: Run local marketplace validation**
+
+Run:
+
+```bash
+pnpm validate:marketplace
+```
+
+Expected: PASS with `Marketplace validation passed for 3 plugin(s).`
+
+- [ ] **Step 2: Run remote marketplace validation**
+
+Run:
+
+```bash
+pnpm validate:marketplace:remote
+```
+
+Expected: PASS with `Marketplace validation passed for 3 plugin(s).`
+
+- [ ] **Step 3: Audit active repo-local editor/config surfaces**
+
+Run:
+
+```bash
+find . -path './node_modules' -prune -o \( -name '.vscode' -o -name '.idea' -o -name '.cursor' -o -name '.windsurf' -o -name '.zed' -o -name '.continue' -o -name '.codex' -o -name '.claude' -o -name '.agents' -o -name '.claude-plugin' -o -name '.codex-plugin' \) -print
+```
+
+Expected: only `.agents`, `.claude`, and `.claude-plugin` repo-local surfaces are present.
+
+- [ ] **Step 4: Audit old identity in active repository surfaces**
+
+Run:
+
+```bash
+rg -n 'github-flows|patinaproject/github-flows' .agents .claude-plugin .claude README.md docs/release-flow.md .github/workflows/plugin-release-bump.yml scripts package.json
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+pnpm exec markdownlint-cli2 docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Review final diff**
+
+Run:
+
+```bash
+git diff origin/main...HEAD -- .agents/plugins/marketplace.json .claude-plugin/marketplace.json README.md package.json scripts/validate-marketplace.js .github/workflows/plugin-release-bump.yml docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
+```
+
+Expected: diff contains only the planned marketplace, validation, docs, and Superteam artifacts.
+
+- [ ] **Step 7: Commit verification note updates**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md
+git commit -m "docs: #38 record marketplace verification plan"
+```
+
+Expected: commit succeeds if the plan file changed during execution; skip if it did not change.

--- a/docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md
@@ -1,0 +1,131 @@
+# Design: Fix duplicate using-github marketplace entries
+
+Issue: [patinaproject/skills#38](https://github.com/patinaproject/skills/issues/38)
+
+## Intent
+
+Restore `using-github` marketplace install behavior by making each marketplace
+manifest expose exactly one canonical `using-github` entry, pinned to the
+current intended release, and by auditing the catalogs for related consistency
+issues before publishing.
+
+## Context
+
+- The current marketplace sources of truth are:
+  - [.agents/plugins/marketplace.json](../../../.agents/plugins/marketplace.json)
+  - [.claude-plugin/marketplace.json](../../../.claude-plugin/marketplace.json)
+- Issue #35 renamed the marketplace entry from `github-flows` to
+  `using-github` while preserving the existing `v1.1.0` ref.
+- Issue #36 added a release bump for `using-github@v2.0.0`, creating a second
+  `using-github` entry in both marketplace manifests.
+- The issue reports that `patinaproject/using-github@v1.1.0` still identifies
+  its Codex manifest as `github-flows`, while
+  `patinaproject/using-github@v2.0.0` identifies as `using-github`.
+- Repository guidance requires plugin names, manifest names, marketplace
+  entries, source repositories, and explicit tagged refs to stay aligned.
+
+## Requirements
+
+1. `.agents/plugins/marketplace.json` must contain exactly one plugin with
+   `name: "using-github"`.
+2. `.claude-plugin/marketplace.json` must contain exactly one plugin with
+   `name: "using-github"`.
+3. The remaining `using-github` entry in both manifests must point to
+   `patinaproject/using-github` at the intended current release, `v2.0.0`.
+4. The stale `v1.1.0` `using-github` entry must be removed from both
+   manifests.
+5. Every plugin entry in each manifest must use an explicit `vX.Y.Z` tag.
+6. Both manifests must be audited for duplicate plugin names, stale refs,
+   mismatched plugin names, mismatched source repositories, and inconsistent
+   entries between the Claude and Agents/Codex catalogs.
+7. Verification notes must document the manifest files reviewed and confirm no
+   other duplicate or inconsistent plugin entries remain.
+
+## Acceptance Criteria
+
+### AC-38-1
+
+The Patina Project marketplace exposes exactly one `using-github` entry in every
+marketplace configuration, pointing at the intended current release.
+
+### AC-38-2
+
+The stale `using-github` entry that points at `v1.1.0` is removed or otherwise
+corrected so marketplace name, source repository, release ref, and plugin
+manifest identity agree.
+
+### AC-38-3
+
+All marketplace configurations in the repository are reviewed for related
+catalog issues, including duplicate plugin names, stale release refs,
+mismatched plugin names, mismatched source repositories, and inconsistent
+entries between Claude and Agents/Codex marketplace manifests.
+
+### AC-38-4
+
+Verification notes document which marketplace configuration files were reviewed
+and confirm no other duplicate or inconsistent plugin entries remain.
+
+## Approaches Considered
+
+### Recommended: Remove stale entries and verify catalog invariants
+
+Delete only the stale `using-github@v1.1.0` entries from both manifests, keep the
+existing `using-github@v2.0.0` entries unchanged, and add focused verification
+that checks duplicates, explicit tag refs, canonical source repositories, and
+cross-manifest consistency. This directly fixes the install failure while
+keeping the current intended release produced by the release bump.
+
+### Rewrite the stale entries to `v2.0.0`
+
+Change both stale entries from `v1.1.0` to `v2.0.0`. This would align the stale
+release ref, but it would leave duplicate `using-github` entries in both
+catalogs and fail the marketplace discovery requirement.
+
+### Revert the release bump
+
+Remove the `v2.0.0` entries and keep the older `v1.1.0` entries. This would
+avoid duplicates, but it would preserve the manifest identity mismatch that
+causes Codex install failure.
+
+## Decision
+
+Use the targeted removal and verification approach. The implementation should
+modify only the marketplace manifests unless the audit finds another current
+catalog source of truth that is inconsistent.
+
+The remaining canonical entries should be:
+
+- Agents/Codex: `name: "using-github"`,
+  `source.url: "https://github.com/patinaproject/using-github.git"`,
+  `source.ref: "v2.0.0"`.
+- Claude: `name: "using-github"`,
+  `source.repo: "patinaproject/using-github"`,
+  `source.ref: "v2.0.0"`.
+
+Historical Superpowers artifacts may retain older references when they describe
+past issue work rather than current marketplace configuration.
+
+## Verification
+
+- Parse both marketplace JSON files.
+- Assert each manifest has exactly one `using-github` entry.
+- Assert the remaining `using-github` entries point to
+  `patinaproject/using-github` and `v2.0.0`.
+- Assert every plugin ref in both manifests matches `vX.Y.Z`.
+- Assert each manifest has no duplicate plugin names.
+- Compare both manifests by plugin name to confirm names, repository owners,
+  repository names, and refs are consistent across Claude and Agents/Codex.
+- Run Markdown lint for the new design and implementation plan artifacts.
+
+## Out of Scope
+
+- Changing upstream `patinaproject/using-github` releases.
+- Changing release-bump automation behavior unless the audit finds it is
+  currently producing malformed entries.
+- Rewriting historical issue artifacts that accurately record past marketplace
+  states.
+
+## Concerns
+
+No approval-relevant concerns remain.

--- a/docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-design.md
@@ -23,6 +23,30 @@ issues before publishing.
   `patinaproject/using-github@v2.0.0` identifies as `using-github`.
 - Repository guidance requires plugin names, manifest names, marketplace
   entries, source repositories, and explicit tagged refs to stay aligned.
+- An adversarial audit found the marketplace repository README is stale: it
+  omits `using-github` from the tracked member plugin list, still describes
+  released plugins as pending first tagged releases, and documents install
+  examples centered on `superteam` rather than every currently listed plugin.
+- The same audit found the release-bump workflow updates every matching plugin
+  name when duplicates exist, but it does not fail on or repair duplicate
+  entries. A duplicate can therefore survive a future bump unless validation is
+  added.
+- Upstream release checks confirmed:
+  - `bootstrap@v1.2.0` Codex and Claude manifests both declare
+    `name: "bootstrap"` and `version: "1.2.0"`.
+  - `superteam@v1.1.0` Codex and Claude manifests both declare
+    `name: "superteam"` and `version: "1.1.0"`.
+  - `using-github@v1.1.0` Codex and Claude manifests both still declare
+    `name: "github-flows"` and `version: "1.1.0"`.
+  - `using-github@v2.0.0` Codex and Claude manifests both declare
+    `name: "using-github"` and `version: "2.0.0"`.
+- The `using-github@v2.0.0` upstream editor surfaces are aligned with the new
+  identity: `.cursor/rules/using-github.mdc`, `.windsurfrules`,
+  `.github/copilot-instructions.md`, `AGENTS.md`, `README.md`, and
+  `skills/using-github/SKILL.md` all route active GitHub work through
+  `/using-github`. Remaining `github-flows` mentions in that release are
+  compatibility notes or historical planning artifacts, not active marketplace
+  entries.
 
 ## Requirements
 
@@ -40,6 +64,15 @@ issues before publishing.
    entries between the Claude and Agents/Codex catalogs.
 7. Verification notes must document the manifest files reviewed and confirm no
    other duplicate or inconsistent plugin entries remain.
+8. The repository README must reflect the marketplace's current supported
+   plugins and install surfaces across Codex and Claude instead of stale
+   first-release or `superteam`-only language.
+9. Release-bump automation or CI validation must reject duplicate marketplace
+   plugin names and cross-manifest inconsistencies so future bumps cannot leave
+   a broken catalog shape silently in place.
+10. Verification must include upstream release manifest checks for every plugin
+    entry in both marketplace manifests and editor-surface checks for active
+    `using-github` rename fallout in supported editor guidance.
 
 ## Acceptance Criteria
 
@@ -68,13 +101,22 @@ and confirm no other duplicate or inconsistent plugin entries remain.
 
 ## Approaches Considered
 
-### Recommended: Remove stale entries and verify catalog invariants
+### Recommended: Remove stale entries, refresh docs, and add catalog validation
 
 Delete only the stale `using-github@v1.1.0` entries from both manifests, keep the
-existing `using-github@v2.0.0` entries unchanged, and add focused verification
-that checks duplicates, explicit tag refs, canonical source repositories, and
-cross-manifest consistency. This directly fixes the install failure while
-keeping the current intended release produced by the release bump.
+existing `using-github@v2.0.0` entries unchanged, refresh marketplace README
+language, and add focused validation that checks duplicates, explicit tag refs,
+canonical source repositories, upstream manifest identity, editor-surface
+rename fallout, and cross-manifest consistency. This directly fixes the install
+failure while keeping the current intended release produced by the release bump,
+and it prevents future release-bump or manual edits from reintroducing the same
+catalog class silently.
+
+### Minimal manifest-only cleanup
+
+Remove the stale entries and stop. This would satisfy the narrow install
+failure, but it would leave stale README guidance and no guard against duplicate
+or inconsistent marketplace entries.
 
 ### Rewrite the stale entries to `v2.0.0`
 
@@ -90,9 +132,9 @@ causes Codex install failure.
 
 ## Decision
 
-Use the targeted removal and verification approach. The implementation should
-modify only the marketplace manifests unless the audit finds another current
-catalog source of truth that is inconsistent.
+Use the targeted removal, documentation refresh, and validation approach. The
+implementation should modify the marketplace manifests, README, and validation
+surface needed to enforce the audited catalog invariants.
 
 The remaining canonical entries should be:
 
@@ -106,6 +148,17 @@ The remaining canonical entries should be:
 Historical Superpowers artifacts may retain older references when they describe
 past issue work rather than current marketplace configuration.
 
+The validation surface should catch at least these failure classes:
+
+- duplicate plugin names within either marketplace manifest;
+- missing plugin names in either Claude or Agents/Codex;
+- mismatched source repositories or refs between manifests;
+- non-`vX.Y.Z` refs;
+- marketplace name/ref pairs whose upstream `.codex-plugin/plugin.json` or
+  `.claude-plugin/plugin.json` declares a different plugin name or version;
+- current README or active editor guidance that still presents `github-flows` as
+  the installable marketplace identity.
+
 ## Verification
 
 - Parse both marketplace JSON files.
@@ -116,13 +169,24 @@ past issue work rather than current marketplace configuration.
 - Assert each manifest has no duplicate plugin names.
 - Compare both manifests by plugin name to confirm names, repository owners,
   repository names, and refs are consistent across Claude and Agents/Codex.
+- Fetch each listed plugin release and confirm `.codex-plugin/plugin.json`,
+  `.claude-plugin/plugin.json`, and, when present, `package.json` use the same
+  plugin name and version as the marketplace entry.
+- Inspect README install guidance for all currently listed plugins:
+  `bootstrap`, `superteam`, and `using-github`.
+- Inspect active editor guidance for rename fallout:
+  `.claude/settings.json`, Codex/Agents marketplace metadata, Claude marketplace
+  metadata, upstream `using-github@v2.0.0` AGENTS/CLAUDE/Copilot/Cursor/Windsurf
+  surfaces, and absence of repo-local `.vscode`, `.idea`, `.windsurf`, `.zed`,
+  `.cursor`, `.continue`, or `.codex` configuration beyond the discovered
+  marketplace and Claude settings surfaces.
 - Run Markdown lint for the new design and implementation plan artifacts.
 
 ## Out of Scope
 
 - Changing upstream `patinaproject/using-github` releases.
-- Changing release-bump automation behavior unless the audit finds it is
-  currently producing malformed entries.
+- Rewriting upstream plugin repository content when the current tagged release
+  surfaces already align with the intended identity.
 - Rewriting historical issue artifacts that accurately record past marketplace
   states.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "commit": "git-cz",
     "commit:retry": "git-cz --retry",
     "commitlint": "commitlint",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#docs/superpowers/**\""
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#docs/superpowers/**\"",
+    "validate:marketplace": "node scripts/validate-marketplace.js",
+    "validate:marketplace:remote": "node scripts/validate-marketplace.js --remote"
   },
   "config": {
     "commitizen": {

--- a/scripts/validate-marketplace.js
+++ b/scripts/validate-marketplace.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+
+const remote = process.argv.includes("--remote");
+const semverTag = /^v(\d+\.\d+\.\d+)$/;
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function normalizeCodexRepo(plugin) {
+  const source = plugin.source || {};
+  if (source.source !== "url") {
+    fail(`Codex plugin ${plugin.name} must use source=url`);
+  }
+  if (
+    !source.url ||
+    !source.url.startsWith("https://github.com/") ||
+    !source.url.endsWith(".git")
+  ) {
+    fail(`Codex plugin ${plugin.name} has invalid source URL: ${source.url}`);
+  }
+  return source.url.replace("https://github.com/", "").replace(/\.git$/, "");
+}
+
+function normalizeClaudeRepo(plugin) {
+  const source = plugin.source || {};
+  if (source.source !== "github") {
+    fail(`Claude plugin ${plugin.name} must use source=github`);
+  }
+  if (!source.repo || !/^[^/]+\/[^/]+$/.test(source.repo)) {
+    fail(`Claude plugin ${plugin.name} has invalid source repo: ${source.repo}`);
+  }
+  return source.repo;
+}
+
+function assertNoDuplicates(kind, plugins) {
+  const counts = new Map();
+  for (const plugin of plugins) {
+    counts.set(plugin.name, (counts.get(plugin.name) || 0) + 1);
+  }
+  const duplicates = [...counts].filter(([, count]) => count > 1);
+  if (duplicates.length > 0) {
+    fail(
+      `${kind} marketplace has duplicate plugin names: ${duplicates
+        .map(([name]) => name)
+        .join(", ")}`
+    );
+  }
+}
+
+function assertRefs(kind, plugins) {
+  for (const plugin of plugins) {
+    if (!semverTag.test(plugin.source?.ref || "")) {
+      fail(
+        `${kind} plugin ${plugin.name} ref is not an explicit vX.Y.Z tag: ${plugin.source?.ref}`
+      );
+    }
+  }
+}
+
+function apiJson(repo, ref, path) {
+  const content = execFileSync(
+    "gh",
+    [
+      "api",
+      "-X",
+      "GET",
+      `repos/${repo}/contents/${path}`,
+      "-f",
+      `ref=${ref}`,
+      "--jq",
+      ".content"
+    ],
+    { encoding: "utf8" }
+  );
+  return JSON.parse(
+    Buffer.from(content.replace(/\s/g, ""), "base64").toString("utf8")
+  );
+}
+
+function assertRemoteManifest(plugin, repo, manifestPath, expectedVersion) {
+  const manifest = apiJson(repo, plugin.source.ref, manifestPath);
+  if (manifest.name !== plugin.name) {
+    fail(
+      `${repo}@${plugin.source.ref} ${manifestPath} name=${manifest.name}; expected ${plugin.name}`
+    );
+  }
+  if (manifest.version !== expectedVersion) {
+    fail(
+      `${repo}@${plugin.source.ref} ${manifestPath} version=${manifest.version}; expected ${expectedVersion}`
+    );
+  }
+}
+
+function assertRemotePackage(plugin, repo, expectedVersion) {
+  const pkg = apiJson(repo, plugin.source.ref, "package.json");
+  if (pkg.name !== plugin.name) {
+    fail(
+      `${repo}@${plugin.source.ref} package.json name=${pkg.name}; expected ${plugin.name}`
+    );
+  }
+  if (pkg.version !== expectedVersion) {
+    fail(
+      `${repo}@${plugin.source.ref} package.json version=${pkg.version}; expected ${expectedVersion}`
+    );
+  }
+}
+
+const codex = readJson(".agents/plugins/marketplace.json").plugins;
+const claude = readJson(".claude-plugin/marketplace.json").plugins;
+
+assertNoDuplicates("Codex", codex);
+assertNoDuplicates("Claude", claude);
+assertRefs("Codex", codex);
+assertRefs("Claude", claude);
+
+const codexByName = new Map(codex.map((plugin) => [plugin.name, plugin]));
+const claudeByName = new Map(claude.map((plugin) => [plugin.name, plugin]));
+
+for (const name of new Set([...codexByName.keys(), ...claudeByName.keys()])) {
+  const codexPlugin = codexByName.get(name);
+  const claudePlugin = claudeByName.get(name);
+  if (!codexPlugin || !claudePlugin) {
+    fail(`Plugin ${name} must be present in both Codex and Claude marketplaces`);
+  }
+
+  const codexRepo = normalizeCodexRepo(codexPlugin);
+  const claudeRepo = normalizeClaudeRepo(claudePlugin);
+  if (codexRepo !== claudeRepo) {
+    fail(
+      `Plugin ${name} repo mismatch: Codex=${codexRepo}, Claude=${claudeRepo}`
+    );
+  }
+  if (codexPlugin.source.ref !== claudePlugin.source.ref) {
+    fail(
+      `Plugin ${name} ref mismatch: Codex=${codexPlugin.source.ref}, Claude=${claudePlugin.source.ref}`
+    );
+  }
+
+  if (remote) {
+    const expectedVersion = codexPlugin.source.ref.match(semverTag)[1];
+    assertRemoteManifest(
+      codexPlugin,
+      codexRepo,
+      ".codex-plugin/plugin.json",
+      expectedVersion
+    );
+    assertRemoteManifest(
+      claudePlugin,
+      claudeRepo,
+      ".claude-plugin/plugin.json",
+      expectedVersion
+    );
+    assertRemotePackage(codexPlugin, codexRepo, expectedVersion);
+  }
+}
+
+console.log(`Marketplace validation passed for ${codex.length} plugin(s).`);


### PR DESCRIPTION
## Summary

- Remove the stale `using-github@v1.1.0` entries from both marketplace catalogs so only `using-github@v2.0.0` remains.
- Add marketplace validation for duplicate names, cross-manifest drift, tag refs, and upstream release manifest identity.
- Refresh README install guidance for `bootstrap`, `superteam`, and `using-github`, and run the validator from release-bump plus PR CI.

## Linked issue

- Closes #38

## Acceptance criteria

### AC-38-1

Both marketplace manifests now expose exactly one `using-github` entry, pinned to `v2.0.0`.

- [x] Codex/Claude catalog evidence — Codex CLI | local worktree | @tlmader | 2026-04-27T09:35:15Z
- [ ] Manual test: 1. Refresh the Patina Project marketplace in Codex and Claude Code. 2. Confirm only one `using-github` entry appears. 3. Install `using-github@patinaproject-skills`. 4. Confirm the installed skill is exposed as `using-github`.

### AC-38-2

The stale `using-github@v1.1.0` entries were removed, and remote validation confirms the remaining `v2.0.0` upstream Codex, Claude, and package manifests declare `using-github` version `2.0.0`.

- [x] Remote manifest evidence — Codex CLI | `pnpm validate:marketplace:remote` | @tlmader | 2026-04-27T09:35:15Z
- [ ] Manual test: 1. Inspect `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`. 2. Confirm no `using-github` entry references `v1.1.0`. 3. Confirm the only remaining `using-github` entries reference `v2.0.0`.

### AC-38-3

All supported marketplace configurations were reviewed and are now checked by `scripts/validate-marketplace.js`, release-bump validation, and PR validation.

- [x] Catalog audit evidence — Codex CLI | `pnpm validate:marketplace && actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml` | @tlmader | 2026-04-27T09:35:15Z
- [ ] Manual test: 1. Review `scripts/validate-marketplace.js`. 2. Confirm it checks duplicate names, explicit refs, repo/ref consistency, and upstream release manifest identity. 3. Confirm both `.github/workflows/lint-pr.yml` and `.github/workflows/plugin-release-bump.yml` invoke it.

### AC-38-4

Verification notes are recorded in the implementation plan and README guidance now names the current marketplace plugins and validation commands.

- [x] Documentation evidence — Codex CLI | `pnpm lint:md` | @tlmader | 2026-04-27T09:35:15Z
- [ ] Manual test: 1. Review `docs/superpowers/plans/2026-04-27-38-codex-fails-to-install-using-github-from-marketplace-plan.md`. 2. Confirm the verification evidence names the reviewed manifests, editor/config surfaces, validation commands, and old-identity scan.

## Validation

- `pnpm validate:marketplace`
- `pnpm validate:marketplace:remote`
- `pnpm lint:md`
- `actionlint .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml`
- `rg -n 'github-flows|patinaproject/github-flows' .agents .claude-plugin .claude README.md docs/release-flow.md .github/workflows/lint-pr.yml .github/workflows/plugin-release-bump.yml scripts package.json` returned no matches.

## Docs updated

- [x] Updated in this PR
