### PR TITLE
docs: #68 clarify superteam prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ handoff artifact and restarts are expensive. `superteam` routes a GitHub issue
 through a six-teammate workflow — Team Lead, Brainstormer, Planner, Executor,
 Reviewer, Finisher — producing durable repo-owned artifacts at every gate.
 
-See [./skills/superteam/](./skills/superteam/) for the
-full README and skill contract.
+See [./skills/superteam/](./skills/superteam/) for the full README and skill
+contract, including the required
+[Superpowers prerequisite](./skills/superteam/README.md#install).
 
 ### using-github
 

--- a/docs/superpowers/plans/2026-05-14-68-clarify-superteams-superpowers-prerequisite-plan.md
+++ b/docs/superpowers/plans/2026-05-14-68-clarify-superteams-superpowers-prerequisite-plan.md
@@ -1,0 +1,45 @@
+# Plan: Clarify Superteam's Superpowers prerequisite [#68](https://github.com/patinaproject/skills/issues/68)
+
+## Approved design
+
+- Design artifact: `docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md`
+- Gate 1 approval: operator explicitly approved on 2026-05-14.
+- Handoff commit: `5f676d1935492f36e62b4ae1303728e91018cbd0`
+
+## Workstreams
+
+### W1: Add the Superteam prerequisite warning
+
+Update `skills/superteam/README.md` in `## Install` before the Superteam install command.
+
+Tasks:
+
+- W1.1 Add a visible prerequisite note stating that Superteam expects Superpowers to be installed first.
+- W1.2 Add the CLI command `npx skills@latest add obra/superpowers`.
+- W1.3 Link to `https://github.com/obra/superpowers` for other installation methods.
+- W1.4 Keep the existing Superteam install commands intact after the prerequisite note.
+
+Acceptance criteria covered: AC-68-1, AC-68-2, AC-68-3.
+
+### W2: Add the root README pointer
+
+Update `README.md` so the repository-level Superteam guidance points users to the Superteam README prerequisite note.
+
+Tasks:
+
+- W2.1 Add a concise sentence in the `superteam` overview pointing to `skills/superteam/README.md#install`.
+- W2.2 Preserve the root all-skills quickstart and host marketplace install commands.
+
+Acceptance criteria covered: AC-68-4.
+
+### W3: Verify documentation
+
+Tasks:
+
+- W3.1 Inspect `skills/superteam/README.md` for the warning, command, and repository link.
+- W3.2 Inspect `README.md` for the root pointer.
+- W3.3 Run `pnpm lint:md`.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md
+++ b/docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md
@@ -1,0 +1,51 @@
+# Design: Clarify Superteam's Superpowers prerequisite [#68](https://github.com/patinaproject/skills/issues/68)
+
+## Intent
+
+Make the Superteam install path explicit that Superpowers is a prerequisite before users install or run `superteam`. The warning belongs in the Superteam-specific install flow, with a lightweight root README pointer so repository-level onboarding does not hide the prerequisite.
+
+## Problem
+
+The Superteam README says the plugin builds on Superpowers, but the install section currently starts with the Superteam install command. A user can follow the install block without realizing the recommended `superpowers` skills must be installed first, then encounter missing-skill gaps once Team Lead delegates to Brainstormer, Planner, Executor, Reviewer, or Finisher.
+
+## Requirements
+
+- AC-68-1: Superteam-specific install documentation warns users before installing Superteam that Superpowers is a prerequisite.
+- AC-68-2: The warning includes an `npx skills` command for installing Superpowers.
+- AC-68-3: The warning links to the Superpowers repository for other installation methods.
+- AC-68-4: Repository-level install guidance points Superteam users to the prerequisite warning or otherwise prevents the root README from obscuring the prerequisite.
+
+## Proposed change
+
+Update `skills/superteam/README.md` in the `## Install` section so the first install content is a prerequisite note. The note should:
+
+- State that Superteam expects Superpowers to be installed first.
+- Show the primary CLI command:
+
+```bash
+npx skills@latest add obra/superpowers
+```
+
+- Link to `https://github.com/obra/superpowers` for other installation methods.
+- Keep the existing Superteam install commands after the prerequisite note.
+
+Update the root `README.md` Superteam section or Quickstart area with a short pointer that Superteam users should read the Superteam README's prerequisite note before installing or invoking it. This keeps the repo-level quickstart from looking complete for Superteam-specific setup while preserving the existing all-skills installation command.
+
+## Non-goals
+
+- Do not change `skills/superteam/SKILL.md`, teammate contracts, routing, gates, or runtime behavior.
+- Do not vendor or install Superpowers as part of this repository's package scripts.
+- Do not replace the existing `patinaproject/skills` install commands.
+- Do not document every individual Superpowers skill in the root README.
+
+## Design notes
+
+This is a documentation clarification, not a workflow-contract change. The Superteam README already has an install section and is the most precise place for a prerequisite warning because users installing only `superteam` land there. The root README should stay concise and avoid duplicating the full prerequisite block, but it should make the prerequisite discoverable from the repository-level overview.
+
+## Verification
+
+- Inspect `skills/superteam/README.md` to confirm the prerequisite warning appears before the Superteam install command.
+- Inspect `skills/superteam/README.md` to confirm it includes `npx skills@latest add obra/superpowers`.
+- Inspect `skills/superteam/README.md` to confirm it links to `https://github.com/obra/superpowers`.
+- Inspect `README.md` to confirm repository-level Superteam guidance points to the prerequisite note.
+- Run `pnpm lint:md` after the implementation.

--- a/skills/superteam/README.md
+++ b/skills/superteam/README.md
@@ -107,6 +107,14 @@ A run is only complete when the published branch state is stable enough to hand 
 
 ## Install
 
+Superteam expects [Superpowers](https://github.com/obra/superpowers) to be installed first. Install it with the `skills` CLI:
+
+```bash
+npx skills@latest add obra/superpowers
+```
+
+See the [Superpowers repository](https://github.com/obra/superpowers) for other installation methods.
+
 Install just this skill via the [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI:
 
 ```bash


### PR DESCRIPTION
# Pull Request

## Linked issue

- Closes #68

## What changed

Context: standalone — follow-up to operator feedback that the Superteam install path did not make the Superpowers prerequisite obvious.

- Added a Superpowers prerequisite note to `skills/superteam/README.md` — users now see the prerequisite before the Superteam install command, with the `npx skills@latest add obra/superpowers` command and a link to the Superpowers repository for other methods.
- Added a root README pointer to the Superteam prerequisite note — repository-level onboarding no longer hides the Superpowers requirement.

## Test coverage

Legend for status cells:

- ✅ — required validation passed with no known relevant gap for this column.
- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ — required validation is missing, failing, pending, or merge-blocked.
- ➖ — not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | Docs |
| --- | --- | --- | --- |
| AC-68-1 | Superteam prerequisite warning | ➖ | ✅ |
| AC-68-2 | Superpowers npx command | ➖ | ✅ |
| AC-68-3 | Superpowers repo link | ➖ | ✅ |
| AC-68-4 | Root README pointer | ➖ | ✅ |

### AC-68-1

The Superteam install section now warns before the Superteam install command that Superteam expects Superpowers to be installed first.

- Evidence: `Docs lint: pnpm exec markdownlint-cli2 README.md skills/superteam/README.md docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md docs/superpowers/plans/2026-05-14-68-clarify-superteams-superpowers-prerequisite-plan.md`, local Codex workspace, passed.
- Gap: None.
- Manual testing needed: No; this is static documentation text.

### AC-68-2

The Superteam install section includes `npx skills@latest add obra/superpowers`.

- Evidence: `Docs lint: pnpm exec markdownlint-cli2 README.md skills/superteam/README.md docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md docs/superpowers/plans/2026-05-14-68-clarify-superteams-superpowers-prerequisite-plan.md`, local Codex workspace, passed.
- Gap: None.
- Manual testing needed: No; this PR documents the install command rather than changing installer behavior.

### AC-68-3

The Superteam install section links to `https://github.com/obra/superpowers` for other installation methods.

- Evidence: `Docs lint: pnpm exec markdownlint-cli2 README.md skills/superteam/README.md docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md docs/superpowers/plans/2026-05-14-68-clarify-superteams-superpowers-prerequisite-plan.md`, local Codex workspace, passed.
- Gap: None.
- Manual testing needed: No; this is a static Markdown link.

### AC-68-4

The root README points Superteam users to the Superteam README's prerequisite note.

- Evidence: `Docs lint: pnpm exec markdownlint-cli2 README.md skills/superteam/README.md docs/superpowers/specs/2026-05-14-68-clarify-superteams-superpowers-prerequisite-design.md docs/superpowers/plans/2026-05-14-68-clarify-superteams-superpowers-prerequisite-plan.md`, local Codex workspace, passed.
- Gap: None.
- Manual testing needed: No; this is static documentation text.

Additional verification: `pnpm lint:md` was attempted after `pnpm install`, but the repo-wide lint is blocked by pre-existing `CHANGELOG.md` MD012 errors at lines 5 and 18, outside this PR's changed files.

## Testing steps

- [x] Review the Superteam install section and confirm the Superpowers prerequisite warning, `npx` command, and Superpowers repository link appear before the Superteam install command.
- [x] Review the root README Superteam section and confirm it points to the Superpowers prerequisite note.
