### PR TITLE
feat: #41 auto-merge release bump PRs

### DIFF
--- a/.github/workflows/plugin-release-bump.yml
+++ b/.github/workflows/plugin-release-bump.yml
@@ -110,6 +110,7 @@ jobs:
           echo "Implement once bootstrap defines its invocation entrypoint."
 
       - name: Create PR
+        id: cpr
         # peter-evans/create-pull-request@v8.1.1
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
@@ -125,3 +126,10 @@ jobs:
             - Tag: `${{ steps.inputs.outputs.tag }}`
             - Source repo: `${{ steps.inputs.outputs.repo }}`
           delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -13,11 +13,22 @@ Current member plugins tracked by this flow:
 1. A member plugin repo (for example `patinaproject/superteam`) uses `release-please` on its default branch. Merging the standing Release PR tags a new semver release and publishes a GitHub Release.
 2. A workflow in that plugin repo fires a `repository_dispatch` into `patinaproject/skills` with event type `plugin-released` and payload `{ plugin, tag, repo }`.
 3. [`.github/workflows/plugin-release-bump.yml`](../.github/workflows/plugin-release-bump.yml) receives the dispatch, updates both marketplace manifests, and opens a bot-generated bump PR titled `chore: bump <plugin> to <tag>`. These bot-generated `bot/bump-*` PRs are the only PRs that may omit an issue ID.
-4. A marketplace maintainer reviews and merges the PR. The new version becomes the one users get on install.
+4. The workflow requests GitHub auto-merge for the trusted bump PR after it is
+   created or updated. GitHub merges it only after required checks and branch
+   protection requirements pass. The new version becomes the one users get on
+   install.
 
 New plugins are added by the same flow: the workflow inserts an entry if the plugin isn't already listed, so the first tagged release of a plugin is also what publishes it.
 
 The release-bump PR workflow enables commit signing in `peter-evans/create-pull-request`, so commits are expected to be signed and verified as `github-actions[bot]` when the workflow uses the repository's default `GITHUB_TOKEN`. Do not switch this workflow to a PAT while expecting bot signature verification; PAT-created PRs are not the supported path for this signing mode.
+
+The workflow also enables GitHub auto-merge for release-bump PRs that it creates
+or updates from `bot/bump-*` branches. This uses
+`gh pr merge --auto --squash` against the PR number returned by
+`peter-evans/create-pull-request`; it does not use admin bypass and does not
+merge unrelated PRs. If repository auto-merge is disabled, token permissions are
+insufficient, required checks fail, or the PR contains unexpected changes,
+maintainers should inspect the open PR and resolve the blocker manually.
 
 ## Required setup in each member plugin repo
 

