### PR TITLE
feat: #63 add plan-ceo-review skill

### DIFF
--- a/.agents/skills/plan-ceo-review
+++ b/.agents/skills/plan-ceo-review
@@ -1,0 +1,1 @@
+../../skills/plan-ceo-review

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, superteam, using-github, office-hours",
+      "description": "Skills used by the Patina Project team — scaffold-repository, superteam, using-github, office-hours, plan-ceo-review",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,6 +4,7 @@
     "./skills/scaffold-repository",
     "./skills/superteam",
     "./skills/using-github",
-    "./skills/office-hours"
+    "./skills/office-hours",
+    "./skills/plan-ceo-review"
   ]
 }

--- a/.claude/skills/plan-ceo-review
+++ b/.claude/skills/plan-ceo-review
@@ -1,0 +1,1 @@
+../../skills/plan-ceo-review

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,6 +5,7 @@
     "./skills/scaffold-repository",
     "./skills/superteam",
     "./skills/using-github",
-    "./skills/office-hours"
+    "./skills/office-hours",
+    "./skills/plan-ceo-review"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,9 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The two standalone skills (`find-skills`, `office-hours`) are not release-please packages.
-Consumers install them from the default branch or a specific `#<git-ref>`.
+The five in-repo skills share the single root `patinaproject-skills` release and tag;
+they are not separate release-please packages. Third-party skills such as `find-skills`
+are installed separately from their source repo's default branch or a specific `#<git-ref>`.
 
 Merging a Release PR tags the commit and publishes a GitHub Release. The workflow also
 auto-merges Release PRs after required checks pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/superteam/`: superteam skill
 - `skills/using-github/`: using-github skill
 - `skills/office-hours/`: office-hours skill
+- `skills/plan-ceo-review/`: plan-ceo-review skill
 - `.agents/skills/<name>/`: symlinks into `../../skills/<name>/` (dogfood overlay)
 - `.claude/skills/<name>/`: symlinks into `../../skills/<name>/` (Claude Code overlay)
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all 4 skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all five skill paths
 - `docs/`: contributor docs plus planning artifacts; use paths such as `docs/file-structure.md`,
   `docs/release-flow.md`, and, when present, `docs/superpowers/`
 - If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
@@ -30,10 +31,10 @@ following acceptance criteria format:
 - `pnpm commit`: create a guided conventional commit with issue tagging
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
-- `pnpm verify:dogfood`: assert all four in-repo skills are discoverable via flat layout
+- `pnpm verify:dogfood`: assert all five in-repo skills are discoverable via flat layout
 - `pnpm verify:marketplace`: assert `.claude-plugin/` catalog is valid
 - `pnpm apply:scaffold-repository:check`: assert scaffolding is in sync (exit 0)
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the four skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the five skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -46,7 +47,7 @@ following acceptance criteria format:
 ## Testing Guidelines
 
 - Validate paths with `find` or `rg`
-- Run `bash scripts/verify-dogfood.sh` to confirm all four in-repo skills pass the flat-layout check
+- Run `bash scripts/verify-dogfood.sh` to confirm all five in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
 - Run `node scripts/apply-scaffold-repository.js skills/scaffold-repository --check` to
   confirm the scaffold baseline is idempotent against the current tree
@@ -104,8 +105,9 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns four skills at flat paths: `skills/scaffold-repository/`,
-`skills/superteam/`, `skills/using-github/`, and `skills/office-hours/`.
+This repo owns five skills at flat paths: `skills/scaffold-repository/`,
+`skills/superteam/`, `skills/using-github/`, `skills/office-hours/`, and
+`skills/plan-ceo-review/`.
 `find-skills` is a third-party skill from `vercel-labs/skills` and is not
 a marketplace entry in this repo.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Skills used by the Patina Project team
 
-Four installable agent skills for repository scaffolding, multi-teammate
-orchestration, GitHub workflows, and product design — available
+Five installable agent skills for repository scaffolding, multi-teammate
+orchestration, GitHub workflows, product design, and strategic plan review — available
 across Claude Code, Codex, and any agent runtime that reads `AGENTS.md`.
 
 ## Quickstart
@@ -81,6 +81,17 @@ hackathons and side projects. Output is always a design doc, never code.
 See [./skills/office-hours/](./skills/office-hours/)
 for the skill contract.
 
+### plan-ceo-review
+
+Plans need a different kind of pressure test once the idea has turned into a
+proposed course of action. `plan-ceo-review` gives an existing plan a
+CEO/founder-mode review: should it expand, selectively expand, hold, or reduce?
+It challenges ambition, user value, sequencing, and opportunity cost, then
+returns a concrete recommendation and smallest next move.
+
+See [./skills/plan-ceo-review/](./skills/plan-ceo-review/)
+for the skill contract.
+
 ### scaffold-repository
 
 Teams spend disproportionate time on repo plumbing — commit conventions,
@@ -101,6 +112,7 @@ for the full README and skill contract.
 | [superteam](./skills/superteam/) | Orchestrate a GitHub issue from design through merged PR |
 | [using-github](./skills/using-github/) | Patina Project GitHub workflow conventions |
 | [office-hours](./skills/office-hours/) | YC-style design partner; runs forcing questions |
+| [plan-ceo-review](./skills/plan-ceo-review/) | Founder-mode review for existing plans |
 | [scaffold-repository](./skills/scaffold-repository/) | Scaffold a new repository to the Patina Project baseline |
 
 ## Local iteration
@@ -121,7 +133,7 @@ npx skills@latest add ./skills/office-hours --list
 node scripts/apply-scaffold-repository.js skills/scaffold-repository --check
 ```
 
-### Check c — dogfood verification, all four skills
+### Check c — dogfood verification, all five skills
 
 ```sh
 bash scripts/verify-dogfood.sh
@@ -135,6 +147,7 @@ skills/
   superteam/
   using-github/
   office-hours/
+  plan-ceo-review/
 .agents/skills/<name>/               Symlinks to ../../skills/<name>/
 .claude/skills/<name>/               Symlinks to ../../skills/<name>/
 .claude-plugin/

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,7 +1,7 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and related install
-documentation. Four skills live under `skills/<name>/` in a flat layout.
+documentation. Five skills live under `skills/<name>/` in a flat layout.
 
 ## Top level
 
@@ -9,10 +9,11 @@ documentation. Four skills live under `skills/<name>/` in a flat layout.
 - `skills/superteam/`: superteam skill
 - `skills/using-github/`: using-github skill
 - `skills/office-hours/`: office-hours skill
-- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (four in-repo)
-- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (four in-repo)
+- `skills/plan-ceo-review/`: plan-ceo-review skill
+- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (five in-repo)
+- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (five in-repo)
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all 4 skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all five skill paths
 - `skills-lock.json`: vercel-labs CLI install lockfile (auto-generated; commit it)
 - `docs/`: contributor-facing docs for skill maintenance
 - `package.json`, `commitizen.config.js`, `commitlint.config.js`: repo tooling
@@ -22,7 +23,7 @@ documentation. Four skills live under `skills/<name>/` in a flat layout.
 
 ## Flat skill layout
 
-Four skills are owned by this repository:
+Five skills are owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
@@ -30,6 +31,7 @@ Four skills are owned by this repository:
 | `superteam` | `skills/superteam/` | Issue-driven orchestration |
 | `using-github` | `skills/using-github/` | GitHub workflow skill |
 | `office-hours` | `skills/office-hours/` | YC-style office hours for product ideation |
+| `plan-ceo-review` | `skills/plan-ceo-review/` | Founder-mode review for existing plans |
 
 `find-skills` is a third-party vendored skill from `vercel-labs/skills`. It is installed
 via the vercel-labs CLI and is not owned by this repository. Install with:
@@ -45,7 +47,7 @@ install-block reframes.
 
 ## Dogfood overlay layout
 
-The four in-repo skills are also accessible through two overlay directories via one-hop
+The five in-repo skills are also accessible through two overlay directories via one-hop
 committed symlinks:
 
 | Overlay path | Symlink target | Mode |
@@ -56,7 +58,7 @@ committed symlinks:
 These symlinks allow the agent runtime to discover the in-repo skills alongside any
 third-party skills installed by the vercel-labs CLI.
 
-Third-party CLI-installed skills (including `find-skills`) are untracked; only the four
+Third-party CLI-installed skills (including `find-skills`) are untracked; only the five
 in-repo overlay symlinks are committed.
 
 ## Symlink hygiene

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,9 +3,10 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Four in-repo skills ship as
-`patinaproject-skills`: `scaffold-repository`, `superteam`, `using-github`, `office-hours`.
-All four are versioned together as a single marketplace surface. On each release,
+Skills live flat at `skills/<name>/` in this repo. Five in-repo skills ship as
+`patinaproject-skills`: `scaffold-repository`, `superteam`, `using-github`,
+`office-hours`, `plan-ceo-review`. All five are versioned together as a single
+marketplace surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
 `patinaproject-skills`; install it separately from `vercel-labs/skills` (see root README).
@@ -100,7 +101,7 @@ items are not applied by the self-apply script:
 
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
-- Standalone skills (`office-hours`, `find-skills`) are not release-please packages.
+- Standalone skills (`office-hours`, `plan-ceo-review`, `find-skills`) are not release-please packages.
   They are installed from the default branch or a specific `#<git-ref>`.
 - `skills-lock.json` must be committed after any `npx skills add` invocation. The lockfile
   records provenance for vercel-labs CLI-managed installs.

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -101,8 +101,10 @@ items are not applied by the self-apply script:
 
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
-- Standalone skills (`office-hours`, `plan-ceo-review`, `find-skills`) are not release-please packages.
-  They are installed from the default branch or a specific `#<git-ref>`.
+- In-repo skills (`scaffold-repository`, `superteam`, `using-github`, `office-hours`,
+  `plan-ceo-review`) are not separate release-please packages; they share the single root
+  `patinaproject-skills` release and tag. Third-party skills such as `find-skills` are
+  installed separately from their source repo's default branch or a specific `#<git-ref>`.
 - `skills-lock.json` must be committed after any `npx skills add` invocation. The lockfile
   records provenance for vercel-labs CLI-managed installs.
 

