### PR TITLE
feat: #71 make non-interactive superteam autonomous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [1.2.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.1.0...patinaproject-skills-v1.2.0) (2026-05-14)
 
-
 ### Features
 
 * [#71](https://github.com/patinaproject/skills/issues/71) add non-interactive superteam command ([#73](https://github.com/patinaproject/skills/issues/73)) ([1356457](https://github.com/patinaproject/skills/commit/135645712ad4cdc33e1109314510d5b82ffaab36))

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ contract, including the required
 
 GitHub Actions cannot answer follow-up questions. `superteam-non-interactive`
 is the headless companion to `superteam`: it uses the same teammate workflow,
-artifacts, gates, and Finisher shutdown, but turns every missing prompt-time
-decision into an explicit CI blocker. Use it for one-shot issue runs where all
-required approvals and publish permissions must come from invocation inputs,
-environment variables, or durable repository state.
+artifacts, gates, and Finisher shutdown, but removes human-in-the-loop pauses.
+Clean designs auto-advance, publishing is allowed by default when the CI token
+permits it, and unresolved technical or review blockers are reported in a
+machine-actionable format for the next run. Use it for one-shot issue runs where
+the workflow must proceed from invocation inputs, environment variables, and
+durable repository state instead of chat replies.
 
 It ships with the same `patinaproject-skills` plugin as `superteam`.
 

--- a/scripts/verify-superteam-contract.sh
+++ b/scripts/verify-superteam-contract.sh
@@ -30,6 +30,7 @@ require_file skills/superteam/pre-flight.md
 require_file skills/superteam/routing-table.md
 require_file skills/superteam/project-deltas.md
 require_file skills/superteam/workflow-diagrams.md
+require_file skills/superteam-non-interactive/SKILL.md
 
 for role in team-lead brainstormer planner executor reviewer finisher; do
   require_file "skills/superteam/agents/$role.openai.yaml"
@@ -69,6 +70,19 @@ require_text skills/superteam/pre-flight.md "check_status_inventory_state"
 require_text skills/superteam/pre-flight.md 'ready`: the latest-head PR completion gate has passed'
 require_text skills/superteam/routing-table.md "latest-head PR completion gate"
 require_text skills/superteam/routing-table.md "PR review comments, review threads, bot findings, checks, statuses, mergeability, or CI"
+
+for needle in \
+  "## Autonomy Defaults" \
+  "Never halt just because an interactive Superteam run would have asked a human" \
+  "Gate 1: auto-advance a clean or fully dispositioned design" \
+  "Publishing: allow" \
+  "to push, create, or update the PR" \
+  "SUPERTEAM_ALLOW_PUBLISH=0" \
+  "Halting for" \
+  "being unset"
+do
+  require_text skills/superteam-non-interactive/SKILL.md "$needle"
+done
 
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "" >&2

--- a/skills/superteam-non-interactive/SKILL.md
+++ b/skills/superteam-non-interactive/SKILL.md
@@ -6,8 +6,9 @@ description: Use when running Superteam in GitHub Actions, CI, headless automati
 # superteam-non-interactive
 
 `superteam-non-interactive` is the CI-safe Superteam entry point. It reuses the
-`superteam` teammate contracts, but changes operator interaction into a strict
-fail-fast input contract so GitHub Actions can run without hanging.
+`superteam` teammate contracts, but removes human-in-the-loop pauses so GitHub
+Actions can keep running without waiting for chat approval, confirmation, or
+follow-up choices.
 
 ## Quick start
 
@@ -22,23 +23,52 @@ Superteam in GitHub Actions, or requests a headless one-shot Superteam run.
 4. Route to the owning teammate using the normal Superteam routing table.
 5. Before delegation, load the routed teammate contract from
    `skills/superteam/agents/` or `skills/superteam/.claude/agents/`.
-6. Before any place where `superteam` would ask the operator, require a
-   provided input, deterministic default, or visible durable state. If none
-   exists, halt with a machine-actionable blocker.
+6. Before any place where `superteam` would ask the operator, use the
+   non-interactive autonomy rules below. Do not stop solely to wait for a human
+   approval, confirmation, or policy choice.
 
 ## Non-Interactive Rules
 
 - Never ask a question, wait for approval, present choices, or rely on a future
   chat reply.
-- Never infer missing required context from vibes. Halt instead.
+- Never infer missing required context from vibes. Use only invocation inputs,
+  environment variables, repository state, host capabilities, and the autonomy
+  defaults documented here.
+- Never halt just because an interactive Superteam run would have asked a human
+  to approve, choose, confirm, or continue. In non-interactive mode, convert
+  those points into deterministic action, explicit safe defaults, or a
+  machine-actionable blocker.
 - Use normal Superteam branch switching, dirty-worktree refusal, project delta
   handling, model selection, execution-mode binding, feedback routing, and
   latest-head shutdown.
-- Treat ambiguous operator text as a blocker, not feedback.
+- Treat ambiguous operator text or conflicting durable state as a blocker, not
+  as a request for clarification.
 - Prefer explicit invocation inputs over environment variables; prefer
   environment variables over repository state.
 - Output concise status lines that CI logs can preserve: current phase, issue,
   branch, PR if any, blocker if any, and verification evidence.
+
+## Autonomy Defaults
+
+Unset policy inputs must not create a human approval stop. Apply these defaults
+unless an explicit input overrides them:
+
+- Gate 1: auto-advance a clean or fully dispositioned design. The normal
+  Superteam evidence remains required, including a real adversarial review and
+  no approval-blocking finding.
+- Design findings: route fixable design findings back to `Brainstormer` in the
+  same run. Halt only when a finding remains blocked after the routed teammate
+  has acted or the blocker is not resolvable by the workflow.
+- Publishing: allow `Finisher` to push, create, or update the PR when the host
+  token and branch permissions allow it. `SUPERTEAM_ALLOW_PUBLISH=0` is the
+  opt-out for dry-run or diagnosis jobs.
+- PR shape: create draft PRs by default. `SUPERTEAM_DRAFT_PR=0` requests a
+  ready-for-review PR after local review passes.
+- CI and feedback: if checks are pending, queued, or temporarily unavailable,
+  report `monitoring` with latest-head evidence and exit without asking for a
+  human. A later run resumes the latest-head gate.
+- Merge: do not merge by default. Merging requires an explicit repository
+  automation outside this skill or a future documented input.
 
 ## Inputs
 
@@ -50,47 +80,57 @@ At minimum, one issue source must be present:
 
 Optional CI policy inputs:
 
-- `SUPERTEAM_APPROVE_CLEAN_DESIGN=1`: lets Gate 1 advance only when the design
-  artifact exists, adversarial review is clean or dispositioned, and no
-  approval-blocking finding remains.
-- `SUPERTEAM_ALLOW_PUBLISH=1`: permits Finisher to push and open or update the
-  PR after local review passes.
-- `SUPERTEAM_DRAFT_PR=1`: asks Finisher to create a draft PR when publishing.
+- `SUPERTEAM_APPROVE_CLEAN_DESIGN=0`: disables automatic Gate 1 advancement and
+  turns a clean design into a blocker for diagnosis. The default is `1`.
+- `SUPERTEAM_ALLOW_PUBLISH=0`: prevents Finisher from pushing or opening/updating
+  a PR. The default is `1`.
+- `SUPERTEAM_DRAFT_PR=0`: asks Finisher to create a ready-for-review PR when
+  publishing. The default is `1` (draft).
 
-Unset optional policy inputs mean "not permitted." Do not prompt to enable them.
+Unset optional policy inputs use the autonomy defaults above. Do not prompt to
+enable or confirm them.
 
 ## Gate Behavior
 
 Gate 1 remains real. In non-interactive mode:
 
 - No design exists: Brainstormer may write and commit one.
-- Design exists but no plan exists: Team Lead may advance to Planner only
-  when `SUPERTEAM_APPROVE_CLEAN_DESIGN=1` and the normal Gate 1 evidence is
-  clean or dispositioned.
-- Gate 1 evidence is blocked, missing, or ambiguous: halt with
+- Design exists but no plan exists: Team Lead advances to Planner when the
+  normal Gate 1 evidence is clean or dispositioned. This is the non-interactive
+  replacement for a human `approve` token.
+- Gate 1 evidence is missing: generate or rerun the missing evidence when the
+  workflow can do so. Halt only if the evidence cannot be produced by the
+  current run.
+- Gate 1 evidence is blocked or ambiguous: route fixable issues back to
+  `Brainstormer`; halt only for unresolved material blockers with
   `superteam halted at Gate 1: <reason>`.
 - Plan exists: execution may continue from the committed plan without a chat
   approval prompt.
 
 Publish behavior remains Finisher-owned. Finisher may push or open a PR only
-when `SUPERTEAM_ALLOW_PUBLISH=1`; otherwise halt with the exact publish action
-that would have been taken.
+when local review has passed and host permissions allow the operation. If
+`SUPERTEAM_ALLOW_PUBLISH=0`, halt with the exact publish action that would have
+been taken.
 
 ## Halt Format
 
-Every non-interactive blocker must be explicit:
+Every non-interactive blocker must be explicit and machine-actionable:
 
 ```text
-superteam halted at <teammate or gate>: non-interactive input missing: <input>
+superteam halted at <teammate or gate>: non-interactive blocker: <reason>
 ```
 
-For CI readability, include a final `next_input:` line when one value would
-unblock the run.
+For CI readability, include a final `next_run:` line when a later run could
+resume automatically, or `next_input:` only when a concrete machine-provided
+input (not a human approval) would unblock the run.
 
 ## Red Flags
 
 - Prompting the operator in a GitHub Actions run.
 - Silently treating missing approval as approval.
+- Halting for `SUPERTEAM_APPROVE_CLEAN_DESIGN` or `SUPERTEAM_ALLOW_PUBLISH`
+  being unset.
 - Skipping adversarial design review because the run is headless.
-- Publishing without `SUPERTEAM_ALLOW_PUBLISH=1`.
+- Treating a blocked or ambiguous Gate 1 review as approved.
+- Publishing after `SUPERTEAM_ALLOW_PUBLISH=0`.
 - Reporting complete before the latest-head PR completion gate passes.


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #71 - follow-up tightening for the already-shipped non-interactive Superteam command.

## What changed

Context: follow-up to #71 and #73 - the initial command existed, but still treated missing policy inputs as CI blockers.

- Updated `superteam-non-interactive` autonomy defaults - clean designs now auto-advance, publish is allowed by default when permissions allow it, and unset policy variables no longer create human-in-the-loop stops.
- Documented the new behavior in the root README - users can see that the command proceeds from durable state and machine-actionable blockers instead of chat replies.
- Added regression assertions for the non-interactive autonomy contract - future edits must keep the no-human-stop defaults visible in verification.
- Removed an extra changelog blank line - keeps repo-wide markdown lint green on current `main`.

## Test coverage

Legend for status cells:

- ✅ - required validation passed with no known relevant gap for this column.
- ⚠️ - validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ - required validation is missing, failing, pending, or merge-blocked.
- ➖ - not relevant to this AC.

| AC | Title | Unit | Repository |
| --- | --- | --- | --- |
| AC-71-3 | Non-interactive input contract | ✅ | ✅ |
| AC-71-4 | No prompts or skipped gates | ✅ | ✅ |
| AC-71-5 | Docs and verification coverage | ✅ | ✅ |

### AC-71-3

Coverage summary focused on the updated input contract and default policy behavior.

- Evidence: `Repository test: bash scripts/verify-superteam-contract.sh, local shell, 2026-05-14`.
- Evidence: `Repository review: skills/superteam-non-interactive/SKILL.md documents default auto-approval, publish opt-out, draft PR default, and monitoring behavior`.
- Gap: None.
- Manual testing needed: no; this is a contract/docs change covered by static verification.

### AC-71-4

Coverage summary focused on preserving gates while removing human-in-the-loop stops.

- Evidence: `Repository test: bash scripts/verify-superteam-contract.sh, local shell, 2026-05-14`.
- Evidence: `Repository review: the skill still requires adversarial Gate 1 evidence, blocks ambiguous or unresolved material findings, and preserves latest-head shutdown`.
- Gap: None.
- Manual testing needed: no; no runtime workflow file changed in this PR.

### AC-71-5

Coverage summary focused on docs and packaging-adjacent verification.

- Evidence: `Repository test: bash scripts/verify-dogfood.sh, local shell, 2026-05-14`.
- Evidence: `Repository test: bash scripts/verify-marketplace.sh, local shell, 2026-05-14`.
- Evidence: `Repository test: pnpm lint:md, local shell, 2026-05-14`.
- Evidence: `Repository test: node scripts/apply-scaffold-repository.js skills/scaffold-repository --check, local shell, 2026-05-14`.
- Gap: None.
- Manual testing needed: no; this PR changes skill contract text and static assertions only.

## Testing steps

- [x] Run `bash scripts/verify-dogfood.sh` and expect all six skills to resolve from the flat layout and dogfood overlays.
- [x] Run `bash scripts/verify-marketplace.sh` and expect Claude and Codex marketplace catalogs to validate.
- [x] Run `bash scripts/verify-superteam-contract.sh` and expect Superteam and non-interactive autonomy assertions to pass.
- [x] Run `pnpm lint:md` and expect zero markdownlint errors.
- [x] Run `node scripts/apply-scaffold-repository.js skills/scaffold-repository --check` and expect the scaffold baseline to be in sync.