--- a/docs/superpowers/plans/2026-04-27-41-auto-merge-release-bump-prs-plan.md
+++ b/docs/superpowers/plans/2026-04-27-41-auto-merge-release-bump-prs-plan.md
@@ -1,0 +1,160 @@
+# Auto-Merge Release Bump PRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configure trusted plugin release-bump PRs to request GitHub native
+auto-merge after the existing workflow creates or updates them.
+
+**Architecture:** Keep the release-bump workflow as the single owner of bump PR
+creation and auto-merge enablement. Add a post-create-pull-request GitHub CLI
+step scoped to the PR number returned by the action, then document the
+maintainer-facing behavior in the release flow.
+
+**Tech Stack:** GitHub Actions YAML, GitHub CLI (`gh`), Markdown, `pnpm`
+repository scripts.
+
+---
+
+### Task 1: Add workflow auto-merge request
+
+**Files:**
+
+- Modify: `.github/workflows/plugin-release-bump.yml`
+
+- [ ] **Step 1: Add an id to the existing Create PR step**
+
+Edit the `Create PR` step so it has an `id` that later steps can reference:
+
+```yaml
+      - name: Create PR
+        id: cpr
+        # peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+```
+
+- [ ] **Step 2: Add the auto-merge step immediately after Create PR**
+
+Append this step after the existing `Create PR` `with:` block:
+
+```yaml
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash
+```
+
+This step must not include `--admin`, `continue-on-error`, `|| true`, or shell
+fallback logic that would hide a `gh pr merge` failure.
+
+- [ ] **Step 3: Inspect the workflow diff**
+
+Run:
+
+```bash
+git diff -- .github/workflows/plugin-release-bump.yml
+```
+
+Expected: the diff only adds `id: cpr` and the `Enable auto-merge` step. The
+new step is gated on `created` or `updated`, uses
+`steps.cpr.outputs.pull-request-number`, and calls
+`gh pr merge "$PR_NUMBER" --auto --squash`.
+
+### Task 2: Document release-flow behavior
+
+**Files:**
+
+- Modify: `docs/release-flow.md`
+
+- [ ] **Step 1: Update the lifecycle merge step**
+
+Replace lifecycle step 4 with:
+
+```markdown
+4. The workflow requests GitHub auto-merge for the trusted bump PR after it is
+   created or updated. GitHub merges it only after required checks and branch
+   protection requirements pass. The new version becomes the one users get on
+   install.
+```
+
+- [ ] **Step 2: Add maintainer fallback documentation**
+
+After the paragraph that starts `The release-bump PR workflow enables commit
+signing`, add:
+
+```markdown
+The workflow also enables GitHub auto-merge for release-bump PRs that it creates
+or updates from `bot/bump-*` branches. This uses `gh pr merge --auto --squash`
+against the PR number returned by `peter-evans/create-pull-request`; it does not
+use admin bypass and does not merge unrelated PRs. If repository auto-merge is
+disabled, token permissions are insufficient, required checks fail, or the PR
+contains unexpected changes, maintainers should inspect the open PR and resolve
+the blocker manually.
+```
+
+- [ ] **Step 3: Inspect the documentation diff**
+
+Run:
+
+```bash
+git diff -- docs/release-flow.md
+```
+
+Expected: the lifecycle no longer says a maintainer always reviews and merges
+every bump PR, and the new note documents `bot/bump-*`, `gh pr merge --auto
+--squash`, no admin bypass, and maintainer fallback cases.
+
+### Task 3: Verify and commit implementation
+
+**Files:**
+
+- Verify: `.github/workflows/plugin-release-bump.yml`
+- Verify: `docs/release-flow.md`
+- Verify: `docs/superpowers/specs/2026-04-27-41-auto-merge-release-bump-prs-design.md`
+- Verify: `docs/superpowers/plans/2026-04-27-41-auto-merge-release-bump-prs-plan.md`
+
+- [ ] **Step 1: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exits 0.
+
+- [ ] **Step 2: Run actionlint if available**
+
+Run:
+
+```bash
+if command -v actionlint >/dev/null 2>&1; then actionlint .github/workflows/plugin-release-bump.yml; else echo "actionlint not installed; inspected workflow manually"; fi
+```
+
+Expected: exits 0. If `actionlint` is not installed, the command prints the
+manual-inspection message and exits 0.
+
+- [ ] **Step 3: Inspect auto-merge safety constraints**
+
+Run:
+
+```bash
+rg -n -- '--admin|continue-on-error|\\|\\| true|pull-request-operation|pull-request-number|gh pr merge' .github/workflows/plugin-release-bump.yml
+```
+
+Expected: output includes `pull-request-operation`, `pull-request-number`, and
+`gh pr merge "$PR_NUMBER" --auto --squash`; output does not include `--admin`,
+`continue-on-error`, or `|| true`.
+
+- [ ] **Step 4: Commit the implementation**
+
+Run:
+
+```bash
+git add .github/workflows/plugin-release-bump.yml docs/release-flow.md docs/superpowers/plans/2026-04-27-41-auto-merge-release-bump-prs-plan.md
+git commit -m "feat: #41 auto-merge release bump PRs"
+```
+
+Expected: commit succeeds and contains the workflow, release-flow doc, and plan
+artifact changes.

--- a/docs/superpowers/specs/2026-04-27-41-auto-merge-release-bump-prs-design.md
+++ b/docs/superpowers/specs/2026-04-27-41-auto-merge-release-bump-prs-design.md
@@ -13,8 +13,15 @@ PR only updates pinned marketplace refs and generated bootstrap scaffolding.
   plugin release-bump workflow.
 - Keep auto-merge constrained to bot-generated `bot/bump-*` PRs that the
   workflow just created or updated.
+- Re-enable auto-merge when the workflow updates an existing bump PR, so the
+  release propagation path remains automatic after reruns or superseding bumps.
+- Include bootstrap release-bump PRs in the auto-merge path, including any
+  workflow-generated scaffold refreshes that land in those PRs.
 - Preserve branch protection and required checks; automation must request
   auto-merge, not bypass checks.