--- a/docs/superpowers/plans/2026-05-13-63-create-an-independent-ceo-plan-review-skill-plan.md
+++ b/docs/superpowers/plans/2026-05-13-63-create-an-independent-ceo-plan-review-skill-plan.md
@@ -1,0 +1,252 @@
+# Create an Independent CEO Plan Review Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` if available, or the resolved `superteam` execute mode. Implement task-by-task. Do not treat this plan as approval to change `superteam` gates.
+
+**Goal:** Add the fifth Patina-owned flat skill, `plan-ceo-review`, and make it discoverable across Claude, Codex, local dogfood overlays, and repository documentation.
+
+**Approved design:** `docs/superpowers/specs/2026-05-13-63-create-an-independent-ceo-plan-review-skill-design.md`
+
+**Architecture:** Add one concise, original Markdown skill at `skills/plan-ceo-review/SKILL.md`. Then update all manifest, marketplace, dogfood, and documentation surfaces that enumerate in-repo skills from four to five. Keep `plan-ceo-review` advisory: it reviews plans, but it does not replace `office-hours`, `Planner`, `Reviewer`, or any `superteam` gate.
+
+**Out of scope:** Do not add scripts beyond updating existing verification. Do not add runtime state, telemetry, local sessions, generated preambles, or upstream-branded behavior. Do not copy, vendor, paraphrase section-by-section, or mechanically translate the upstream inspiration.
+
+---
+
+## Workstreams
+
+### W1 — Author the `plan-ceo-review` Skill
+
+**Goal:** Create the new flat skill with original Patina-native CEO/founder review behavior. Covers AC-63-1, AC-63-2, and AC-63-3.
+
+**Files:**
+
+- Create: `skills/plan-ceo-review/SKILL.md`
+
+**Tasks:**
+
+- [ ] Create `skills/plan-ceo-review/SKILL.md` with YAML frontmatter:
+  - `name: plan-ceo-review`
+  - `description:` includes the discoverability triggers `CEO review`, `founder-mode review`, `think bigger`, `strategy review`, `rethink this plan`, and `is this ambitious enough`.
+- [ ] Use the approved section shape:
+  - `# CEO Plan Review`
+  - `## When to Use`
+  - `## When Not to Use`
+  - `## Inputs`
+  - `## Review Modes`
+  - `## Workflow`
+  - `## Output`
+  - `## Red Flags`
+- [ ] Define the four review modes and make each mode behaviorally distinct:
+  - `Expand`
+  - `Selectively expand`
+  - `Hold`
+  - `Reduce`
+- [ ] Cover the required review dimensions:
+  - Ambition: meaningful outcome versus local improvement.
+  - Scope: expand, selectively expand, hold, or reduce.
+  - User value: beneficiary, changed workflow, and validating proof.
+  - Sequencing: first move, later moves, and decision gates.
+  - Risks: premise, product, execution, and opportunity cost.
+  - Recommended next steps: decision, smallest next move, and evidence that would change the recommendation.
+- [ ] Include an output template with these sections:
+  - `Verdict`
+  - `Premise check`
+  - `Ambition check`
+  - `Scope decision`
+  - `User value`
+  - `Sequencing`
+  - `Risks`
+  - `Recommendation`
+- [ ] State the routing boundary:
+  - If the user has only an idea and no plan, ask for a plan or route to `office-hours`.
+  - Inside `superteam`, this skill is advisory and cannot approve Gate 1, replace Planner, replace Reviewer, or alter Finisher shutdown.
+- [ ] Keep the skill concise, targeting 150-350 lines and avoiding long sample reports.
+- [ ] Run the independence check before leaving W1:
+
+```bash
+rg -n "gstack|~/.gstack|gbrain|telemetry|analytics|update-check|session" skills/plan-ceo-review/SKILL.md
+```
+
+Expected: no matches. If the word `session` appears only as ordinary prose, remove or rephrase it to keep the forbidden-string check clean.
+
+**Commit:** `feat: #63 add plan-ceo-review skill`
+
+### W2 — Wire Claude and Codex Marketplace Surfaces
+
+**Goal:** Make both host plugin manifests expose the same five skills in the same order, and update marketplace descriptions that enumerate included skills. Covers AC-63-4.
+
+**Files:**
+
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.codex-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `.agents/plugins/marketplace.json` only if its description or metadata enumerates included skills at implementation time
+
+**Tasks:**
+
+- [ ] Add `./skills/plan-ceo-review` to `.claude-plugin/plugin.json`.
+- [ ] Add `./skills/plan-ceo-review` to `.codex-plugin/plugin.json`.
+- [ ] Keep Claude and Codex `skills[]` arrays byte-for-byte equal in order:
+  - `./skills/scaffold-repository`
+  - `./skills/superteam`
+  - `./skills/using-github`
+  - `./skills/office-hours`
+  - `./skills/plan-ceo-review`
+- [ ] Update `.claude-plugin/marketplace.json` because it currently enumerates the included skills in `plugins[0].description`; append `plan-ceo-review`.
+- [ ] Inspect `.agents/plugins/marketplace.json`. If it still does not enumerate skill names, leave it unchanged. If another worker has added an enumerated description before Executor reaches this task, update it to include `plan-ceo-review`.
+- [ ] Use JSON tooling or careful formatting so the files stay valid and minimally changed.
+
+**Commit:** `feat: #63 expose plan-ceo-review in plugin manifests`
+
+### W3 — Add Dogfood Overlay Symlinks and Verification Count
+
+**Goal:** Make local dogfood discovery prove all five in-repo skills resolve to their flat canonical homes. Covers AC-63-4 and AC-63-5.
+
+**Files:**
+
+- Create symlink: `.agents/skills/plan-ceo-review` -> `../../skills/plan-ceo-review`
+- Create symlink: `.claude/skills/plan-ceo-review` -> `../../skills/plan-ceo-review`
+- Modify: `scripts/verify-dogfood.sh`
+
+**Tasks:**
+
+- [ ] Create both overlay symlinks with the same relative target used by the existing four in-repo skills:
+
+```bash
+ln -s ../../skills/plan-ceo-review .agents/skills/plan-ceo-review
+ln -s ../../skills/plan-ceo-review .claude/skills/plan-ceo-review
+```
+
+- [ ] Update `scripts/verify-dogfood.sh` comments and final success message from four to five in-repo skills.
+- [ ] Add `plan-ceo-review` to the `SKILLS` array after `office-hours`.
+- [ ] Preserve the existing flat-layout and frontmatter-name assertions.
+- [ ] Run:
+
+```bash
+pnpm verify:dogfood
+```
+
+Expected: exits 0 and reports all five in-repo skills discoverable.
+
+**Commit:** `test: #63 verify five dogfood skills`
+
+### W4 — Update Repository Documentation and Cross-References
+
+**Goal:** Keep user-facing and contributor-facing skill lists coherent after the fifth skill lands. Covers AC-63-4's discoverability intent and resolves the design's README / `office-hours` open question.
+
+**Decision:** Update the root README and contributor docs in this issue. Add only a small `office-hours` cross-reference if it can be done without expanding `office-hours` behavior.
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/release-flow.md`
+- Modify: `scripts/install-third-party-skills.sh` comments only if they still say four in-repo skills
+- Modify: `skills/office-hours/SKILL.md` only for a one-sentence `plan-ceo-review` cross-reference; skip if the edit would require reorganizing the skill
+
+**Tasks:**
+
+- [ ] Update `README.md`:
+  - Opening count from four to five.
+  - Add a `plan-ceo-review` section under "Why these skills exist".
+  - Add a `plan-ceo-review` row to the skills table.
+  - Change "dogfood verification, all four skills" to five.
+  - Add `plan-ceo-review/` to the repository layout block.
+- [ ] Update `AGENTS.md`:
+  - Add `skills/plan-ceo-review/` to project structure.
+  - Change all "four in-repo skills" and "all 4 skill paths" guidance to five where it refers to the current repository-owned skill set.
+  - Add `skills/plan-ceo-review/` to the "Skill Releases" flat-path list.
+  - Preserve the existing note that `find-skills` is third-party.
+- [ ] Update `docs/release-flow.md` where it enumerates the released in-repo skill set.
+- [ ] Inspect `scripts/install-third-party-skills.sh` comments. If they still describe four in-repo `patinaproject-skills`, update the comments to five. Do not change behavior.
+- [ ] Add a one-sentence cross-reference in `skills/office-hours/SKILL.md` only if there is a natural "when not to use" or routing location: use `plan-ceo-review` when the user already has a plan to critique. Do not make `office-hours` call `plan-ceo-review` or change its output contract.
+- [ ] Search for stale current-count text outside historical design and plan artifacts:
+
+```bash
+rg -n "four|4 skill|all four|five|5 skill|plan-ceo-review" AGENTS.md README.md docs scripts skills .claude-plugin .codex-plugin .agents/plugins
+```
+
+Expected: current docs and scripts describe five in-repo skills; historical artifacts may preserve prior issue context.
+
+**Commit:** `docs: #63 document plan-ceo-review skill`
+
+### W5 — Final Verification and Handoff
+
+**Goal:** Prove all acceptance criteria before handing to Reviewer. Covers AC-63-1 through AC-63-5.
+
+**Tasks:**
+
+- [ ] Run required verification:
+
+```bash
+pnpm verify:dogfood
+pnpm verify:marketplace
+find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort
+```
+
+- [ ] Confirm the `find` output is exactly:
+
+```text
+skills/office-hours/SKILL.md
+skills/plan-ceo-review/SKILL.md
+skills/scaffold-repository/SKILL.md
+skills/superteam/SKILL.md
+skills/using-github/SKILL.md
+```
+
+- [ ] Re-run the forbidden-coupling check:
+
+```bash
+rg -n "gstack|~/.gstack|gbrain|telemetry|analytics|update-check|session" skills/plan-ceo-review/SKILL.md
+```
+
+Expected: no matches.
+
+- [ ] Confirm plugin manifest parity:
+
+```bash
+jq -c '.skills' .claude-plugin/plugin.json
+jq -c '.skills' .codex-plugin/plugin.json
+```
+
+Expected: identical five-entry arrays in the W2 order.
+
+- [ ] Check final status:
+
+```bash
+git status --short
+git log --oneline --decorate -5
+```
+
+- [ ] Commit any verification-only documentation touch-ups if needed. Do not commit generated logs.
+- [ ] Handoff to Reviewer with:
+  - completed task IDs or workstreams,
+  - verification command outcomes,
+  - current HEAD SHA,
+  - known residual risk, if any.
+
+**Commit:** Only create a W5 commit if final verification requires a tracked fix.
+
+---
+
+## Acceptance Criteria Coverage
+
+- `AC-63-1`: W1 creates `skills/plan-ceo-review/SKILL.md` with YAML metadata and discoverability triggers.
+- `AC-63-2`: W1 and W5 enforce independence from upstream-branded commands, local state, telemetry, analytics, update checks, and forbidden strings.
+- `AC-63-3`: W1 defines the CEO/founder review process, modes, required dimensions, risks, and next-step recommendation.
+- `AC-63-4`: W2, W3, and W4 update plugin manifests, marketplace descriptions that enumerate skills, dogfood symlinks, `verify-dogfood`, and repository docs.
+- `AC-63-5`: W3 and W5 run required verification and confirm exactly five flat `SKILL.md` entry points.
+
+## Risks and Blockers
+
+- No active blockers.
+- Main risk: accidental upstream coupling in the new skill prose. Mitigation: W1 and W5 forbidden-string checks plus Reviewer independence review.
+- Main discoverability risk: a stale "four skills" reference in docs or scripts. Mitigation: W4 repository-wide search and targeted updates outside historical artifacts.
+- Main workflow risk: presenting CEO review as a `superteam` approval gate. Mitigation: W1 requires explicit advisory-only language and W4 keeps `office-hours` cross-reference narrow.
+
+## Executor Notes
+
+- Preserve unrelated edits if the worktree is dirty when execution starts.
+- Use `apply_patch` or normal symlink commands for focused edits; do not reformat unrelated JSON or Markdown.
+- Keep commits conventional and issue-tagged.
+- Do not push or open a PR from the Executor role.

