### PR TITLE
fix: #72 fix scaffold README skill references

### DIFF
--- a/docs/superpowers/plans/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-plan.md
+++ b/docs/superpowers/plans/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-plan.md
@@ -1,0 +1,79 @@
+# Plan: Fix scaffold agent-plugin README install and skill references [#72](https://github.com/patinaproject/skills/issues/72)
+
+## Approved design
+
+- Design artifact: `docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md`
+- Gate 1 approval: operator explicitly approved on 2026-05-14.
+- Handoff commit: `51f1d2f98947f20f0466612f8fa5561e126f0fb0`
+
+## Workstreams
+
+### W1: Add rendered-template regression coverage
+
+Create `scripts/verify-scaffold-agent-plugin-readme.js`.
+
+Tasks:
+
+- W1.1 Read `skills/scaffold-repository/templates/agent-plugin/README.md.tmpl`.
+- W1.2 Render a test README by replacing:
+  - `{{owner}}` with `patinaproject`
+  - `{{repo}}` with `workflow-kit`
+  - `{{repo-description}}` with `Workflow coordination test plugin.`
+  - `{{primary-skill-name}}` with `issue-router`
+- W1.3 Assert the rendered README contains `/workflow-kit:issue-router`.
+- W1.4 Assert the rendered README does not contain `/workflow-kit:workflow-kit`.
+- W1.5 Assert Codex CLI/App prompt examples contain `$issue-router` and do not contain `$workflow-kit`.
+- W1.6 Assert the Related skill link points at `./skills/issue-router/SKILL.md`.
+- W1.7 Assert the Codex CLI section contains `codex plugin marketplace add patinaproject/skills`.
+- W1.8 Assert the rendered README does not contain `codex plugin marketplace add patinaproject/workflow-kit@v0.1.0`.
+- W1.9 Assert the rendered README does not contain `codex plugin install`.
+- W1.10 Assert the rendered README still contains `.cursor/rules/workflow-kit.mdc`.
+- W1.11 Add a second render with an empty primary skill name and fail unless the renderer refuses before producing `/workflow-kit:` or `skills//SKILL.md`.
+- W1.12 Add package script `verify:scaffold-readme` that runs the new script.
+
+Acceptance criteria covered: AC-72-1, AC-72-2, AC-72-3.
+
+### W2: Fix the agent-plugin README template
+
+Modify `skills/scaffold-repository/templates/agent-plugin/README.md.tmpl`.
+
+Tasks:
+
+- W2.1 Keep Claude install keyed to the plugin slug:
+  `/plugin install {{repo}}@patinaproject-skills`.
+- W2.2 Change Claude invocation from `/{{repo}}:{{repo}}` to
+  `/{{repo}}:{{primary-skill-name}}`.
+- W2.3 Replace the Codex CLI second marketplace-add command with prose that tells users to install or enable `{{repo}}` from the registered Patina Project marketplace/plugin source.
+- W2.4 Change Codex CLI and Codex App prompt examples from `${{repo}}` to `${{primary-skill-name}}`.
+- W2.5 Change Usage examples from `/{{repo}}:{{repo}}` to
+  `/{{repo}}:{{primary-skill-name}}`.
+- W2.6 Change Related from `skills/{{repo}}/SKILL.md` to
+  `skills/{{primary-skill-name}}/SKILL.md`.
+- W2.7 Preserve repo-keyed surfaces such as `.cursor/rules/{{repo}}.mdc`.
+
+Acceptance criteria covered: AC-72-1, AC-72-2, AC-72-3.
+
+### W3: Document the primary skill requirement
+
+Modify `skills/scaffold-repository/SKILL.md`.
+
+Tasks:
+
+- W3.1 Update the prompt table so `<primary-skill-name>` is required when `<is-agent-plugin>` is yes.
+- W3.2 Add a short note in `## Agent plugin surfaces` explaining that the agent-plugin README documents a primary skill invocation, so agent-plugin mode must collect a primary skill name before rendering that README.
+
+Acceptance criteria covered: AC-72-1, AC-72-2.
+
+### W4: Verify and commit implementation
+
+Tasks:
+
+- W4.1 Run `pnpm verify:scaffold-readme`; expect pass.
+- W4.2 Run `pnpm verify:dogfood`; expect pass.
+- W4.3 Run `pnpm apply:scaffold-repository:check`; expect pass.
+- W4.4 Run `pnpm lint:md`; if it fails only on pre-existing `CHANGELOG.md` blank-line errors, record that as a known blocker and run targeted markdownlint for changed Markdown files.
+- W4.5 Commit implementation with `fix: #72 fix scaffold README skill references`.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md
+++ b/docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md
@@ -1,0 +1,162 @@
+# Design: Fix scaffold agent-plugin README install and skill references
+
+Issue: [patinaproject/skills#72](https://github.com/patinaproject/skills/issues/72)
+
+## Intent
+
+Make the `scaffold-repository` agent-plugin README template emit install,
+invocation, usage, and related-link guidance that stays correct when the
+generated plugin repository name and the generated primary skill name differ.
+
+## Context
+
+- The affected template is
+  [`skills/scaffold-repository/templates/agent-plugin/README.md.tmpl`](../../../skills/scaffold-repository/templates/agent-plugin/README.md.tmpl).
+- `skills/scaffold-repository/SKILL.md` treats `<repo>` and
+  `<primary-skill-name>` as separate scaffold inputs. The primary skill name is
+  optional and, when present, represents the emitted `skills/<name>/SKILL.md`
+  entry point.
+- The current Claude Code install section registers the Patina Project
+  marketplace correctly but invokes `/{{repo}}:{{repo}}`. That is only correct
+  when the plugin slug and primary skill name are identical.
+- The current Usage examples repeat `/{{repo}}:{{repo}}`, so the generated
+  README can teach the same wrong command in more than one place.
+- The current Related section links to `skills/{{repo}}/SKILL.md`, which can
+  point at a missing file when `<primary-skill-name>` differs from `<repo>`.
+- The current Codex CLI install section registers `patinaproject/skills`, then
+  tells users to run `codex plugin marketplace add {{owner}}/{{repo}}@v0.1.0`.
+  That second command registers the generated plugin repository as another
+  marketplace source instead of installing the generated plugin from the
+  already-registered Patina Project skills marketplace.
+- The `write-a-skill` structure check is relevant because the change affects a
+  skill-owned template, not because it creates a new skill. The fix should keep
+  template behavior concise and avoid introducing extra reference material.
+- The `writing-skills` pressure-test dimensions apply because the change lives
+  under `skills/`: preserve testable RED/GREEN behavior, make the failure case
+  explicit, keep role/ownership boundaries clear, avoid rationalizing the
+  `<repo> == <primary-skill-name>` shortcut, and verify the generated docs from
+  rendered output rather than only inspecting the template.
+
+## Requirements
+
+1. The agent-plugin README template must use `{{primary-skill-name}}` anywhere
+   it points at, invokes, or describes the generated primary skill entry point.
+2. The template may continue to use `{{repo}}` for plugin identity, repository
+   identity, marketplace plugin installation, and editor/project surfaces that
+   are keyed by the plugin repository slug.
+3. Claude Code invocation examples must install the plugin by plugin slug but
+   invoke the primary skill by primary skill name.
+4. Usage examples must not reintroduce the repo-name shortcut for skill
+   invocation.
+5. The Related skill link must point at the emitted
+   `skills/{{primary-skill-name}}/SKILL.md` path.
+6. The Codex CLI section must install the generated plugin from the
+   already-registered `patinaproject/skills` marketplace instead of registering
+   the generated plugin repository as a second marketplace source.
+7. The implementation must include a verification path that renders or otherwise
+   evaluates the template with `<repo> != <primary-skill-name>`.
+8. Existing guidance for editor surfaces that read repository files directly
+   must remain keyed to `{{repo}}` unless those surfaces are explicitly invoking
+   the primary skill.
+
+## Acceptance Criteria
+
+### AC-72-1
+
+Given a scaffold request where `<primary-skill-name>` differs from `<repo>`,
+when the generated README is rendered, then the Claude Code invocation examples
+reference the primary skill name rather than the repo name.
+
+### AC-72-2
+
+Given that same generated README, when a reader follows the Related skill link,
+then it points at the emitted `skills/<primary-skill-name>/SKILL.md` file.
+
+### AC-72-3
+
+Given the generated README's Codex CLI installation section, when a reader
+follows the marketplace instructions, then the commands install the generated
+plugin from the registered `patinaproject/skills` marketplace instead of
+registering the generated plugin repo as a second marketplace.
+
+## Approaches Considered
+
+### Recommended: Split plugin slug from primary skill name in README guidance
+
+Update only the agent-plugin README template so plugin installation commands
+keep using `{{repo}}`, while skill invocation examples and the Related skill
+link use `{{primary-skill-name}}`. Add a focused regression check that renders
+the template with intentionally different values, then asserts the relevant
+Claude Code, Usage, Related, and Codex CLI lines.
+
+This directly matches the issue's failure mode and keeps the scaffold prompt
+contract intact: repo slug and skill name remain independent inputs.
+
+### Document `<primary-skill-name> == <repo>` as a constraint
+
+Make the scaffold prompt table declare that the primary skill name must match
+the repository name. This would make the current template easier to defend, but
+it would remove useful flexibility, contradict the current prompt shape, and
+still leave existing callers with confusing generated docs.
+
+### Rename every `{{repo}}` reference in the README template
+
+Replace all README-template uses of `{{repo}}` with `{{primary-skill-name}}`.
+This would fix invocation and Related links, but it would break plugin install
+commands, repository references, Cursor rule names, and places where the plugin
+slug is the correct identifier.
+
+## Decision
+
+Use the targeted split between plugin slug and primary skill identity.
+
+The implementation should update the agent-plugin README template so:
+
+- Claude Code install remains `/plugin install {{repo}}@patinaproject-skills`;
+- Claude Code invocation becomes `/{{repo}}:{{primary-skill-name}}`;
+- Usage examples use `/{{repo}}:{{primary-skill-name}}`;
+- Related links use `skills/{{primary-skill-name}}/SKILL.md`;
+- Codex CLI install uses a plugin-install command against the already-added
+  `patinaproject/skills` marketplace, not another marketplace-add command for
+  `{{owner}}/{{repo}}@v0.1.0`.
+
+If the exact Codex CLI install subcommand is already established elsewhere in
+the repository, reuse that wording. If it is not established, choose the form
+that mirrors the Claude Code marketplace flow: register the marketplace once,
+then install `{{repo}}` from that marketplace with a tag or marketplace
+qualifier rather than adding the generated plugin repository as a marketplace.
+
+## Verification
+
+- Render or programmatically substitute the README template with:
+  - `repo = "workflow-kit"`
+  - `owner = "patinaproject"`
+  - `primary-skill-name = "issue-router"`
+- Assert the rendered Claude Code invocation and Usage examples contain
+  `/workflow-kit:issue-router`.
+- Assert the rendered README does not contain `/workflow-kit:workflow-kit`.
+- Assert the Related skill link points to
+  `./skills/issue-router/SKILL.md`.
+- Assert the Codex CLI section registers `patinaproject/skills` and does not
+  contain `codex plugin marketplace add patinaproject/workflow-kit@v0.1.0`.
+- Run `pnpm lint:md`.
+- Run `pnpm verify:dogfood`.
+- Run `pnpm apply:scaffold-repository:check` to confirm the scaffold baseline
+  remains idempotent.
+
+## Out of Scope
+
+- Changing the scaffold prompt contract to require matching repo and primary
+  skill names.
+- Changing generated plugin manifest names or marketplace metadata outside the
+  README template.
+- Reworking non-plugin README templates.
+- Rewriting historical Superpowers artifacts that contain older example
+  commands.
+
+## Concerns
+
+No approval-blocking concerns remain. The main implementation risk is choosing
+an unsupported Codex CLI install subcommand; the executor should confirm the
+current expected command from repo-local docs or the available Codex plugin
+surface before changing that line.

--- a/docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md
+++ b/docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md
@@ -28,6 +28,17 @@ generated plugin repository name and the generated primary skill name differ.
   That second command registers the generated plugin repository as another
   marketplace source instead of installing the generated plugin from the
   already-registered Patina Project skills marketplace.
+- Local `codex plugin --help` and `codex plugin marketplace --help` expose
+  marketplace management commands (`add`, `upgrade`, `remove`) and no separate
+  `codex plugin install` subcommand. The template must not invent a CLI command
+  that is unsupported by the installed Codex surface.
+- When `<primary-skill-name>` is absent, there is no emitted
+  `skills/<primary-skill-name>/SKILL.md` file to invoke or link. Agent-plugin
+  README generation must either require a primary skill name before emitting the
+  skill-specific README variant, or omit skill-specific invocation examples and
+  Related links. For this issue, the intended fix is to require
+  `<primary-skill-name>` for agent-plugin README generation so the generated
+  plugin has one documented primary skill entry point.
 - The `write-a-skill` structure check is relevant because the change affects a
   skill-owned template, not because it creates a new skill. The fix should keep
   template behavior concise and avoid introducing extra reference material.
@@ -53,9 +64,17 @@ generated plugin repository name and the generated primary skill name differ.
 6. The Codex CLI section must install the generated plugin from the
    already-registered `patinaproject/skills` marketplace instead of registering
    the generated plugin repository as a second marketplace source.
-7. The implementation must include a verification path that renders or otherwise
+7. Because the current Codex CLI exposes marketplace management but no install
+   subcommand, the Codex CLI section must use exactly one CLI command:
+   `codex plugin marketplace add patinaproject/skills`. It must then instruct
+   users to install or enable `{{repo}}` from that registered Patina Project
+   marketplace/plugin source, without adding `{{owner}}/{{repo}}` as another
+   marketplace.
+8. Agent-plugin README generation must require `<primary-skill-name>` when the
+   README includes skill invocation examples or Related skill links.
+9. The implementation must include a verification path that renders or otherwise
    evaluates the template with `<repo> != <primary-skill-name>`.
-8. Existing guidance for editor surfaces that read repository files directly
+10. Existing guidance for editor surfaces that read repository files directly
    must remain keyed to `{{repo}}` unless those surfaces are explicitly invoking
    the primary skill.
 
@@ -116,15 +135,13 @@ The implementation should update the agent-plugin README template so:
 - Claude Code invocation becomes `/{{repo}}:{{primary-skill-name}}`;
 - Usage examples use `/{{repo}}:{{primary-skill-name}}`;
 - Related links use `skills/{{primary-skill-name}}/SKILL.md`;
-- Codex CLI install uses a plugin-install command against the already-added
-  `patinaproject/skills` marketplace, not another marketplace-add command for
-  `{{owner}}/{{repo}}@v0.1.0`.
-
-If the exact Codex CLI install subcommand is already established elsewhere in
-the repository, reuse that wording. If it is not established, choose the form
-that mirrors the Claude Code marketplace flow: register the marketplace once,
-then install `{{repo}}` from that marketplace with a tag or marketplace
-qualifier rather than adding the generated plugin repository as a marketplace.
+- Codex CLI install uses only
+  `codex plugin marketplace add patinaproject/skills`, then tells the user to
+  install or enable `{{repo}}` from the registered Patina Project marketplace or
+  Codex plugin source; it must not include
+  `codex plugin marketplace add {{owner}}/{{repo}}@v0.1.0`;
+- the scaffold path that emits this README requires `<primary-skill-name>` for
+  agent-plugin mode, or otherwise refuses/asks before rendering the README.
 
 ## Verification
 
@@ -139,6 +156,14 @@ qualifier rather than adding the generated plugin repository as a marketplace.
   `./skills/issue-router/SKILL.md`.
 - Assert the Codex CLI section registers `patinaproject/skills` and does not
   contain `codex plugin marketplace add patinaproject/workflow-kit@v0.1.0`.
+- Assert the Codex CLI section contains a positive instruction to install or
+  enable `workflow-kit` from the registered Patina Project marketplace/plugin
+  source, and does not contain an unsupported `codex plugin install` command.
+- Assert the generated README keeps repository-keyed editor/project surfaces as
+  `workflow-kit`, including the Cursor rule path `.cursor/rules/workflow-kit.mdc`.
+- Verify the scaffold path refuses or prompts when agent-plugin README
+  generation lacks `<primary-skill-name>`, so it cannot emit an empty
+  skill-invocation command or `skills//SKILL.md` link.
 - Run `pnpm lint:md`.
 - Run `pnpm verify:dogfood`.
 - Run `pnpm apply:scaffold-repository:check` to confirm the scaffold baseline
@@ -148,6 +173,10 @@ qualifier rather than adding the generated plugin repository as a marketplace.
 
 - Changing the scaffold prompt contract to require matching repo and primary
   skill names.
+- Supporting agent-plugin README generation with no primary skill entry point in
+  this issue. The fix requires `<primary-skill-name>` for this README variant
+  because the template documents a primary skill invocation and Related skill
+  link.
 - Changing generated plugin manifest names or marketplace metadata outside the
   README template.
 - Reworking non-plugin README templates.
@@ -156,7 +185,6 @@ qualifier rather than adding the generated plugin repository as a marketplace.
 
 ## Concerns
 
-No approval-blocking concerns remain. The main implementation risk is choosing
-an unsupported Codex CLI install subcommand; the executor should confirm the
-current expected command from repo-local docs or the available Codex plugin
-surface before changing that line.
+No approval-blocking concerns remain. The main implementation risk is preserving
+existing repo-keyed editor guidance while tightening primary-skill-specific
+examples; the rendered-output regression should catch that split.

--- a/docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md
+++ b/docs/superpowers/specs/2026-05-14-72-fix-scaffold-agent-plugin-readme-install-and-skill-references-design.md
@@ -52,6 +52,8 @@ generated plugin repository name and the generated primary skill name differ.
 
 1. The agent-plugin README template must use `{{primary-skill-name}}` anywhere
    it points at, invokes, or describes the generated primary skill entry point.
+   This includes Claude Code slash-command examples and Codex CLI/App prompt
+   examples that currently say `${{repo}}`.
 2. The template may continue to use `{{repo}}` for plugin identity, repository
    identity, marketplace plugin installation, and editor/project surfaces that
    are keyed by the plugin repository slug.
@@ -61,9 +63,11 @@ generated plugin repository name and the generated primary skill name differ.
    invocation.
 5. The Related skill link must point at the emitted
    `skills/{{primary-skill-name}}/SKILL.md` path.
-6. The Codex CLI section must install the generated plugin from the
-   already-registered `patinaproject/skills` marketplace instead of registering
-   the generated plugin repository as a second marketplace source.
+6. The Codex CLI section must not describe a command-based plugin install path
+   that the installed Codex CLI does not expose. Its command sequence must only
+   register the `patinaproject/skills` marketplace and must direct the user to
+   install or enable the generated plugin from that registered marketplace or
+   Codex plugin source.
 7. Because the current Codex CLI exposes marketplace management but no install
    subcommand, the Codex CLI section must use exactly one CLI command:
    `codex plugin marketplace add patinaproject/skills`. It must then instruct
@@ -94,9 +98,10 @@ then it points at the emitted `skills/<primary-skill-name>/SKILL.md` file.
 ### AC-72-3
 
 Given the generated README's Codex CLI installation section, when a reader
-follows the marketplace instructions, then the commands install the generated
-plugin from the registered `patinaproject/skills` marketplace instead of
-registering the generated plugin repo as a second marketplace.
+follows the marketplace instructions, then the command sequence registers only
+the `patinaproject/skills` marketplace and the surrounding instruction tells the
+reader to install or enable the generated plugin from that registered source
+instead of registering the generated plugin repo as a second marketplace.
 
 ## Approaches Considered
 
@@ -133,7 +138,11 @@ The implementation should update the agent-plugin README template so:
 
 - Claude Code install remains `/plugin install {{repo}}@patinaproject-skills`;
 - Claude Code invocation becomes `/{{repo}}:{{primary-skill-name}}`;
-- Usage examples use `/{{repo}}:{{primary-skill-name}}`;
+- Codex CLI/App prompt examples become `Use ${{primary-skill-name}} for the
+  workflow described above.`;
+- Usage examples use `/{{repo}}:{{primary-skill-name}}` when showing Claude Code
+  slash commands and `${{primary-skill-name}}` when showing Codex prompt
+  examples;
 - Related links use `skills/{{primary-skill-name}}/SKILL.md`;
 - Codex CLI install uses only
   `codex plugin marketplace add patinaproject/skills`, then tells the user to
@@ -152,6 +161,8 @@ The implementation should update the agent-plugin README template so:
 - Assert the rendered Claude Code invocation and Usage examples contain
   `/workflow-kit:issue-router`.
 - Assert the rendered README does not contain `/workflow-kit:workflow-kit`.
+- Assert the rendered Codex CLI and Codex App prompt examples contain
+  `$issue-router` and do not contain `$workflow-kit`.
 - Assert the Related skill link points to
   `./skills/issue-router/SKILL.md`.
 - Assert the Codex CLI section registers `patinaproject/skills` and does not

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "skills:install": "bash scripts/install-third-party-skills.sh",
     "verify:dogfood": "bash scripts/verify-dogfood.sh",
     "verify:marketplace": "bash scripts/verify-marketplace.sh",
+    "verify:scaffold-readme": "node scripts/verify-scaffold-agent-plugin-readme.js",
     "verify:superteam": "bash scripts/verify-superteam-contract.sh",
     "apply:scaffold-repository": "node scripts/apply-scaffold-repository.js skills/scaffold-repository",
     "apply:scaffold-repository:check": "node scripts/apply-scaffold-repository.js skills/scaffold-repository --check"

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -18,6 +18,7 @@ const codexPluginTemplatePath = path.join(
   "skills/scaffold-repository/templates/agent-plugin/.codex-plugin/plugin.json.tmpl",
 );
 const skillContractPath = path.join(repoRoot, "skills/scaffold-repository/SKILL.md");
+const auditChecklistPath = path.join(repoRoot, "skills/scaffold-repository/audit-checklist.md");
 
 const values = {
   owner: "patinaproject",
@@ -75,6 +76,7 @@ const template = fs.readFileSync(templatePath, "utf8");
 const skillTemplate = fs.readFileSync(skillTemplatePath, "utf8");
 const codexPluginTemplate = fs.readFileSync(codexPluginTemplatePath, "utf8");
 const skillContract = fs.readFileSync(skillContractPath, "utf8");
+const auditChecklist = fs.readFileSync(auditChecklistPath, "utf8");
 const rendered = renderTemplate(template, values);
 const renderedSkill = renderTemplate(skillTemplate, values);
 const renderedCodexPlugin = renderTemplate(codexPluginTemplate, {
@@ -106,6 +108,16 @@ assertIncludes(
   skillContract,
   "must collect `<primary-skill-name>` before rendering the README and primary skill starter",
   "Primary skill render requirement",
+);
+assertIncludes(
+  auditChecklist,
+  "skills/<primary-skill-name>/SKILL.md",
+  "Realignment primary skill check",
+);
+assertIncludes(
+  auditChecklist,
+  "`skills/.gitkeep` alone is stale for agent-plugin repos",
+  "Realignment stale gitkeep check",
 );
 assertIncludes(rendered, ".cursor/rules/workflow-kit.mdc", "Cursor rule path");
 assertNotIncludes(renderedSkill, "{{", "rendered primary skill starter");

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -13,6 +13,10 @@ const skillTemplatePath = path.join(
   repoRoot,
   "skills/scaffold-repository/templates/agent-plugin/skills/{{primary-skill-name}}/SKILL.md.tmpl",
 );
+const codexPluginTemplatePath = path.join(
+  repoRoot,
+  "skills/scaffold-repository/templates/agent-plugin/.codex-plugin/plugin.json.tmpl",
+);
 const skillContractPath = path.join(repoRoot, "skills/scaffold-repository/SKILL.md");
 
 const values = {
@@ -69,9 +73,16 @@ function renderTemplate(template, replacements) {
 
 const template = fs.readFileSync(templatePath, "utf8");
 const skillTemplate = fs.readFileSync(skillTemplatePath, "utf8");
+const codexPluginTemplate = fs.readFileSync(codexPluginTemplatePath, "utf8");
 const skillContract = fs.readFileSync(skillContractPath, "utf8");
 const rendered = renderTemplate(template, values);
 const renderedSkill = renderTemplate(skillTemplate, values);
+const renderedCodexPlugin = renderTemplate(codexPluginTemplate, {
+  ...values,
+  "author-name": "Test Author",
+  "author-email": "test@example.com",
+  "author-handle": "test-author",
+});
 
 assertNotIncludes(rendered, "{{", "rendered README");
 assertIncludes(rendered, "/workflow-kit:issue-router", "Claude invocation");
@@ -100,6 +111,11 @@ assertIncludes(rendered, ".cursor/rules/workflow-kit.mdc", "Cursor rule path");
 assertNotIncludes(renderedSkill, "{{", "rendered primary skill starter");
 assertIncludes(renderedSkill, "name: issue-router", "primary skill frontmatter");
 assertIncludes(renderedSkill, "Use this skill to run the `workflow-kit` workflow.", "primary skill body");
+
+const codexPlugin = JSON.parse(renderedCodexPlugin);
+const defaultPrompt = codexPlugin.interface.defaultPrompt.join("\n");
+assertIncludes(defaultPrompt, "$issue-router", "Codex plugin default prompt");
+assertNotIncludes(defaultPrompt, "$workflow-kit", "Codex plugin default prompt");
 
 const codexCliSection = getSection(
   rendered,

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -9,6 +9,11 @@ const templatePath = path.join(
   repoRoot,
   "skills/scaffold-repository/templates/agent-plugin/README.md.tmpl",
 );
+const skillTemplatePath = path.join(
+  repoRoot,
+  "skills/scaffold-repository/templates/agent-plugin/skills/{{primary-skill-name}}/SKILL.md.tmpl",
+);
+const skillContractPath = path.join(repoRoot, "skills/scaffold-repository/SKILL.md");
 
 const values = {
   owner: "patinaproject",
@@ -63,7 +68,10 @@ function renderTemplate(template, replacements) {
 }
 
 const template = fs.readFileSync(templatePath, "utf8");
+const skillTemplate = fs.readFileSync(skillTemplatePath, "utf8");
+const skillContract = fs.readFileSync(skillContractPath, "utf8");
 const rendered = renderTemplate(template, values);
+const renderedSkill = renderTemplate(skillTemplate, values);
 
 assertNotIncludes(rendered, "{{", "rendered README");
 assertIncludes(rendered, "/workflow-kit:issue-router", "Claude invocation");
@@ -73,7 +81,25 @@ assertIncludes(
   "[`skills/issue-router/SKILL.md`](./skills/issue-router/SKILL.md)",
   "Related skill link",
 );
+assertIncludes(
+  skillContract,
+  "skills/{{primary-skill-name}}/SKILL.md",
+  "Agent plugin emitted primary skill surface",
+);
+assertIncludes(
+  skillContract,
+  "required when `<is-agent-plugin>` is yes",
+  "Primary skill prompt requirement",
+);
+assertIncludes(
+  skillContract,
+  "must collect `<primary-skill-name>` before rendering the README and primary skill starter",
+  "Primary skill render requirement",
+);
 assertIncludes(rendered, ".cursor/rules/workflow-kit.mdc", "Cursor rule path");
+assertNotIncludes(renderedSkill, "{{", "rendered primary skill starter");
+assertIncludes(renderedSkill, "name: issue-router", "primary skill frontmatter");
+assertIncludes(renderedSkill, "Use this skill to run the `workflow-kit` workflow.", "primary skill body");
 
 const codexCliSection = getSection(
   rendered,

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = process.cwd();
+const templatePath = path.join(
+  repoRoot,
+  "skills/scaffold-repository/templates/agent-plugin/README.md.tmpl",
+);
+
+const values = {
+  owner: "patinaproject",
+  repo: "workflow-kit",
+  "repo-description": "Workflow coordination test plugin.",
+  "primary-skill-name": "issue-router",
+};
+
+function fail(message) {
+  console.error(`verify-scaffold-agent-plugin-readme: ${message}`);
+  process.exit(1);
+}
+
+function assertIncludes(content, expected, label) {
+  if (!content.includes(expected)) {
+    fail(`${label}: expected to find ${JSON.stringify(expected)}`);
+  }
+}
+
+function assertNotIncludes(content, unexpected, label) {
+  if (content.includes(unexpected)) {
+    fail(`${label}: did not expect to find ${JSON.stringify(unexpected)}`);
+  }
+}
+
+function getSection(content, heading, nextHeading) {
+  const start = content.indexOf(heading);
+  if (start === -1) {
+    fail(`missing section heading ${JSON.stringify(heading)}`);
+  }
+
+  const end = content.indexOf(nextHeading, start + heading.length);
+  if (end === -1) {
+    fail(`missing next section heading ${JSON.stringify(nextHeading)}`);
+  }
+
+  return content.slice(start, end);
+}
+
+function renderTemplate(template, replacements) {
+  if (!replacements["primary-skill-name"]?.trim()) {
+    throw new Error("primary-skill-name is required for agent-plugin README rendering");
+  }
+
+  return template.replace(/\{\{([^}]+)\}\}/g, (match, key) => {
+    if (!Object.hasOwn(replacements, key)) {
+      return match;
+    }
+
+    return replacements[key];
+  });
+}
+
+const template = fs.readFileSync(templatePath, "utf8");
+const rendered = renderTemplate(template, values);
+
+assertNotIncludes(rendered, "{{", "rendered README");
+assertIncludes(rendered, "/workflow-kit:issue-router", "Claude invocation");
+assertNotIncludes(rendered, "/workflow-kit:workflow-kit", "Claude invocation");
+assertIncludes(
+  rendered,
+  "[`skills/issue-router/SKILL.md`](./skills/issue-router/SKILL.md)",
+  "Related skill link",
+);
+assertIncludes(rendered, ".cursor/rules/workflow-kit.mdc", "Cursor rule path");
+
+const codexCliSection = getSection(
+  rendered,
+  "### OpenAI Codex CLI",
+  "### OpenAI Codex App",
+);
+assertIncludes(
+  codexCliSection,
+  "codex plugin marketplace add patinaproject/skills",
+  "Codex CLI marketplace registration",
+);
+assertIncludes(codexCliSection, "$issue-router", "Codex CLI prompt");
+assertNotIncludes(codexCliSection, "$workflow-kit", "Codex CLI prompt");
+assertIncludes(
+  codexCliSection,
+  "Install or enable `workflow-kit` from the registered Patina Project marketplace/plugin source.",
+  "Codex CLI install guidance",
+);
+
+const marketplaceAddCommands = codexCliSection.match(/codex plugin marketplace add /g) ?? [];
+if (marketplaceAddCommands.length !== 1) {
+  fail(
+    `Codex CLI marketplace registration: expected exactly one marketplace add command, found ${marketplaceAddCommands.length}`,
+  );
+}
+
+assertNotIncludes(
+  codexCliSection,
+  "codex plugin marketplace add patinaproject/workflow-kit@v0.1.0",
+  "Codex CLI generated plugin repo registration",
+);
+assertNotIncludes(codexCliSection, "codex plugin install", "Codex CLI unsupported install command");
+
+const codexAppSection = getSection(
+  rendered,
+  "### OpenAI Codex App",
+  "### GitHub Copilot",
+);
+assertIncludes(codexAppSection, "$issue-router", "Codex App prompt");
+assertNotIncludes(codexAppSection, "$workflow-kit", "Codex App prompt");
+
+try {
+  renderTemplate(template, { ...values, "primary-skill-name": "" });
+  fail("empty primary skill name should be rejected before rendering");
+} catch (error) {
+  if (!/primary-skill-name is required/.test(error.message)) {
+    throw error;
+  }
+}
+
+console.log("verify-scaffold-agent-plugin-readme: ok");

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -118,12 +118,13 @@ Emitted only when `<is-agent-plugin>` is yes:
 README.md                           (replaces core README with installation instructions)
 release-please-config.json
 .release-please-manifest.json
+skills/{{primary-skill-name}}/SKILL.md
 skills/.gitkeep
 ```
 
 The agent-plugin `README.md.tmpl` is richer than the core one: it includes install steps for Claude Code, Codex CLI, and Codex App, plus usage examples. The core `README.md.tmpl` is emitted only for non-plugin repos.
 
-Because the agent-plugin README documents a primary skill invocation and links to that skill contract, agent-plugin mode must collect `<primary-skill-name>` before rendering the README.
+Because the agent-plugin README documents a primary skill invocation and links to that skill contract, agent-plugin mode must collect `<primary-skill-name>` before rendering the README and primary skill starter.
 
 Aider, Zed, Cline, and Opencode read `AGENTS.md` natively and are covered by the core baseline – no dedicated surface needed. Codex CLI also reads `AGENTS.md` natively but additionally consumes `.codex-plugin/plugin.json` in agent-plugin mode. Continue.dev is available as an opt-in secondary editor (`.continue/config.json`).
 

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -60,7 +60,7 @@ The skill collects the following inputs. Author name, author email, and the secu
 | `<visibility>` | public | public \| private |
 | `<is-agent-plugin>` | no | yes emits plugin/config surfaces for every supported AI coding tool |
 | `<use-superteam>` | no | yes emits `docs/superpowers/` skeleton |
-| `<primary-skill-name>` | – | optional; scaffolds `skills/<name>/SKILL.md` starter |
+| `<primary-skill-name>` | – | required when `<is-agent-plugin>` is yes; scaffolds `skills/<name>/SKILL.md` starter |
 | `<codeowner>` | `@<owner>` | written into `.github/CODEOWNERS` |
 | `<security-contact>` | from `git config user.email` | public repos only; written into `SECURITY.md` |
 | `<author-name>` | from `git config user.name` | written into every `author` block |
@@ -122,6 +122,8 @@ skills/.gitkeep
 ```
 
 The agent-plugin `README.md.tmpl` is richer than the core one: it includes install steps for Claude Code, Codex CLI, and Codex App, plus usage examples. The core `README.md.tmpl` is emitted only for non-plugin repos.
+
+Because the agent-plugin README documents a primary skill invocation and links to that skill contract, agent-plugin mode must collect `<primary-skill-name>` before rendering the README.
 
 Aider, Zed, Cline, and Opencode read `AGENTS.md` natively and are covered by the core baseline – no dedicated surface needed. Codex CLI also reads `AGENTS.md` natively but additionally consumes `.codex-plugin/plugin.json` in agent-plugin mode. Continue.dev is available as an opt-in secondary editor (`.continue/config.json`).
 

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -87,7 +87,7 @@ When detected, the following surfaces should all be present. Missing platforms a
 | `.release-please-manifest.json` | yes | valid JSON; `.` version matches `package.json.version` |
 | `.cursor/rules/<repo>.mdc` | yes | present with frontmatter |
 | `.windsurfrules` | yes | present |
-| `skills/` | yes | directory exists with at least a `.gitkeep` or a skill subdirectory |
+| `skills/<primary-skill-name>/SKILL.md` | yes | present; frontmatter `name:` equals the primary skill name documented by the README/plugin workflow; `skills/.gitkeep` alone is stale for agent-plugin repos |
 
 Author URLs in `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` must point to the resolved `https://github.com/<author-handle>`, not the repository owner URL. Repository-level URLs such as `homepage`, `repository`, and Codex interface URLs stay on `https://github.com/<owner>/<repo>`.
 

--- a/skills/scaffold-repository/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
+++ b/skills/scaffold-repository/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
@@ -23,7 +23,7 @@
     "privacyPolicyURL": "https://github.com/{{owner}}/{{repo}}",
     "termsOfServiceURL": "https://github.com/{{owner}}/{{repo}}",
     "defaultPrompt": [
-      "Use ${{repo}} for the workflow described in this plugin's README."
+      "Use ${{primary-skill-name}} for the workflow described in this plugin's README."
     ],
     "brandColor": "#E6A77E"
   }

--- a/skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
+++ b/skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
@@ -32,7 +32,7 @@
 3. Open a target repository (or an issue in one) in Claude Code and invoke:
 
    ```text
-   /{{repo}}:{{repo}}
+   /{{repo}}:{{primary-skill-name}}
    ```
 
 ### OpenAI Codex CLI
@@ -43,16 +43,12 @@
    codex plugin marketplace add patinaproject/skills
    ```
 
-2. Install the plugin (pin to a tag for reproducible installs):
-
-   ```bash
-   codex plugin marketplace add {{owner}}/{{repo}}@v0.1.0
-   ```
+2. Install or enable `{{repo}}` from the registered Patina Project marketplace/plugin source.
 
 3. Invoke from the target repository:
 
    ```text
-   Use ${{repo}} for the workflow described above.
+   Use ${{primary-skill-name}} for the workflow described above.
    ```
 
 ### OpenAI Codex App
@@ -62,7 +58,7 @@
 3. Invoke:
 
    ```text
-   Use ${{repo}} for the workflow described above.
+   Use ${{primary-skill-name}} for the workflow described above.
    ```
 
 ### GitHub Copilot
@@ -153,8 +149,8 @@ Then ask Continue to apply the `{{repo}}` workflow described in `AGENTS.md`.
 
 <!-- Example prompts or invocations tailored to this plugin. -->
 <!-- Example: -->
-<!-- /{{repo}}:{{repo}} work on issue 42 -->
-<!-- /{{repo}}:{{repo}} resume from review -->
+<!-- /{{repo}}:{{primary-skill-name}} work on issue 42 -->
+<!-- /{{repo}}:{{primary-skill-name}} resume from review -->
 
 ## Development
 
@@ -188,6 +184,6 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`AGENTS.md`](./AGENTS.md).
 
 ## Related
 
-- [`skills/{{repo}}/SKILL.md`](./skills/{{repo}}/SKILL.md) – skill contract.
+- [`skills/{{primary-skill-name}}/SKILL.md`](./skills/{{primary-skill-name}}/SKILL.md) – skill contract.
 - [`patinaproject/skills`](https://github.com/patinaproject/skills) – marketplace distributing Patina Project plugins.
 - [`patinaproject/bootstrap`](https://github.com/patinaproject/bootstrap) – scaffolding skill that emitted this repo's baseline.

--- a/skills/scaffold-repository/templates/agent-plugin/skills/{{primary-skill-name}}/SKILL.md.tmpl
+++ b/skills/scaffold-repository/templates/agent-plugin/skills/{{primary-skill-name}}/SKILL.md.tmpl
@@ -1,0 +1,8 @@
+---
+name: {{primary-skill-name}}
+description: Use when applying the {{repo}} workflow in a target repository.
+---
+
+# {{primary-skill-name}}
+
+Use this skill to run the `{{repo}}` workflow.


### PR DESCRIPTION
# Pull Request

## Linked issue

- Closes #72

## What changed

Context: standalone — fixes scaffolded agent-plugin README guidance when the plugin repository slug and primary skill name differ.

- Updated the agent-plugin README template — skill invocation examples and Related links now use `{{primary-skill-name}}`, while plugin installs and repo-keyed editor surfaces keep using `{{repo}}`.
- Replaced the broken Codex CLI second marketplace registration — generated docs now register `patinaproject/skills` once and tell users to install or enable the plugin from that registered source.
- Added a primary skill starter template and scaffold contract guidance — agent-plugin mode now requires `<primary-skill-name>` because the README links to the emitted skill contract.
- Added `verify:scaffold-readme` — renders the template with `repo != primary-skill-name` and checks the regression cases mechanically.

## Test coverage

Legend for status cells:

- ✅ — required validation passed with no known relevant gap for this column.
- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ — required validation is missing, failing, pending, or merge-blocked.
- ➖ — not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | Scaffold template |
| --- | --- | --- | --- |
| AC-72-1 | Claude invocation uses primary skill | ✅ | ✅ |
| AC-72-2 | Related link points at emitted skill | ✅ | ✅ |
| AC-72-3 | Codex marketplace guidance avoids second registration | ✅ | ✅ |

### AC-72-1

Generated Claude Code invocation examples now use the primary skill name when `<repo>` differs from `<primary-skill-name>`.

- Evidence: Unit test: `pnpm verify:scaffold-readme`, local branch, renders `workflow-kit` plus `issue-router` and asserts `/workflow-kit:issue-router` is present while `/workflow-kit:workflow-kit` is absent.
- Gap: None.
- Manual testing needed: no; rendered-template coverage exercises the failing case directly.

### AC-72-2

The Related skill link now points at the emitted primary skill starter path.

- Evidence: Unit test: `pnpm verify:scaffold-readme`, local branch, asserts `./skills/issue-router/SKILL.md` and renders the new primary skill starter template with `name: issue-router`.
- Gap: None.
- Manual testing needed: no; the verifier checks both the README link and the emitted starter template.

### AC-72-3

The Codex CLI section no longer registers the generated plugin repository as a second marketplace source.

- Evidence: Unit test: `pnpm verify:scaffold-readme`, local branch, asserts the Codex CLI section has exactly one `codex plugin marketplace add` command for `patinaproject/skills`, does not contain `codex plugin marketplace add patinaproject/workflow-kit@v0.1.0`, and does not invent `codex plugin install`.
- Evidence: CLI probe: `codex plugin --help` and `codex plugin marketplace --help`, local branch, confirmed the installed Codex surface exposes marketplace management but no separate plugin install command.
- Gap: None.
- Manual testing needed: no; docs now match the observed CLI surface and avoid the broken command from the issue.

## Testing steps

- [x] Run `pnpm verify:scaffold-readme`; expected result: rendered scaffold README regression checks pass.
- [x] Run `pnpm verify:dogfood`; expected result: all five in-repo skills are discoverable via the flat layout.
- [x] Run `pnpm apply:scaffold-repository:check`; expected result: scaffold baseline is in sync.
- [x] Run targeted Markdown lint for changed Markdown/template files; expected result: zero errors.
- [x] Run `git diff --check 19f6a20..HEAD`; expected result: no whitespace errors.
- [x] Run `pnpm lint:md`; expected result: currently fails only on pre-existing `CHANGELOG.md` MD012 blank-line errors already present on the base branch.