+- Fail with a clear, actionable workflow error if GitHub cannot enable
+  auto-merge, such as when repository-level auto-merge is disabled or token
+  permissions are insufficient.
 - Document the release flow so maintainers understand when bump PRs merge
   automatically and when they remain open.
 
@@ -73,6 +80,29 @@ auto-merge path behind required checks and branch protection. If checks are
 pending, GitHub CLI enables auto-merge for later completion; if checks fail,
 GitHub leaves the PR open.
 
+The auto-merge step should be intentionally loud on setup failures. If the
+repository has not enabled auto-merge, or if the default workflow token cannot
+enable auto-merge for the PR, the step should fail after the bump PR exists. The
+failure is useful because it tells maintainers that repository settings or token
+permissions must be corrected; silently continuing would leave the release flow
+looking automated while still requiring manual merges.
+
+The workflow should enable auto-merge for both newly created and updated bump
+PRs. If a maintainer manually disables auto-merge on an existing bump PR, a later
+workflow update may re-enable it. That is intentional for this issue because the
+trusted `bot/bump-*` branch remains owned by the release-bump workflow, and the
+desired release path is automatic whenever checks pass. Manual intervention
+remains available by closing the PR, fixing the workflow, or changing branch
+protection rather than relying on a disabled auto-merge toggle as persistent
+state.
+
+Bootstrap bump PRs are included in the same behavior. They can eventually carry
+both marketplace ref changes and bootstrap scaffolding refreshes, but the trust
+boundary is still the same release-bump workflow and protected-branch check set.
+If bootstrap-generated scaffold changes become too broad for automatic release
+propagation, that should be handled by a separate policy issue rather than a
+hidden carve-out in this implementation.
+
 The release-flow documentation should update the lifecycle step that currently
 says a maintainer reviews and merges the PR. It should instead say the workflow
 requests auto-merge for trusted bump PRs, while maintainers still inspect PRs
@@ -98,5 +128,8 @@ that fail checks, cannot enable auto-merge, or include unexpected changes.
 - Inspect `.github/workflows/plugin-release-bump.yml` to confirm auto-merge is
   gated on `pull-request-operation` being `created` or `updated` and uses the
   `pull-request-number` output.
+- Inspect the workflow to confirm it does not use `--admin`, does not suppress
+  `gh pr merge` failures, and therefore surfaces missing auto-merge settings or
+  token-permission problems.
 - Inspect `docs/release-flow.md` to confirm the release lifecycle documents the
   auto-merge constraints and maintainer fallback path.