--- a/docs/superpowers/specs/2026-05-13-63-create-an-independent-ceo-plan-review-skill-design.md
+++ b/docs/superpowers/specs/2026-05-13-63-create-an-independent-ceo-plan-review-skill-design.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-Create a new Patina-owned `ceo-plan-review` skill at `skills/ceo-plan-review/SKILL.md`. The skill gives an agent a founder-mode review process for product, strategy, and implementation plans: challenge the premise, test ambition, decide whether to expand or reduce scope, and return a concrete recommendation with next steps. It may cite the upstream gstack plan review skill as inspiration in planning notes, but the implementation must be original and must not depend on gstack commands, runtime checks, telemetry, local state, generated preambles, branding, or file layout.
+Create a new Patina-owned `plan-ceo-review` skill at `skills/plan-ceo-review/SKILL.md`. The skill gives an agent a founder-mode review process for product, strategy, and implementation plans: challenge the premise, test ambition, decide whether to expand or reduce scope, and return a concrete recommendation with next steps. It may cite the upstream gstack plan review skill as inspiration in planning notes, but the implementation must be original and must not depend on gstack commands, runtime checks, telemetry, local state, generated preambles, branding, or file layout.
 
-The skill should feel adjacent to `office-hours` but not duplicate it. `office-hours` helps discover whether an idea is worth building before code. `ceo-plan-review` reviews an existing plan and pressure-tests whether it is ambitious enough, focused enough, sequenced well, and valuable enough to justify the work. It should also be usable inside `superteam` as a strategy review surface before or after a plan exists, without changing `superteam` gates.
+The skill should feel adjacent to `office-hours` but not duplicate it. `office-hours` helps discover whether an idea is worth building before code. `plan-ceo-review` reviews an existing plan and pressure-tests whether it is ambitious enough, focused enough, sequenced well, and valuable enough to justify the work. It should also be usable inside `superteam` as a strategy review surface before or after a plan exists, without changing `superteam` gates.
 
 ## Goals
 
