### PR TITLE
feat: #71 add non-interactive superteam command

### DIFF
--- a/.agents/skills/superteam-non-interactive
+++ b/.agents/skills/superteam-non-interactive
@@ -1,0 +1,1 @@
+../../skills/superteam-non-interactive

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, superteam, using-github, office-hours, plan-ceo-review",
+      "description": "Skills used by the Patina Project team — scaffold-repository, superteam, superteam-non-interactive, using-github, office-hours, plan-ceo-review",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "skills": [
     "./skills/scaffold-repository",
     "./skills/superteam",
+    "./skills/superteam-non-interactive",
     "./skills/using-github",
     "./skills/office-hours",
     "./skills/plan-ceo-review"

--- a/.claude/skills/superteam-non-interactive
+++ b/.claude/skills/superteam-non-interactive
@@ -1,0 +1,1 @@
+../../skills/superteam-non-interactive

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -4,6 +4,7 @@
   "skills": [
     "./skills/scaffold-repository",
     "./skills/superteam",
+    "./skills/superteam-non-interactive",
     "./skills/using-github",
     "./skills/office-hours",
     "./skills/plan-ceo-review"

--- a/.gitignore
+++ b/.gitignore
@@ -3,15 +3,19 @@ docs/superpowers/plans/.artifacts/
 
 # Third-party skills (installed via `npx skills add` on demand) are not
 # committed to the repo. The pnpm `postinstall` script restores them from
-# `skills-lock.json` so editors get them after `pnpm install`. Only the four
+# `skills-lock.json` so editors get them after `pnpm install`. Only the six
 # in-repo `patinaproject-skills` overlay symlinks are tracked.
 .agents/skills/*
 !.agents/skills/scaffold-repository
 !.agents/skills/superteam
+!.agents/skills/superteam-non-interactive
 !.agents/skills/using-github
 !.agents/skills/office-hours
+!.agents/skills/plan-ceo-review
 .claude/skills/*
 !.claude/skills/scaffold-repository
 !.claude/skills/superteam
+!.claude/skills/superteam-non-interactive
 !.claude/skills/using-github
 !.claude/skills/office-hours
+!.claude/skills/plan-ceo-review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,14 @@ This repository is the marketplace surface for Patina Project plugins and relate
 
 - `skills/scaffold-repository/`: scaffold-repository skill
 - `skills/superteam/`: superteam skill
+- `skills/superteam-non-interactive/`: CI-safe superteam skill
 - `skills/using-github/`: using-github skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
 - `.agents/skills/<name>/`: symlinks into `../../skills/<name>/` (dogfood overlay)
 - `.claude/skills/<name>/`: symlinks into `../../skills/<name>/` (Claude Code overlay)
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all five skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all six skill paths
 - `docs/`: contributor docs plus planning artifacts; use paths such as `docs/file-structure.md`,
   `docs/release-flow.md`, and, when present, `docs/superpowers/`
 - If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
@@ -31,11 +32,11 @@ following acceptance criteria format:
 - `pnpm commit`: create a guided conventional commit with issue tagging
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
-- `pnpm verify:dogfood`: assert all five in-repo skills are discoverable via flat layout
+- `pnpm verify:dogfood`: assert all six in-repo skills are discoverable via flat layout
 - `pnpm verify:marketplace`: assert `.claude-plugin/` catalog is valid
 - `pnpm verify:superteam`: assert Superteam contract surfaces stay in sync
 - `pnpm apply:scaffold-repository:check`: assert scaffolding is in sync (exit 0)
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the five skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the six skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -66,7 +67,7 @@ structure check; `writing-skills` is the workflow-contract quality gate.
 ## Testing Guidelines
 
 - Validate paths with `find` or `rg`
-- Run `bash scripts/verify-dogfood.sh` to confirm all five in-repo skills pass the flat-layout check
+- Run `bash scripts/verify-dogfood.sh` to confirm all six in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
 - Run `bash scripts/verify-superteam-contract.sh` after changing `skills/superteam/**`
 - Run `node scripts/apply-scaffold-repository.js skills/scaffold-repository --check` to
@@ -125,9 +126,9 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns five skills at flat paths: `skills/scaffold-repository/`,
-`skills/superteam/`, `skills/using-github/`, `skills/office-hours/`, and
-`skills/plan-ceo-review/`.
+This repo owns six skills at flat paths: `skills/scaffold-repository/`,
+`skills/superteam/`, `skills/superteam-non-interactive/`,
+`skills/using-github/`, `skills/office-hours/`, and `skills/plan-ceo-review/`.
 `find-skills` is a third-party skill from `vercel-labs/skills` and is not
 a marketplace entry in this repo.
 
@@ -136,7 +137,7 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The five in-repo skills share the single root `patinaproject-skills` release and tag;
+The six in-repo skills share the single root `patinaproject-skills` release and tag;
 they are not separate release-please packages. Third-party skills such as `find-skills`
 are installed separately from their source repo's default branch or a specific `#<git-ref>`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,15 @@
 
 ## [1.1.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.0.0...patinaproject-skills-v1.1.0) (2026-05-14)
 
-
 ### Features
 
 * [#63](https://github.com/patinaproject/skills/issues/63) add plan-ceo-review skill ([#66](https://github.com/patinaproject/skills/issues/66)) ([c22ad3c](https://github.com/patinaproject/skills/commit/c22ad3cbea9d9a15c0fafa25a6ba4746ec6d3552))
-
 
 ### Bug Fixes
 
 * [#64](https://github.com/patinaproject/skills/issues/64) require latest-head PR completion gate ([#65](https://github.com/patinaproject/skills/issues/65)) ([fc1d699](https://github.com/patinaproject/skills/commit/fc1d699581cf970209e61fa8d0ea4a5c2c9bc8e1))
 
 ## 1.0.0 (2026-05-12)
-
 
 ### ⚠ BREAKING CHANGES
 
@@ -26,7 +23,6 @@
 * [#2](https://github.com/patinaproject/skills/issues/2) add Claude marketplace support ([#3](https://github.com/patinaproject/skills/issues/3)) ([aeb1c62](https://github.com/patinaproject/skills/commit/aeb1c62e156ae2547e9acb788ea0ac2013540d0d))
 * [#41](https://github.com/patinaproject/skills/issues/41) auto-merge release bump PRs ([#42](https://github.com/patinaproject/skills/issues/42)) ([d0dc1bf](https://github.com/patinaproject/skills/commit/d0dc1bf9750806904f49a72a6b98d8552c8b371b))
 * [#58](https://github.com/patinaproject/skills/issues/58) merge skills in-repo, rename bootstrap-&gt;scaffold-repository, adopt vercel-labs CLI ([#59](https://github.com/patinaproject/skills/issues/59)) ([15cfaf8](https://github.com/patinaproject/skills/commit/15cfaf88ff5a28f7c3b337dcee8e07138b9a0941))
-
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Skills used by the Patina Project team
 
-Five installable agent skills for repository scaffolding, multi-teammate
-orchestration, GitHub workflows, product design, and strategic plan review — available
+Six installable agent skills for repository scaffolding, multi-teammate
+orchestration, CI-safe orchestration, GitHub workflows, product design, and strategic plan review — available
 across Claude Code, Codex, and any agent runtime that reads `AGENTS.md`.
 
 ## Quickstart
@@ -55,6 +55,20 @@ Reviewer, Finisher — producing durable repo-owned artifacts at every gate.
 
 See [./skills/superteam/](./skills/superteam/) for the
 full README and skill contract.
+
+### superteam-non-interactive
+
+GitHub Actions cannot answer follow-up questions. `superteam-non-interactive`
+is the headless companion to `superteam`: it uses the same teammate workflow,
+artifacts, gates, and Finisher shutdown, but turns every missing prompt-time
+decision into an explicit CI blocker. Use it for one-shot issue runs where all
+required approvals and publish permissions must come from invocation inputs,
+environment variables, or durable repository state.
+
+It ships with the same `patinaproject-skills` plugin as `superteam`.
+
+See [./skills/superteam-non-interactive/](./skills/superteam-non-interactive/)
+for the skill contract.
 
 ### using-github
 
@@ -110,6 +124,7 @@ for the full README and skill contract.
 | Skill | Description |
 |---|---|
 | [superteam](./skills/superteam/) | Orchestrate a GitHub issue from design through merged PR |
+| [superteam-non-interactive](./skills/superteam-non-interactive/) | Run Superteam in GitHub Actions without prompts |
 | [using-github](./skills/using-github/) | Patina Project GitHub workflow conventions |
 | [office-hours](./skills/office-hours/) | YC-style design partner; runs forcing questions |
 | [plan-ceo-review](./skills/plan-ceo-review/) | Founder-mode review for existing plans |
@@ -133,7 +148,7 @@ npx skills@latest add ./skills/office-hours --list
 node scripts/apply-scaffold-repository.js skills/scaffold-repository --check
 ```
 
-### Check c — dogfood verification, all five skills
+### Check c — dogfood verification, all six skills
 
 ```sh
 bash scripts/verify-dogfood.sh
@@ -145,6 +160,7 @@ bash scripts/verify-dogfood.sh
 skills/
   scaffold-repository/
   superteam/
+  superteam-non-interactive/
   using-github/
   office-hours/
   plan-ceo-review/

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,19 +1,20 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and related install
-documentation. Five skills live under `skills/<name>/` in a flat layout.
+documentation. Six skills live under `skills/<name>/` in a flat layout.
 
 ## Top level
 
 - `skills/scaffold-repository/`: scaffold-repository skill
 - `skills/superteam/`: superteam skill
+- `skills/superteam-non-interactive/`: CI-safe superteam skill
 - `skills/using-github/`: using-github skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
-- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (five in-repo)
-- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (five in-repo)
+- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (six in-repo)
+- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (six in-repo)
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all five skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all six skill paths
 - `skills-lock.json`: vercel-labs CLI install lockfile (auto-generated; commit it)
 - `docs/`: contributor-facing docs for skill maintenance
 - `package.json`, `commitizen.config.js`, `commitlint.config.js`: repo tooling
@@ -23,12 +24,13 @@ documentation. Five skills live under `skills/<name>/` in a flat layout.
 
 ## Flat skill layout
 
-Five skills are owned by this repository:
+Six skills are owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
 | `scaffold-repository` | `skills/scaffold-repository/` | Scaffold or realign a repo to the Patina Project baseline |
 | `superteam` | `skills/superteam/` | Issue-driven orchestration |
+| `superteam-non-interactive` | `skills/superteam-non-interactive/` | CI-safe Superteam orchestration |
 | `using-github` | `skills/using-github/` | GitHub workflow skill |
 | `office-hours` | `skills/office-hours/` | YC-style office hours for product ideation |
 | `plan-ceo-review` | `skills/plan-ceo-review/` | Founder-mode review for existing plans |
@@ -47,7 +49,7 @@ install-block reframes.
 
 ## Dogfood overlay layout
 
-The five in-repo skills are also accessible through two overlay directories via one-hop
+The six in-repo skills are also accessible through two overlay directories via one-hop
 committed symlinks:
 
 | Overlay path | Symlink target | Mode |
@@ -58,7 +60,7 @@ committed symlinks:
 These symlinks allow the agent runtime to discover the in-repo skills alongside any
 third-party skills installed by the vercel-labs CLI.
 
-Third-party CLI-installed skills (including `find-skills`) are untracked; only the five
+Third-party CLI-installed skills (including `find-skills`) are untracked; only the six
 in-repo overlay symlinks are committed.
 
 ## Symlink hygiene

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,9 +3,10 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Five in-repo skills ship as
-`patinaproject-skills`: `scaffold-repository`, `superteam`, `using-github`,
-`office-hours`, `plan-ceo-review`. All five are versioned together as a single
+Skills live flat at `skills/<name>/` in this repo. Six in-repo skills ship as
+`patinaproject-skills`: `scaffold-repository`, `superteam`,
+`superteam-non-interactive`, `using-github`, `office-hours`, `plan-ceo-review`.
+All six are versioned together as a single
 marketplace surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
@@ -68,7 +69,7 @@ The vercel-labs CLI consumer pins a specific tag via `#<git-ref>`:
 npx skills@latest add patinaproject/skills@scaffold-repository#v1.0.0
 ```
 
-The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all five
+The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all six
 skills live under `skills/<name>/SKILL.md` in the same repo, one tag pins the full set.
 `skills-lock.json`'s `computedHash` records per-skill content provenance for reproducible
 re-installs within a given tag.
@@ -101,8 +102,9 @@ items are not applied by the self-apply script:
 
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
-- In-repo skills (`scaffold-repository`, `superteam`, `using-github`, `office-hours`,
-  `plan-ceo-review`) are not separate release-please packages; they share the single root
+- In-repo skills (`scaffold-repository`, `superteam`, `superteam-non-interactive`,
+  `using-github`, `office-hours`, `plan-ceo-review`) are not separate release-please
+  packages; they share the single root
   `patinaproject-skills` release and tag. Third-party skills such as `find-skills` are
   installed separately from their source repo's default branch or a specific `#<git-ref>`.
 - `skills-lock.json` must be committed after any `npx skills add` invocation. The lockfile

--- a/docs/superpowers/plans/2026-05-14-71-add-non-interactive-superteam-command-for-github-actions-plan.md
+++ b/docs/superpowers/plans/2026-05-14-71-add-non-interactive-superteam-command-for-github-actions-plan.md
@@ -1,0 +1,34 @@
+# Add Non-Interactive Superteam Command for GitHub Actions Plan
+
+Issue: #71
+
+## Acceptance Criteria
+
+- AC-71-1: `skills/superteam-non-interactive/SKILL.md` exists and declares
+  `name: superteam-non-interactive`.
+- AC-71-2: `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+  `.agents/skills/`, and `.claude/skills/` expose the new skill.
+- AC-71-3: The skill documents required issue input and optional CI policy
+  inputs for clean design approval, publish permission, and draft PR creation.
+- AC-71-4: The skill forbids prompts, implicit approvals, skipped adversarial
+  review, unauthorized publishing, and premature completion.
+- AC-71-5: README, release-flow, file-structure, marketplace description, and
+  dogfood verification reflect six in-repo skills.
+
+## Workstreams
+
+1. Add the new skill folder and concise `SKILL.md`.
+2. Wire plugin manifests and overlay symlinks.
+3. Update repository docs and verification scripts from five to six skills.
+4. Run dogfood, marketplace, and Superteam contract verification.
+
+## Verification
+
+- `bash scripts/verify-dogfood.sh`
+- `bash scripts/verify-marketplace.sh`
+- `bash scripts/verify-superteam-contract.sh`
+- `pnpm lint:md`
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-14-71-add-non-interactive-superteam-command-for-github-actions-design.md
+++ b/docs/superpowers/specs/2026-05-14-71-add-non-interactive-superteam-command-for-github-actions-design.md
@@ -1,0 +1,66 @@
+# Add Non-Interactive Superteam Command for GitHub Actions Design
+
+Issue: #71
+
+## Intent
+
+Add a CI-safe Superteam entry point named `superteam-non-interactive` that ships
+with the existing Patina Project skills plugin. The new skill must preserve the
+Superteam workflow contract while replacing chat-time prompts with explicit
+inputs and fail-fast blockers.
+
+## Requirements
+
+- AC-71-1: A new installable skill exists at
+  `skills/superteam-non-interactive/` with `name: superteam-non-interactive`.
+- AC-71-2: The skill is discoverable from both Claude and Codex plugin
+  manifests, and from the local `.agents/skills/` and `.claude/skills/`
+  overlays.
+- AC-71-3: The skill defines a non-interactive input contract for issue
+  resolution, design approval policy, publish permission, and draft PR policy.
+- AC-71-4: The skill explicitly forbids prompts, implicit approvals, skipped
+  adversarial review, and completion before the latest-head PR gate passes.
+- AC-71-5: Repository docs and verification scripts describe six in-repo skills
+  and include the new skill in marketplace packaging.
+
+## Design
+
+Implement `superteam-non-interactive` as a sibling skill rather than a new
+plugin. This keeps the command discoverable as its own entry point while
+packaging it with `patinaproject-skills`, the same distribution surface that
+already ships `superteam`.
+
+The new skill should not duplicate all Superteam role contracts. It should load
+and reuse the existing `superteam` references, then layer the non-interactive
+policy on top:
+
+- resolve required context from prompt tokens, environment variables, or branch
+  state;
+- halt instead of asking the operator;
+- require explicit CI policy inputs before advancing Gate 1 or publishing;
+- preserve branch switching, dirty-worktree refusal, model selection, execution
+  mode, project deltas, feedback routing, and Finisher shutdown.
+
+This keeps RED/GREEN behavior narrow: an agent that would otherwise ask
+"which issue?" or "approve this design?" now has a documented blocker format and
+the exact input needed to proceed.
+
+## Adversarial Review
+
+Review dimensions checked: RED/GREEN baseline obligations, rationalization
+resistance, red flags, token efficiency, role ownership, and stage-gate bypass
+paths.
+
+Findings:
+
+- `clean`: The design adds a separate entry point without weakening existing
+  `superteam` gates.
+- `clean`: The CI approval path requires explicit policy input and clean or
+  dispositioned Gate 1 evidence, avoiding silent approval.
+- `clean`: Finisher remains the only publishing owner and publish requires an
+  explicit non-interactive policy input.
+
+## Decision
+
+Proceed with a compact sibling skill, marketplace manifest updates, overlay
+symlinks, documentation updates, and dogfood verification updates.

--- a/scripts/install-third-party-skills.sh
+++ b/scripts/install-third-party-skills.sh
@@ -6,7 +6,7 @@
 # `pnpm skills:install`). Idempotent — re-runs are a no-op when the skills
 # are already present.
 #
-# Why this script exists: the five in-repo `patinaproject-skills` are tracked
+# Why this script exists: the six in-repo `patinaproject-skills` are tracked
 # in `skills/<name>/`; third-party skills (obra/superpowers, openai/skills,
 # anthropics/claude-code, mattpocock/skills, vercel-labs/skills) are tracked
 # only as pinned entries in `skills-lock.json` to avoid bloating
@@ -31,7 +31,7 @@ fi
 
 # `npx skills experimental_install` reads skills-lock.json and restores all
 # entries. The lockfile records only third-party skills; in-repo skills
-# (the five `patinaproject-skills`) are not in it.
+# (the six `patinaproject-skills`) are not in it.
 echo "install-third-party-skills: restoring vendored skills from skills-lock.json..."
 npx --yes skills@latest experimental_install --yes
 echo "install-third-party-skills: done"

--- a/scripts/verify-dogfood.sh
+++ b/scripts/verify-dogfood.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# verify-dogfood.sh — Asserts that all five in-repo skills are discoverable
+# verify-dogfood.sh — Asserts that all six in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
 # Covers AC-58-3 check c.
 #
-# Exit 0: all five skills pass all assertions.
+# Exit 0: all six skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -17,6 +17,7 @@ cd "$REPO_ROOT"
 SKILLS=(
   scaffold-repository
   superteam
+  superteam-non-interactive
   using-github
   office-hours
   plan-ceo-review
@@ -120,5 +121,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all five in-repo skills discoverable via flat layout"
+echo "OK: all six in-repo skills discoverable via flat layout"
 exit 0

--- a/skills/superteam-non-interactive/SKILL.md
+++ b/skills/superteam-non-interactive/SKILL.md
@@ -20,7 +20,9 @@ Superteam in GitHub Actions, or requests a headless one-shot Superteam run.
    current branch name. If none exists, halt.
 3. Run the normal Superteam pre-flight with `interaction_mode=non-interactive`.
 4. Route to the owning teammate using the normal Superteam routing table.
-5. Before any place where `superteam` would ask the operator, require a
+5. Before delegation, load the routed teammate contract from
+   `skills/superteam/agents/` or `skills/superteam/.claude/agents/`.
+6. Before any place where `superteam` would ask the operator, require a
    provided input, deterministic default, or visible durable state. If none
    exists, halt with a machine-actionable blocker.
 

--- a/skills/superteam-non-interactive/SKILL.md
+++ b/skills/superteam-non-interactive/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: superteam-non-interactive
+description: Use when running Superteam in GitHub Actions, CI, headless automation, or any one-shot environment where prompts, confirmations, or interactive gate decisions would hang the job.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Task
+  - TodoRead
+  - TodoWrite
+---
+
+# superteam-non-interactive
+
+`superteam-non-interactive` is the CI-safe Superteam entry point. It reuses the
+`superteam` Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher
+contracts, but changes operator interaction into a strict fail-fast input
+contract so GitHub Actions can run without hanging.
+
+## Quick start
+
+Use this skill when the operator invokes `/superteam-non-interactive`, asks for
+Superteam in GitHub Actions, or requests a headless one-shot Superteam run.
+
+1. Load `skills/superteam/SKILL.md`, `pre-flight.md`, `routing-table.md`, and
+   `project-deltas.md`.
+2. Resolve the issue from an explicit `#<number>`, `SUPERTEAM_ISSUE`, or the
+   current branch name. If none exists, halt.
+3. Run the normal Superteam pre-flight with `interaction_mode=non-interactive`.
+4. Route to the owning teammate using the normal Superteam routing table.
+5. Before any place where `superteam` would ask the operator, require a
+   provided input, deterministic default, or visible durable state. If none
+   exists, halt with a machine-actionable blocker.
+
+## Non-Interactive Rules
+
+- Never ask a question, wait for approval, present choices, or rely on a future
+  chat reply.
+- Never infer missing required context from vibes. Halt instead.
+- Use normal Superteam branch switching, dirty-worktree refusal, project delta
+  handling, model selection, execution-mode binding, feedback routing, and
+  latest-head shutdown.
+- Treat ambiguous operator text as a blocker, not feedback.
+- Prefer explicit invocation inputs over environment variables; prefer
+  environment variables over repository state.
+- Output concise status lines that CI logs can preserve: current phase, issue,
+  branch, PR if any, blocker if any, and verification evidence.
+
+## Required Inputs
+
+At minimum, one issue source must be present:
+
+- Prompt token: `#71`
+- Environment: `SUPERTEAM_ISSUE=71`
+- Branch: `71-kebab-title`
+
+Optional CI policy inputs:
+
+- `SUPERTEAM_NON_INTERACTIVE=1`: confirms this is a headless run.
+- `SUPERTEAM_APPROVE_CLEAN_DESIGN=1`: lets Gate 1 advance only when the design
+  artifact exists, adversarial review is clean or dispositioned, and no
+  approval-blocking finding remains.
+- `SUPERTEAM_ALLOW_PUBLISH=1`: permits Finisher to push and open or update the
+  PR after local review passes.
+- `SUPERTEAM_DRAFT_PR=1`: asks Finisher to create a draft PR when publishing.
+
+Unset optional policy inputs mean "not permitted." Do not prompt to enable them.
+
+## Gate Behavior
+
+Gate 1 remains real. In non-interactive mode:
+
+- If no design exists, Brainstormer may write and commit one.
+- If a design exists but no plan exists, Team Lead may advance to Planner only
+  when `SUPERTEAM_APPROVE_CLEAN_DESIGN=1` and the normal Gate 1 evidence is
+  clean or dispositioned.
+- If Gate 1 evidence is blocked, missing, or ambiguous, halt with
+  `superteam halted at Gate 1: <reason>`.
+- If a plan exists, execution may continue from the committed plan without a
+  chat approval prompt.
+
+Publish behavior remains Finisher-owned. Finisher may push or open a PR only
+when `SUPERTEAM_ALLOW_PUBLISH=1`; otherwise halt with the exact publish action
+that would have been taken.
+
+## Halt Format
+
+Every non-interactive blocker must be explicit:
+
+```text
+superteam halted at <teammate or gate>: non-interactive input missing: <input>
+```
+
+For CI readability, include a final `next_input:` line when one value would
+unblock the run.
+
+## Red Flags
+
+- Prompting the operator in a GitHub Actions run.
+- Silently treating missing approval as approval.
+- Skipping adversarial design review because the run is headless.
+- Publishing without `SUPERTEAM_ALLOW_PUBLISH=1`.
+- Reporting complete before the latest-head PR completion gate passes.

--- a/skills/superteam-non-interactive/SKILL.md
+++ b/skills/superteam-non-interactive/SKILL.md
@@ -1,32 +1,21 @@
 ---
 name: superteam-non-interactive
 description: Use when running Superteam in GitHub Actions, CI, headless automation, or any one-shot environment where prompts, confirmations, or interactive gate decisions would hang the job.
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
-  - Bash
-  - Task
-  - TodoRead
-  - TodoWrite
 ---
 
 # superteam-non-interactive
 
 `superteam-non-interactive` is the CI-safe Superteam entry point. It reuses the
-`superteam` Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher
-contracts, but changes operator interaction into a strict fail-fast input
-contract so GitHub Actions can run without hanging.
+`superteam` teammate contracts, but changes operator interaction into a strict
+fail-fast input contract so GitHub Actions can run without hanging.
 
 ## Quick start
 
 Use this skill when the operator invokes `/superteam-non-interactive`, asks for
 Superteam in GitHub Actions, or requests a headless one-shot Superteam run.
 
-1. Load `skills/superteam/SKILL.md`, `pre-flight.md`, `routing-table.md`, and
-   `project-deltas.md`.
+1. Load the sibling Superteam files from `skills/superteam/`: `SKILL.md`,
+   `pre-flight.md`, `routing-table.md`, and `project-deltas.md`.
 2. Resolve the issue from an explicit `#<number>`, `SUPERTEAM_ISSUE`, or the
    current branch name. If none exists, halt.
 3. Run the normal Superteam pre-flight with `interaction_mode=non-interactive`.
@@ -49,7 +38,7 @@ Superteam in GitHub Actions, or requests a headless one-shot Superteam run.
 - Output concise status lines that CI logs can preserve: current phase, issue,
   branch, PR if any, blocker if any, and verification evidence.
 
-## Required Inputs
+## Inputs
 
 At minimum, one issue source must be present:
 
@@ -59,7 +48,6 @@ At minimum, one issue source must be present:
 
 Optional CI policy inputs:
 
-- `SUPERTEAM_NON_INTERACTIVE=1`: confirms this is a headless run.
 - `SUPERTEAM_APPROVE_CLEAN_DESIGN=1`: lets Gate 1 advance only when the design
   artifact exists, adversarial review is clean or dispositioned, and no
   approval-blocking finding remains.
@@ -73,14 +61,14 @@ Unset optional policy inputs mean "not permitted." Do not prompt to enable them.
 
 Gate 1 remains real. In non-interactive mode:
 
-- If no design exists, Brainstormer may write and commit one.
-- If a design exists but no plan exists, Team Lead may advance to Planner only
+- No design exists: Brainstormer may write and commit one.
+- Design exists but no plan exists: Team Lead may advance to Planner only
   when `SUPERTEAM_APPROVE_CLEAN_DESIGN=1` and the normal Gate 1 evidence is
   clean or dispositioned.
-- If Gate 1 evidence is blocked, missing, or ambiguous, halt with
+- Gate 1 evidence is blocked, missing, or ambiguous: halt with
   `superteam halted at Gate 1: <reason>`.
-- If a plan exists, execution may continue from the committed plan without a
-  chat approval prompt.
+- Plan exists: execution may continue from the committed plan without a chat
+  approval prompt.
 
 Publish behavior remains Finisher-owned. Finisher may push or open a PR only
 when `SUPERTEAM_ALLOW_PUBLISH=1`; otherwise halt with the exact publish action

--- a/skills/superteam/README.md
+++ b/skills/superteam/README.md
@@ -130,6 +130,11 @@ See the [root README](../../README.md) for the full install guide.
 
 Superteam keeps the workflow grounded in explicit teammate ownership, written design and plan artifacts, verification before completion, and finish-owned review follow-through. You can invoke Superteam at any point in the lifecycle and have it resume from the right teammate instead of starting over.
 
+For GitHub Actions or other headless one-shot runs, use
+`/superteam-non-interactive`. It ships with this plugin and preserves the same
+teammate contracts while failing fast whenever an interactive prompt would have
+been required.
+
 ## Development
 
 This repository is the source for the plugin. Local workflow:


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #71

## What changed

Context: standalone — issue #71 requested a CI-safe Superteam entry point packaged with the existing Superteam plugin.

- Added `superteam-non-interactive` — gives GitHub Actions and other headless runners a prompt-free Superteam command that fails with explicit blockers when required inputs are missing.
- Wired the new skill into Claude and Codex plugin manifests plus dogfood overlays — ensures installers receive it with the same `patinaproject-skills` plugin as `superteam`.
- Updated repository docs and verification scripts from five to six in-repo skills — keeps local checks, install docs, and release docs aligned with the packaged surface.
- Added issue #71 design and plan artifacts — records the workflow-contract reasoning and acceptance criteria for future Superteam resumes.

## Test coverage

Legend for status cells:

- ✅ — required validation passed with no known relevant gap for this column.
- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ — required validation is missing, failing, pending, or merge-blocked.
- ➖ — not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | Claude/Codex packaging |
| --- | --- | --- | --- |
| AC-71-1 | New skill exists | ✅ | ✅ |
| AC-71-2 | Skill is discoverable | ✅ | ✅ |
| AC-71-3 | CI input contract | ✅ | ➖ |
| AC-71-4 | Non-interactive guardrails | ✅ | ➖ |
| AC-71-5 | Docs and verification updated | ✅ | ✅ |

### AC-71-1

`skills/superteam-non-interactive/SKILL.md` exists and declares `name: superteam-non-interactive`.

- Evidence: `Unit test: npx skills@1.5.6 add ./skills/superteam-non-interactive --list, local worktree`.
- Evidence: `Unit test: bash scripts/verify-dogfood.sh, local worktree`.
- Gap: None.
- Manual testing needed: no; local path discovery and dogfood verification cover the file shape.

### AC-71-2

Claude and Codex plugin manifests plus local overlays expose the new skill.

- Evidence: `Claude/Codex packaging test: bash scripts/verify-marketplace.sh, local worktree`.
- Evidence: `Unit test: bash scripts/verify-dogfood.sh, local worktree`.
- Gap: None.
- Manual testing needed: no; manifest parity and symlink resolution are covered by scripts.

### AC-71-3

The skill documents issue resolution and CI policy inputs for clean design approval, publish permission, and draft PR behavior.

- Evidence: `Unit review: skills/superteam-non-interactive/SKILL.md, local worktree`.
- Evidence: `Unit test: pnpm lint:md, local worktree`.
- Gap: None.
- Manual testing needed: no; this is a documentation contract change.

### AC-71-4

The skill forbids prompts, implicit approvals, skipped adversarial review, unauthorized publishing, and premature completion.

- Evidence: `Unit review: skills/superteam-non-interactive/SKILL.md, local worktree`.
- Evidence: `Contract test: bash scripts/verify-superteam-contract.sh, local worktree`.
- Gap: None.
- Manual testing needed: no; this is a workflow-contract guardrail.

### AC-71-5

Repository docs and verification scripts now describe six in-repo skills and package the new skill with `patinaproject-skills`.

- Evidence: `Unit test: bash scripts/verify-dogfood.sh, local worktree`.
- Evidence: `Claude/Codex packaging test: bash scripts/verify-marketplace.sh, local worktree`.
- Evidence: `Markdown test: pnpm lint:md, local worktree`.
- Gap: None.
- Manual testing needed: no; docs and scripts are covered by lint plus packaging checks.

## Testing steps

- [x] Run `bash scripts/verify-dogfood.sh` and confirm all six in-repo skills resolve.
- [x] Run `bash scripts/verify-marketplace.sh` and confirm Claude and Codex manifests match.
- [x] Run `bash scripts/verify-superteam-contract.sh` and confirm Superteam contract assertions pass.
- [x] Run `pnpm lint:md` and confirm Markdown lint passes.
- [x] Run `npx skills@1.5.6 add ./skills/superteam-non-interactive --list` and confirm the new skill is discoverable.