--- a/docs/superpowers/specs/2026-04-27-41-auto-merge-release-bump-prs-design.md
+++ b/docs/superpowers/specs/2026-04-27-41-auto-merge-release-bump-prs-design.md
@@ -1,0 +1,102 @@
+# Auto-Merge Release Bump PRs
+
+## Problem
+
+The plugin release-bump workflow opens narrow bot-generated PRs after tagged
+member-plugin releases, but those PRs still require a maintainer to merge them
+after checks pass. That manual step slows marketplace propagation even when the
+PR only updates pinned marketplace refs and generated bootstrap scaffolding.
+
+## Goals
+
+- Enable auto-merge for trusted release-bump PRs produced by the existing
+  plugin release-bump workflow.
+- Keep auto-merge constrained to bot-generated `bot/bump-*` PRs that the
+  workflow just created or updated.
+- Preserve branch protection and required checks; automation must request
+  auto-merge, not bypass checks.
+- Document the release flow so maintainers understand when bump PRs merge
+  automatically and when they remain open.
+
+## Non-Goals
+
+- Auto-merge contributor PRs, arbitrary bot PRs, or PRs from untrusted branches.
+- Add admin bypass behavior or weaken branch protection.
+- Replace the existing `peter-evans/create-pull-request` release-bump PR
+  creation flow.
+- Configure repository settings outside this repository, such as enabling
+  repository-level auto-merge or changing required status checks.
+
+## Acceptance Criteria
+
+### AC-41-1
+
+Given a bot-generated release bump PR from a `bot/bump-*` branch, when all
+required checks and branch protection requirements pass, then the PR is
+automatically merged.
+
+### AC-41-2
+
+Given a release bump PR has failing or pending required checks, when the
+auto-merge path evaluates it, then the PR remains open until the checks pass.
+
+### AC-41-3
+
+Given a non-bump PR or a PR from an untrusted branch, when the auto-merge path
+evaluates it, then it is not automatically merged.
+
+### AC-41-4
+
+Given auto-merge is configured, when maintainers inspect the release flow
+documentation, then it documents the constraints and expected behavior.
+
+## Design
+
+Use GitHub's native pull request auto-merge through the GitHub CLI after
+`peter-evans/create-pull-request` finishes. The create-pull-request step should
+gain an `id`, and a following workflow step should run only when that action
+reports a PR was `created` or `updated`. The auto-merge step should call
+`gh pr merge <number> --auto --squash` using the action's
+`pull-request-number` output.
+
+This keeps trust boundaries simple. The workflow itself already controls the
+branch name with `branch: bot/bump-${{ steps.inputs.outputs.plugin }}-${{
+steps.inputs.outputs.tag }}` and only runs from the release-bump events. By
+keying auto-merge to the PR output from that same step, the workflow avoids
+searching for or modifying unrelated PRs. If the create-pull-request action
+finds no PR work to do, the auto-merge step is skipped.
+
+The merge method should be squash merge to match the repository's
+squash-and-merge conventions and PR-title-driven commit format. The command must
+not use `--admin`, because the desired behavior is to queue GitHub's regular
+auto-merge path behind required checks and branch protection. If checks are
+pending, GitHub CLI enables auto-merge for later completion; if checks fail,
+GitHub leaves the PR open.
+
+The release-flow documentation should update the lifecycle step that currently
+says a maintainer reviews and merges the PR. It should instead say the workflow
+requests auto-merge for trusted bump PRs, while maintainers still inspect PRs
+that fail checks, cannot enable auto-merge, or include unexpected changes.
+
+## Alternatives Considered
+
+1. **Enable auto-merge with `gh pr merge --auto --squash` in the existing
+   workflow**: recommended. It is small, uses GitHub's native protected-branch
+   behavior, and can be tightly scoped to the PR just created or updated.
+2. **Add a separate workflow that reacts to pull request events**: rejected for
+   this issue. It would need additional branch, actor, and payload filtering to
+   avoid touching unrelated PRs, while the existing workflow already has the
+   trusted PR number in hand.
+3. **Use admin merge or a privileged token to merge immediately**: rejected. The
+   issue asks for auto-merge after checks pass, not a bypass of branch
+   protection.
+
+## Verification
+
+- Run `pnpm lint:md`.
+- Run or inspect the workflow with `actionlint` if available.
+- Inspect `.github/workflows/plugin-release-bump.yml` to confirm auto-merge is
+  gated on `pull-request-operation` being `created` or `updated` and uses the
+  `pull-request-number` output.
+- Inspect `docs/release-flow.md` to confirm the release lifecycle documents the
+  auto-merge constraints and maintainer fallback path.


### PR DESCRIPTION
## Summary

- Adds an auto-merge step to the plugin release-bump workflow scoped to PRs created or updated by `peter-evans/create-pull-request`.
- Documents the trusted `bot/bump-*` auto-merge behavior and maintainer fallback cases.
- Adds Superteam design and plan artifacts for issue #41.

## Linked issue

- Closes #41

## Acceptance criteria

### AC-41-1

Trusted `bot/bump-*` release-bump PRs now request native GitHub auto-merge after the workflow creates or updates them.

- [x] Repository validation — local | macOS worktree | @tlmader | 2026-04-27T15:35:15Z

### AC-41-2

The workflow uses `gh pr merge --auto --squash` without `--admin`, so pending checks stay under GitHub auto-merge and failed checks leave the PR open.

- [x] Repository validation — local | macOS worktree | @tlmader | 2026-04-27T15:35:15Z

### AC-41-3

Auto-merge is scoped to the PR number returned by the release-bump workflow and only runs when that action reports `created` or `updated`.

- [x] Repository validation — local | macOS worktree | @tlmader | 2026-04-27T15:35:15Z

### AC-41-4

`docs/release-flow.md` documents auto-merge constraints, no admin bypass, and maintainer fallback cases.

- [x] Repository validation — local | macOS worktree | @tlmader | 2026-04-27T15:35:15Z

## Validation

- `pnpm lint:md`
- `actionlint .github/workflows/plugin-release-bump.yml`
- `rg -n -- '--admin|continue-on-error|\\|\\| true|pull-request-operation|pull-request-number|gh pr merge' .github/workflows/plugin-release-bump.yml`
- `git diff --check`

## Docs updated

- [x] Updated in this PR