-- Add a fifth in-repo flat skill named `ceo-plan-review`.
+- Add a fifth in-repo flat skill named `plan-ceo-review`.
 - Provide an original Patina-native workflow for reviewing plans from a CEO/founder perspective.
 - Cover ambition, scope, user value, sequencing, risk, and next steps.
 - Include clear mode selection for expanding scope, selectively expanding scope, holding scope, and reducing scope.
@@ -20,14 +20,14 @@ The skill should feel adjacent to `office-hours` but not duplicate it. `office-h
 - Do not copy, vendor, paraphrase section-by-section, or mechanically translate the gstack skill.
 - Do not add gstack-specific commands, telemetry, config files, analytics writes, session files, generated preambles, update checks, or local state paths.
 - Do not change `superteam` orchestration gates or treat CEO review as approval for any existing `superteam` gate.
-- Do not turn `ceo-plan-review` into customer discovery. If the user has no plan yet, route them to `office-hours`.
+- Do not turn `plan-ceo-review` into customer discovery. If the user has no plan yet, route them to `office-hours`.
 - Do not add scripts unless implementation proves deterministic automation is needed. The first version should be a lean Markdown skill.
 
 ## Acceptance Criteria
 
 ### AC-63-1
 
-A new Patina-owned skill exists at a flat `skills/ceo-plan-review/SKILL.md` path with YAML metadata and original workflow instructions. The `description` must include trigger language such as "CEO review", "founder-mode review", "think bigger", "strategy review", "rethink this plan", and "is this ambitious enough" so the skill is discoverable when users ask for strategic plan critique.
+A new Patina-owned skill exists at a flat `skills/plan-ceo-review/SKILL.md` path with YAML metadata and original workflow instructions. The `description` must include trigger language such as "CEO review", "founder-mode review", "think bigger", "strategy review", "rethink this plan", and "is this ambitious enough" so the skill is discoverable when users ask for strategic plan critique.
 
 ### AC-63-2
 
@@ -48,10 +48,10 @@ The skill gives agents a practical CEO/founder-mode review process covering:
 
 Marketplace and dogfood surfaces are updated so the new skill is discoverable with the other in-repo skills:
 
-- `.claude-plugin/plugin.json` includes `./skills/ceo-plan-review`.
+- `.claude-plugin/plugin.json` includes `./skills/plan-ceo-review`.
 - `.codex-plugin/plugin.json` includes the same skill path in the same order as Claude.
-- `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` descriptions mention `ceo-plan-review` if they enumerate included skills.
-- `.agents/skills/ceo-plan-review` and `.claude/skills/ceo-plan-review` symlink to `../../skills/ceo-plan-review`.
+- `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` descriptions mention `plan-ceo-review` if they enumerate included skills.
+- `.agents/skills/plan-ceo-review` and `.claude/skills/plan-ceo-review` symlink to `../../skills/plan-ceo-review`.
 - `scripts/verify-dogfood.sh` treats the repository as owning five in-repo skills.
 
 ### AC-63-5
@@ -93,7 +93,7 @@ The first implementation should be a single `SKILL.md` plus optional host metada
 Recommended `SKILL.md` shape:
 
 1. YAML frontmatter:
-   - `name: ceo-plan-review`
+   - `name: plan-ceo-review`
    - `description:` one concise paragraph naming when to use it and its trigger phrases.
 2. `# CEO Plan Review`
 3. `## When to Use`
@@ -108,9 +108,9 @@ Keep the skill body under roughly 350 lines. The body should contain enough exam
 
 ## Integration Notes
 
-`office-hours` relationship: `office-hours` remains the pre-plan idea interrogation skill. `ceo-plan-review` should say to use `office-hours` when the user has only an idea, no plan, or no evidence of demand. `office-hours` does not need to call `ceo-plan-review` in this issue unless the Executor finds a small cross-reference worthwhile and low risk.
+`office-hours` relationship: `office-hours` remains the pre-plan idea interrogation skill. `plan-ceo-review` should say to use `office-hours` when the user has only an idea, no plan, or no evidence of demand. `office-hours` does not need to call `plan-ceo-review` in this issue unless the Executor finds a small cross-reference worthwhile and low risk.
 
-`superteam` relationship: `ceo-plan-review` can review a spec or plan, but it does not approve Gate 1, replace Planner, bypass Reviewer, or alter Finisher shutdown. If `superteam` uses it later, it should be an advisory review surface whose findings route through the existing teammate owner for spec-level, plan-level, or implementation-level feedback.
+`superteam` relationship: `plan-ceo-review` can review a spec or plan, but it does not approve Gate 1, replace Planner, bypass Reviewer, or alter Finisher shutdown. If `superteam` uses it later, it should be an advisory review surface whose findings route through the existing teammate owner for spec-level, plan-level, or implementation-level feedback.
 
 Marketplace relationship: this repository currently validates both Claude and Codex plugin manifests and the dogfood symlink overlays. Adding the skill requires updating all surfaces that enumerate in-repo skills, including verification scripts whose messages still say "four".
 
@@ -127,7 +127,7 @@ RED baseline for implementation:
 
 GREEN target:
 
-- `skills/ceo-plan-review/SKILL.md` exists and has `name: ceo-plan-review`.
+- `skills/plan-ceo-review/SKILL.md` exists and has `name: plan-ceo-review`.
 - All marketplace and dogfood enumerations include the fifth skill.
 - Verification scripts pass without special casing.
 - The skill runs as standalone instructions with no external runtime dependency.
@@ -144,7 +144,7 @@ Implementation must resist these shortcuts:
 
 ### Red Flags
 
-- Any occurrence of `gstack`, `~/.gstack`, `gbrain`, `telemetry`, `analytics`, `session`, or `update-check` inside `skills/ceo-plan-review/SKILL.md`, except if a verification comment explicitly names forbidden strings.
+- Any occurrence of `gstack`, `~/.gstack`, `gbrain`, `telemetry`, `analytics`, `session`, or `update-check` inside `skills/plan-ceo-review/SKILL.md`, except if a verification comment explicitly names forbidden strings.
 - The skill asks broad discovery questions when the user already supplied a plan, instead of reviewing the plan.
 - The output is neutral when a clear scope decision is needed.
 - The review mode names exist but do not change behavior.
@@ -170,7 +170,7 @@ Implementation must resist these shortcuts:
 
 ### Stage-Gate Bypass Paths
 
-The implementation must not use `ceo-plan-review` to bypass existing workflow gates:
+The implementation must not use `plan-ceo-review` to bypass existing workflow gates:
 
 - It does not replace `office-hours` discovery when no plan exists.
 - It does not replace `superteam` Brainstormer approval.
@@ -191,15 +191,15 @@ find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort
 Executor should also inspect the new skill for forbidden gstack coupling:
 
 ```bash
-rg -n "gstack|~/.gstack|gbrain|telemetry|analytics|update-check|session" skills/ceo-plan-review/SKILL.md
+rg -n "gstack|~/.gstack|gbrain|telemetry|analytics|update-check|session" skills/plan-ceo-review/SKILL.md
 ```
 
 The expected result is no matches, unless the final implementation intentionally places a forbidden-string check outside the skill body.
 
 ## Open Questions
 
-- Should the root README's skill table mention `ceo-plan-review` in this issue? The acceptance criteria do not require it, but the repository currently uses the README as a user-facing skill index. Planner should decide whether to include it as part of discoverability.
-- Should `office-hours` include a small "use `ceo-plan-review` when a plan already exists" cross-reference? This is useful but not required by the issue.
+- Should the root README's skill table mention `plan-ceo-review` in this issue? The acceptance criteria do not require it, but the repository currently uses the README as a user-facing skill index. Planner should decide whether to include it as part of discoverability.
+- Should `office-hours` include a small "use `plan-ceo-review` when a plan already exists" cross-reference? This is useful but not required by the issue.
 - Should the marketplace description list every included skill or stay generic? If it lists skills, it must include the new one.
 
 ## Adversarial Review

--- a/docs/superpowers/specs/2026-05-13-63-create-an-independent-ceo-plan-review-skill-design.md
+++ b/docs/superpowers/specs/2026-05-13-63-create-an-independent-ceo-plan-review-skill-design.md
@@ -1,0 +1,218 @@
+# Design: Create an independent CEO plan review skill [#63](https://github.com/patinaproject/skills/issues/63)
+
+## Summary
+
+Create a new Patina-owned `ceo-plan-review` skill at `skills/ceo-plan-review/SKILL.md`. The skill gives an agent a founder-mode review process for product, strategy, and implementation plans: challenge the premise, test ambition, decide whether to expand or reduce scope, and return a concrete recommendation with next steps. It may cite the upstream gstack plan review skill as inspiration in planning notes, but the implementation must be original and must not depend on gstack commands, runtime checks, telemetry, local state, generated preambles, branding, or file layout.
+
+The skill should feel adjacent to `office-hours` but not duplicate it. `office-hours` helps discover whether an idea is worth building before code. `ceo-plan-review` reviews an existing plan and pressure-tests whether it is ambitious enough, focused enough, sequenced well, and valuable enough to justify the work. It should also be usable inside `superteam` as a strategy review surface before or after a plan exists, without changing `superteam` gates.
+
+## Goals
+
+- Add a fifth in-repo flat skill named `ceo-plan-review`.
+- Provide an original Patina-native workflow for reviewing plans from a CEO/founder perspective.
+- Cover ambition, scope, user value, sequencing, risk, and next steps.
+- Include clear mode selection for expanding scope, selectively expanding scope, holding scope, and reducing scope.
+- Make the skill discoverable from Claude, Codex, and local dogfood overlays.
+- Keep the skill concise enough to load cheaply while still carrying strong review behavior.
+
+## Non-Goals
+
+- Do not copy, vendor, paraphrase section-by-section, or mechanically translate the gstack skill.
+- Do not add gstack-specific commands, telemetry, config files, analytics writes, session files, generated preambles, update checks, or local state paths.
+- Do not change `superteam` orchestration gates or treat CEO review as approval for any existing `superteam` gate.
+- Do not turn `ceo-plan-review` into customer discovery. If the user has no plan yet, route them to `office-hours`.
+- Do not add scripts unless implementation proves deterministic automation is needed. The first version should be a lean Markdown skill.
+
+## Acceptance Criteria
+
+### AC-63-1
+
+A new Patina-owned skill exists at a flat `skills/ceo-plan-review/SKILL.md` path with YAML metadata and original workflow instructions. The `description` must include trigger language such as "CEO review", "founder-mode review", "think bigger", "strategy review", "rethink this plan", and "is this ambitious enough" so the skill is discoverable when users ask for strategic plan critique.
+
+### AC-63-2
+
+The skill is independent from gstack. It must not require or mention gstack commands, gstack config, `~/.gstack`, telemetry, analytics, update checks, local session files, generated boilerplate, or gstack-branded runtime behavior. The skill may include a short provenance note in implementation documentation or PR text that the issue was inspired by the public upstream concept, but the skill body itself should stand alone as Patina-authored instructions.
+
+### AC-63-3
+
+The skill gives agents a practical CEO/founder-mode review process covering:
+
+- Ambition: whether the plan aims at a meaningful outcome or settles for a local improvement.
+- Scope: whether to expand, selectively expand, hold, or reduce.
+- User value: who benefits, what changes for them, and what proof would validate the bet.
+- Sequencing: what must happen first, what can wait, and what decision gates prevent thrash.
+- Risks: premise risks, product risks, execution risks, and opportunity-cost risks.
+- Recommended next steps: a clear decision, the smallest next move, and evidence that would change the recommendation.
+
+### AC-63-4
+
+Marketplace and dogfood surfaces are updated so the new skill is discoverable with the other in-repo skills:
+
+- `.claude-plugin/plugin.json` includes `./skills/ceo-plan-review`.
+- `.codex-plugin/plugin.json` includes the same skill path in the same order as Claude.
+- `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` descriptions mention `ceo-plan-review` if they enumerate included skills.
+- `.agents/skills/ceo-plan-review` and `.claude/skills/ceo-plan-review` symlink to `../../skills/ceo-plan-review`.
+- `scripts/verify-dogfood.sh` treats the repository as owning five in-repo skills.
+
+### AC-63-5
+
+Repository verification passes after implementation:
+
+- `pnpm verify:dogfood`
+- `pnpm verify:marketplace`
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`
+
+The `find` output must include exactly the five in-repo skill entry points unless a later approved design explicitly changes the repository's skill count.
+
+## Proposed Skill Behavior
+
+The skill should run a structured review, not a broad brainstorming session. The agent first identifies what artifact it is reviewing: an implementation plan, product spec, strategy memo, issue, PR description, roadmap item, or pasted plan. If there is no plan, it asks for one or routes to `office-hours`.
+
+The skill then classifies the review into one of four modes:
+
+- `Expand`: the plan is directionally right but under-ambitious. The review proposes the larger product bet and the smallest credible step toward it.
+- `Selectively expand`: the plan should hold its core scope but borrow one or two high-leverage moves from a bigger vision.
+- `Hold`: the plan is appropriately scoped. The review tightens assumptions, sequencing, and success criteria.
+- `Reduce`: the plan is overloaded or premature. The review strips it to the essential wedge and names what to defer.
+
+The output should be opinionated and useful in one pass. It should include:
+
+- `Verdict`: one of the four modes with a one-sentence rationale.
+- `Premise check`: the assumption most likely to be false, plus evidence that would change the review.
+- `Ambition check`: what a stronger version would accomplish.
+- `Scope decision`: what to add, keep, defer, or remove.
+- `User value`: the person or workflow that becomes better, faster, cheaper, more delightful, or more strategically important.
+- `Sequencing`: first move, later moves, and decision gates.
+- `Risks`: the top risks by category.
+- `Recommendation`: concrete next steps and the next artifact to produce.
+
+## Skill Structure
+
+The first implementation should be a single `SKILL.md` plus optional host metadata only if the repository already requires it for new skills. Do not create a README, examples directory, scripts directory, or extra reference files for the first version.
+
+Recommended `SKILL.md` shape:
+
+1. YAML frontmatter:
+   - `name: ceo-plan-review`
+   - `description:` one concise paragraph naming when to use it and its trigger phrases.
+2. `# CEO Plan Review`
+3. `## When to Use`
+4. `## When Not to Use`
+5. `## Inputs`
+6. `## Review Modes`
+7. `## Workflow`
+8. `## Output`
+9. `## Red Flags`
+
+Keep the skill body under roughly 350 lines. The body should contain enough examples to calibrate the agent, but no long sample reports.
+
+## Integration Notes
+
+`office-hours` relationship: `office-hours` remains the pre-plan idea interrogation skill. `ceo-plan-review` should say to use `office-hours` when the user has only an idea, no plan, or no evidence of demand. `office-hours` does not need to call `ceo-plan-review` in this issue unless the Executor finds a small cross-reference worthwhile and low risk.
+
+`superteam` relationship: `ceo-plan-review` can review a spec or plan, but it does not approve Gate 1, replace Planner, bypass Reviewer, or alter Finisher shutdown. If `superteam` uses it later, it should be an advisory review surface whose findings route through the existing teammate owner for spec-level, plan-level, or implementation-level feedback.
+
+Marketplace relationship: this repository currently validates both Claude and Codex plugin manifests and the dogfood symlink overlays. Adding the skill requires updating all surfaces that enumerate in-repo skills, including verification scripts whose messages still say "four".
+
+## Workflow-Contract Review Dimensions
+
+### RED/GREEN Baseline Obligations
+
+RED baseline for implementation:
+
+- The new skill is absent from `skills/`.
+- Existing verification expects four skills.
+- Marketplace manifests list four skills.
+- Dogfood overlays do not expose the new skill.
+
+GREEN target:
+
+- `skills/ceo-plan-review/SKILL.md` exists and has `name: ceo-plan-review`.
+- All marketplace and dogfood enumerations include the fifth skill.
+- Verification scripts pass without special casing.
+- The skill runs as standalone instructions with no external runtime dependency.
+
+### Rationalization Resistance
+
+Implementation must resist these shortcuts:
+
+- "The upstream skill is public, so close paraphrase is fine." It is not. Write original Patina instructions.
+- "A link to the upstream skill is enough." It is not. Agents need a first-class local workflow.
+- "Marketplace validation passing is enough." It is not. Dogfood symlinks and `verify-dogfood` must also prove local discoverability.
+- "CEO review can approve superteam plans." It cannot. It is advisory unless a later issue changes `superteam`.
+- "Telemetry/update/local-state code is harmless if optional." It is out of scope and should not exist.
+
+### Red Flags
+
+- Any occurrence of `gstack`, `~/.gstack`, `gbrain`, `telemetry`, `analytics`, `session`, or `update-check` inside `skills/ceo-plan-review/SKILL.md`, except if a verification comment explicitly names forbidden strings.
+- The skill asks broad discovery questions when the user already supplied a plan, instead of reviewing the plan.
+- The output is neutral when a clear scope decision is needed.
+- The review mode names exist but do not change behavior.
+- The skill duplicates `office-hours` instead of specializing in plan review.
+- Marketplace manifests diverge between Claude and Codex.
+- `scripts/verify-dogfood.sh` still claims there are four in-repo skills.
+
+### Token-Efficiency Targets
+
+- Keep `SKILL.md` concise: target 150 to 350 lines.
+- Prefer checklists and short examples over long theory.
+- Do not include the upstream source text.
+- Avoid bundled reference files in the first version.
+- Use one output template, not separate templates for every mode.
+
+### Role Ownership
+
+- `Brainstormer` owns this design artifact and the acceptance criteria.
+- `Planner` owns the implementation plan and task breakdown.
+- `Executor` owns the new skill, manifest edits, symlinks, and verification-script updates.
+- `Reviewer` owns local review for independence, discoverability, and verification risk.
+- `Finisher` owns PR publication, CI, external feedback routing, and shutdown.
+
+### Stage-Gate Bypass Paths
+
+The implementation must not use `ceo-plan-review` to bypass existing workflow gates:
+
+- It does not replace `office-hours` discovery when no plan exists.
+- It does not replace `superteam` Brainstormer approval.
+- It does not replace Planner's implementation plan.
+- It does not replace Reviewer's pre-publish review.
+- It does not let Finisher ignore CI or PR feedback.
+
+## Verification Plan
+
+Executor should run:
+
+```bash
+pnpm verify:dogfood
+pnpm verify:marketplace
+find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort
+```
+
+Executor should also inspect the new skill for forbidden gstack coupling:
+
+```bash
+rg -n "gstack|~/.gstack|gbrain|telemetry|analytics|update-check|session" skills/ceo-plan-review/SKILL.md
+```
+
+The expected result is no matches, unless the final implementation intentionally places a forbidden-string check outside the skill body.
+
+## Open Questions
+
+- Should the root README's skill table mention `ceo-plan-review` in this issue? The acceptance criteria do not require it, but the repository currently uses the README as a user-facing skill index. Planner should decide whether to include it as part of discoverability.
+- Should `office-hours` include a small "use `ceo-plan-review` when a plan already exists" cross-reference? This is useful but not required by the issue.
+- Should the marketplace description list every included skill or stay generic? If it lists skills, it must include the new one.
+
+## Adversarial Review
+
+Review context: same-thread fallback.
+
+Dimensions checked:
+
+- RED/GREEN baseline obligations: clean. The design names the current failing surfaces and the target passing surfaces.
+- Rationalization resistance: clean. The design explicitly blocks copying, linking-only, runtime coupling, and gate bypass.
+- Red flags: clean. The design gives concrete strings and behavioral failures for Reviewer and Executor to check.
+- Token-efficiency targets: clean. The design keeps the proposed skill lean and avoids extra resources.
+- Role ownership: clean. The design assigns work to Brainstormer, Planner, Executor, Reviewer, and Finisher.
+- Stage-gate bypass paths: clean. The design preserves `office-hours` and `superteam` authority boundaries.
+
+Findings: no approval-blocking findings remain.

--- a/scripts/install-third-party-skills.sh
+++ b/scripts/install-third-party-skills.sh
@@ -6,7 +6,7 @@
 # `pnpm skills:install`). Idempotent — re-runs are a no-op when the skills
 # are already present.
 #
-# Why this script exists: the four in-repo `patinaproject-skills` are tracked
+# Why this script exists: the five in-repo `patinaproject-skills` are tracked
 # in `skills/<name>/`; third-party skills (obra/superpowers, openai/skills,
 # anthropics/claude-code, mattpocock/skills, vercel-labs/skills) are tracked
 # only as pinned entries in `skills-lock.json` to avoid bloating
@@ -31,7 +31,7 @@ fi
 
 # `npx skills experimental_install` reads skills-lock.json and restores all
 # entries. The lockfile records only third-party skills; in-repo skills
-# (the four `patinaproject-skills`) are not in it.
+# (the five `patinaproject-skills`) are not in it.
 echo "install-third-party-skills: restoring vendored skills from skills-lock.json..."
 npx --yes skills@latest experimental_install --yes
 echo "install-third-party-skills: done"

--- a/scripts/verify-dogfood.sh
+++ b/scripts/verify-dogfood.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# verify-dogfood.sh — Asserts that all four in-repo skills are discoverable
+# verify-dogfood.sh — Asserts that all five in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
 # Covers AC-58-3 check c.
 #
-# Exit 0: all four skills pass all assertions.
+# Exit 0: all five skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -19,6 +19,7 @@ SKILLS=(
   superteam
   using-github
   office-hours
+  plan-ceo-review
 )
 FAIL_COUNT=0
 
@@ -119,5 +120,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all four in-repo skills discoverable via flat layout"
+echo "OK: all five in-repo skills discoverable via flat layout"
 exit 0

--- a/skills/office-hours/SKILL.md
+++ b/skills/office-hours/SKILL.md
@@ -23,6 +23,7 @@ Do NOT write code, scaffold a project, invoke any implementation skill, or take 
    - Startup / new revenue line / external pilot → **Startup mode** (Phase 2A)
    - Internal Patina feature pitch needing a sponsor → **Startup mode**, intrapreneurship adaptation (see Q4/Q6 below)
    - Hackathon, learning, OSS, side project, just for fun → **Builder mode** (Phase 2B)
+   - Existing concrete plan needing CEO/founder-level critique → use `plan-ceo-review` instead
 4. For startup mode only, ask product stage:
    - Pre-product (idea, no users)
    - Has users (people using it, no revenue)

--- a/skills/plan-ceo-review/SKILL.md
+++ b/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: plan-ceo-review
-description: "Review an existing product, strategy, or implementation plan from a CEO/founder perspective. Use for CEO review, founder-mode review, think bigger, strategy review, rethink this plan, or is this ambitious enough requests."
+description: "Use when a user asks for CEO review, founder-mode review, think bigger, strategy review, rethink this plan, is this ambitious enough, or critique of an existing product, strategy, roadmap, or implementation plan."
 ---
 
 # CEO Plan Review
 
-Use this skill to pressure-test a plan that already exists. Your job is to decide whether the plan is ambitious enough, focused enough, sequenced well, and worth the opportunity cost.
+Pressure-test a plan that already exists. Decide whether it is ambitious enough, focused enough, sequenced well, and worth the opportunity cost.
 
 Be opinionated. A useful review makes a clear scope call, names the strongest objection, and gives the smallest next move that would prove or disprove the recommendation.
 
@@ -13,8 +13,7 @@ Be opinionated. A useful review makes a clear scope call, names the strongest ob
 
 - The user asks for a CEO review, founder-mode review, strategy review, ambition review, or "think bigger" pass.
 - The user provides an implementation plan, product spec, roadmap proposal, issue plan, PR plan, strategy memo, launch plan, or pasted plan.
-- The user asks whether a plan is too small, too broad, too cautious, too complex, or sequenced poorly.
-- A `superteam` artifact needs advisory strategic critique before its owner decides what to change.
+- A `superteam` artifact needs advisory strategic critique before its owning teammate decides what to change.
 
 ## When Not to Use
 
@@ -25,63 +24,22 @@ Be opinionated. A useful review makes a clear scope call, names the strongest ob
 
 ## Inputs
 
-Identify the artifact before reviewing:
+Identify the artifact before reviewing. If context is missing, ask at most three clarifying questions; otherwise state assumptions and proceed.
 
 - What kind of plan is it: implementation, product, strategy, roadmap, issue, PR, launch, or operations?
-- Who is the intended beneficiary: user, buyer, operator, maintainer, teammate, or business sponsor?
-- What outcome does the plan claim to create?
-- What constraint matters most: time, risk, quality, trust, distribution, cost, or learning?
-- What evidence is already present: usage, revenue, support pain, customer quotes, internal urgency, benchmark, or none?
-
-If the plan is missing critical context, ask at most three clarifying questions. If you can review with stated assumptions, proceed and mark those assumptions in the output.
+- Who benefits: user, buyer, operator, maintainer, teammate, or sponsor?
+- What outcome, constraint, and evidence matter most?
 
 ## Review Modes
 
 Choose exactly one mode for the verdict.
 
-### Expand
-
-Use when the plan is directionally right but too local. The plan solves a small symptom while a larger outcome is nearby.
-
-Behavior:
-
-- Name the bigger product or strategic bet.
-- Identify the smallest credible move toward that bigger bet.
-- Preserve only the current work that compounds into the larger outcome.
-- Challenge the user to measure a meaningful behavior change, not just task completion.
-
-### Selectively Expand
-
-Use when the core plan is right but one or two additions would materially improve leverage.
-
-Behavior:
-
-- Keep the current center of gravity.
-- Add only the highest-leverage missing move.
-- Explain why other expansions should wait.
-- Define the decision gate that decides whether to expand further.
-
-### Hold
-
-Use when the plan is appropriately scoped and the best move is execution discipline.
-
-Behavior:
-
-- Tighten the premise, success criteria, and sequencing.
-- Remove ambiguity without increasing scope.
-- Name the one risk most likely to surprise the team.
-- Protect the plan from ambition theater and unnecessary polish.
-
-### Reduce
-
-Use when the plan is overloaded, premature, or trying to solve too many problems at once.
-
-Behavior:
-
-- Strip the work to the essential wedge.
-- Name what to defer and why it can safely wait.
-- Replace broad deliverables with a sharper proof point.
-- Protect the team from spending effort before the premise earns it.
+| Mode | Use When | Behavior |
+| --- | --- | --- |
+| `Expand` | Directionally right, but too local | Name the larger bet and the smallest credible move toward it |
+| `Selectively expand` | Core scope is right, but one missing move would add leverage | Keep the center, add the highest-leverage move, gate later expansion |
+| `Hold` | Scope is right and execution discipline matters most | Tighten premise, success criteria, sequencing, and surprise risk |
+| `Reduce` | Plan is overloaded, premature, or trying to solve too much | Strip to the essential wedge and defer what has not earned its cost |
 
 ## Workflow
 
@@ -93,65 +51,31 @@ Behavior:
 6. Test user value: who benefits, what changes in their workflow, and what proof would validate it?
 7. Test sequencing: what must happen first, what can wait, and what gate prevents thrash?
 8. Test risks: premise, product, execution, and opportunity cost.
-9. Recommend one decision and the smallest next move.
+9. Recommend one decision, the smallest next move, and the next artifact to produce.
 
 Keep the review concrete. Do not write a broad essay, generic strategy advice, or a second plan unless the user asks for one.
 
+## Calibration
+
+- `Expand`: "This solves the admin problem, but the bigger bet is becoming the weekly operating review."
+- `Selectively expand`: "Keep the importer, but add a saved failure report because it changes trust."
+- `Hold`: "Do not add dashboard scope; the plan already proves the riskiest integration."
+- `Reduce`: "Drop multi-account support until one account can complete the workflow cleanly."
+
 ## Output
 
-Use this template.
+Use these headings:
 
-```markdown
-## Verdict
+- `Verdict`: one mode plus one-sentence rationale.
+- `Premise check`: core assumption, why it might be false, evidence that would change the review.
+- `Ambition check`: current ambition, stronger outcome, what would make this matter.
+- `Scope decision`: add, keep, defer, remove.
+- `User value`: beneficiary, workflow change, validating proof.
+- `Sequencing`: first move, later moves, decision gates.
+- `Risks`: premise, product, execution, and opportunity-cost risks.
+- `Recommendation`: decision, smallest next move, next artifact to produce.
 
-<Expand | Selectively expand | Hold | Reduce>: <one-sentence rationale.>
-
-## Premise check
-
-- Core assumption:
-- Why it might be false:
-- Evidence that would change this review:
-
-## Ambition check
-
-- Current ambition:
-- Stronger outcome:
-- What would make this matter:
-
-## Scope decision
-
-- Add:
-- Keep:
-- Defer:
-- Remove:
-
-## User value
-
-- Beneficiary:
-- Workflow change:
-- Validating proof:
-
-## Sequencing
-
-- First move:
-- Later moves:
-- Decision gates:
-
-## Risks
-
-- Premise risk:
-- Product risk:
-- Execution risk:
-- Opportunity-cost risk:
-
-## Recommendation
-
-- Decision:
-- Smallest next move:
-- Next artifact to produce:
-```
-
-If a section does not apply, write `None` and explain why in one phrase. Do not leave blanks.
+If a field does not apply, write `None` and explain why in one phrase.
 
 ## Red Flags
 
@@ -160,7 +84,5 @@ If a section does not apply, write `None` and explain why in one phrase. Do not 
 - The plan says "platform" but lacks a narrow wedge.
 - The plan is busy, but the expected outcome is small.
 - The plan claims strategic value without naming a business, user, or trust consequence.
-- The plan expands because expansion feels exciting, not because it increases leverage.
-- The plan reduces because reduction feels safer, not because the extra scope lacks proof.
 - The review stays neutral when the plan needs a decision.
 - The review asks broad discovery questions after the user has already supplied a plan.

--- a/skills/plan-ceo-review/SKILL.md
+++ b/skills/plan-ceo-review/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: plan-ceo-review
+description: "Review an existing product, strategy, or implementation plan from a CEO/founder perspective. Use for CEO review, founder-mode review, think bigger, strategy review, rethink this plan, or is this ambitious enough requests."
+---
+
+# CEO Plan Review
+
+Use this skill to pressure-test a plan that already exists. Your job is to decide whether the plan is ambitious enough, focused enough, sequenced well, and worth the opportunity cost.
+
+Be opinionated. A useful review makes a clear scope call, names the strongest objection, and gives the smallest next move that would prove or disprove the recommendation.
+
+## When to Use
+
+- The user asks for a CEO review, founder-mode review, strategy review, ambition review, or "think bigger" pass.
+- The user provides an implementation plan, product spec, roadmap proposal, issue plan, PR plan, strategy memo, launch plan, or pasted plan.
+- The user asks whether a plan is too small, too broad, too cautious, too complex, or sequenced poorly.
+- A `superteam` artifact needs advisory strategic critique before its owner decides what to change.
+
+## When Not to Use
+
+- The user has only an idea and no plan. Ask for the plan, or route to `office-hours` for pre-plan discovery.
+- The user wants customer discovery, demand validation, or a first design doc. Use `office-hours`.
+- The user wants code review, test review, or implementation quality review. Use the repo's review workflow.
+- Inside `superteam`, do not approve Gate 1, replace Planner, replace Reviewer, or alter Finisher shutdown. This skill is advisory only.
+
+## Inputs
+
+Identify the artifact before reviewing:
+
+- What kind of plan is it: implementation, product, strategy, roadmap, issue, PR, launch, or operations?
+- Who is the intended beneficiary: user, buyer, operator, maintainer, teammate, or business sponsor?
+- What outcome does the plan claim to create?
+- What constraint matters most: time, risk, quality, trust, distribution, cost, or learning?
+- What evidence is already present: usage, revenue, support pain, customer quotes, internal urgency, benchmark, or none?
+
+If the plan is missing critical context, ask at most three clarifying questions. If you can review with stated assumptions, proceed and mark those assumptions in the output.
+
+## Review Modes
+
+Choose exactly one mode for the verdict.
+
+### Expand
+
+Use when the plan is directionally right but too local. The plan solves a small symptom while a larger outcome is nearby.
+
+Behavior:
+
+- Name the bigger product or strategic bet.
+- Identify the smallest credible move toward that bigger bet.
+- Preserve only the current work that compounds into the larger outcome.
+- Challenge the user to measure a meaningful behavior change, not just task completion.
+
+### Selectively Expand
+
+Use when the core plan is right but one or two additions would materially improve leverage.
+
+Behavior:
+
+- Keep the current center of gravity.
+- Add only the highest-leverage missing move.
+- Explain why other expansions should wait.
+- Define the decision gate that decides whether to expand further.
+
+### Hold
+
+Use when the plan is appropriately scoped and the best move is execution discipline.
+
+Behavior:
+
+- Tighten the premise, success criteria, and sequencing.
+- Remove ambiguity without increasing scope.
+- Name the one risk most likely to surprise the team.
+- Protect the plan from ambition theater and unnecessary polish.
+
+### Reduce
+
+Use when the plan is overloaded, premature, or trying to solve too many problems at once.
+
+Behavior:
+
+- Strip the work to the essential wedge.
+- Name what to defer and why it can safely wait.
+- Replace broad deliverables with a sharper proof point.
+- Protect the team from spending effort before the premise earns it.
+
+## Workflow
+
+1. Restate the plan in one sentence, using the user's concrete nouns.
+2. Identify the outcome that would make the work matter.
+3. Test the premise: what assumption, if false, makes the plan wasteful?
+4. Test ambition: does this create a meaningful change or only tidy the local surface?
+5. Test scope: should the plan expand, selectively expand, hold, or reduce?
+6. Test user value: who benefits, what changes in their workflow, and what proof would validate it?
+7. Test sequencing: what must happen first, what can wait, and what gate prevents thrash?
+8. Test risks: premise, product, execution, and opportunity cost.
+9. Recommend one decision and the smallest next move.
+
+Keep the review concrete. Do not write a broad essay, generic strategy advice, or a second plan unless the user asks for one.
+
+## Output
+
+Use this template.
+
+```markdown
+## Verdict
+
+<Expand | Selectively expand | Hold | Reduce>: <one-sentence rationale.>
+
+## Premise check
+
+- Core assumption:
+- Why it might be false:
+- Evidence that would change this review:
+
+## Ambition check
+
+- Current ambition:
+- Stronger outcome:
+- What would make this matter:
+
+## Scope decision
+
+- Add:
+- Keep:
+- Defer:
+- Remove:
+
+## User value
+
+- Beneficiary:
+- Workflow change:
+- Validating proof:
+
+## Sequencing
+
+- First move:
+- Later moves:
+- Decision gates:
+
+## Risks
+
+- Premise risk:
+- Product risk:
+- Execution risk:
+- Opportunity-cost risk:
+
+## Recommendation
+
+- Decision:
+- Smallest next move:
+- Next artifact to produce:
+```
+
+If a section does not apply, write `None` and explain why in one phrase. Do not leave blanks.
+
+## Red Flags
+
+- The plan optimizes an internal artifact but cannot name a user workflow that improves.
+- The plan adds architecture, process, or polish before proving the premise.
+- The plan says "platform" but lacks a narrow wedge.
+- The plan is busy, but the expected outcome is small.
+- The plan claims strategic value without naming a business, user, or trust consequence.
+- The plan expands because expansion feels exciting, not because it increases leverage.
+- The plan reduces because reduction feels safer, not because the extra scope lacks proof.
+- The review stays neutral when the plan needs a decision.
+- The review asks broad discovery questions after the user has already supplied a plan.


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #63

## What changed

Context: standalone — adds the independent Patina-owned CEO plan review skill requested in #63.

- Added `plan-ceo-review` — gives existing plans a founder-mode review with expand, selectively expand, hold, and reduce verdicts.
- Wired Claude, Codex, dogfood overlays, and verification — makes the fifth in-repo skill discoverable through all current surfaces.
- Updated repository docs and routing notes — keeps README, AGENTS, release-flow docs, and office-hours boundaries accurate for the five-skill catalog.

## Test coverage

Legend for status cells:

- ✅ — required validation passed with no known relevant gap for this column.
- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ — required validation is missing, failing, pending, or merge-blocked.
- ➖ — not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | Claude/Codex marketplace |
| --- | --- | --- | --- |
| AC-63-1 | Skill entry point | ✅ | ➖ |
| AC-63-2 | gstack independence | ✅ | ➖ |
| AC-63-3 | CEO review workflow | ✅ | ➖ |
| AC-63-4 | Discoverability surfaces | ✅ | ✅ |
| AC-63-5 | Repository verification | ✅ | ✅ |

### AC-63-1

The new skill exists at `skills/plan-ceo-review/SKILL.md` with `name: plan-ceo-review`, discoverability trigger language, review modes, workflow, output template, and red flags.

- Evidence: Local file inspection and `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`.
- Gap: None.
- Manual testing needed: No; this is a static skill entry-point requirement.

### AC-63-2

The skill body is original Patina-authored guidance and contains no gstack runtime, config, telemetry, analytics, update-check, local-state, or session coupling.

- Evidence: Local forbidden-coupling scan: `rg -n "gstack|~/.gstack|gbrain|telemetry|analytics|update-check|session" skills/plan-ceo-review/SKILL.md` returned no matches.
- Gap: None.
- Manual testing needed: No.

### AC-63-3

The skill defines distinct `Expand`, `Selectively Expand`, `Hold`, and `Reduce` modes, and its workflow covers ambition, scope, user value, sequencing, risks, and recommended next steps.

- Evidence: Local inspection of `skills/plan-ceo-review/SKILL.md`.
- Gap: None.
- Manual testing needed: No; reviewers may read the skill prose for product taste.

### AC-63-4

Claude and Codex plugin manifests include `./skills/plan-ceo-review` in matching five-skill arrays, marketplace text enumerates the new skill, dogfood symlinks resolve, and docs now describe five in-repo skills.

- Evidence: `pnpm verify:dogfood`, `pnpm verify:marketplace`, and `jq -c '.skills' .claude-plugin/plugin.json` / `.codex-plugin/plugin.json` parity check.
- Gap: None.
- Manual testing needed: No.

### AC-63-5

Required repository verification passes locally and the flat skill list contains exactly the five expected entry points.

- Evidence: `pnpm verify:dogfood`; `pnpm verify:marketplace`; `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`.
- Gap: `pnpm lint:md` could not run because this worktree does not have `node_modules`; required AC verification passed, and the repo lint command excludes `skills/**` and `docs/superpowers/**`.
- Manual testing needed: No.

## Testing steps

- [x] Run `pnpm verify:dogfood` and expect all five in-repo skills to resolve through flat layout and dogfood overlays.
- [x] Run `pnpm verify:marketplace` and expect Claude/Codex marketplace validation to pass.
- [x] Run `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort` and expect exactly `office-hours`, `plan-ceo-review`, `scaffold-repository`, `superteam`, and `using-github`.
- [x] Run the forbidden-coupling `rg` check against `skills/plan-ceo-review/SKILL.md` and expect no matches.
