### PR TITLE
ci: #78 upgrade semantic pull request action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,8 +24,8 @@ jobs:
           fi
 
       - name: Validate conventional commits
-        # amannn/action-semantic-pull-request@v5.5.3
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        # amannn/action-semantic-pull-request@v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/docs/superpowers/plans/2026-05-14-78-upgrade-semantic-pull-request-action-to-v6-1-1-plan.md
+++ b/docs/superpowers/plans/2026-05-14-78-upgrade-semantic-pull-request-action-to-v6-1-1-plan.md
@@ -1,0 +1,57 @@
+# Plan: Upgrade semantic pull request action to v6.1.1
+
+## Issue
+
+- Issue: #78
+- Design:
+  `docs/superpowers/specs/2026-05-14-78-upgrade-semantic-pull-request-action-to-v6-1-1-design.md`
+
+## Objective
+
+Update the repository's PR-title workflow and the scaffold-owned template copy
+to use `amannn/action-semantic-pull-request@v6.1.1` pinned to
+`48f256284bd46cdaab1048c3721360e808335d50`, without changing the PR-title
+policy configuration.
+
+## Task 1: Update both workflow copies
+
+- Edit `.github/workflows/pull-request.yml`.
+- Edit `skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml`.
+- In both files, change only the adjacent action-version comment and the
+  full-SHA `uses:` line for `amannn/action-semantic-pull-request`.
+- Preserve all `with:` inputs and surrounding workflow behavior.
+
+## Task 2: Verify local invariants
+
+- Confirm the old v5.5.3 comment and SHA are absent from both active workflow
+  copies.
+- Confirm the v6.1.1 comment and SHA are present in both active workflow copies.
+- Confirm the two workflow copies remain synchronized for the semantic action
+  step.
+- Run the scaffold repository check so the root workflow and template copy do
+  not drift.
+- Run repository verification commands appropriate for workflow/template edits.
+
+## Task 3: Publish and capture PR evidence
+
+- Open a pull request with a compliant title and no `dependencies` label.
+- Record evidence that the upgraded `Validate conventional commits` step
+  executes and passes for the compliant title.
+- Temporarily retitle the PR to a non-compliant title, record evidence that the
+  upgraded step executes and fails with the configured title guidance, then
+  restore the compliant title.
+- Record AC evidence in the PR body using the repository PR template.
+
+## Verification Commands
+
+- `rg -n 'amannn/action-semantic-pull-request@(v5\.5\.3|0723387faaf9b38adef4775cd42cfd5155ed6017|v6\.1\.1|48f256284bd46cdaab1048c3721360e808335d50)' .github/workflows/pull-request.yml skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml`
+- `git diff --check -- .github/workflows/pull-request.yml skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml`
+- `pnpm apply:scaffold-repository:check`
+- `pnpm lint:md`
+- `pnpm verify:dogfood`
+- `pnpm verify:marketplace`
+- `pnpm verify:superteam`
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-14-78-upgrade-semantic-pull-request-action-to-v6-1-1-design.md
+++ b/docs/superpowers/specs/2026-05-14-78-upgrade-semantic-pull-request-action-to-v6-1-1-design.md
@@ -1,0 +1,79 @@
+# Upgrade semantic pull request action to v6.1.1
+
+## Issue
+
+- Issue: #78
+- Title: Upgrade semantic pull request action to v6.1.1
+
+## Intent
+
+Update the skills repository PR-title workflow to use the current
+`amannn/action-semantic-pull-request` release already adopted by the Patina
+Project app repository, while preserving the repository's existing title and
+PR-body policy.
+
+## Requirements
+
+### AC-78-1
+
+Both `.github/workflows/pull-request.yml` and the scaffold-owned template at
+`skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml`
+name `amannn/action-semantic-pull-request@v6.1.1` in the comment immediately
+above the semantic-title action step and pin `uses:` to the full v6.1.1 commit
+SHA `48f256284bd46cdaab1048c3721360e808335d50`.
+
+### AC-78-2
+
+The action upgrade preserves the existing `Validate conventional commits`
+configuration in both workflow copies, including allowed types,
+`requireScope: false`, `disallowScopes`, `subjectPattern`,
+`subjectPatternError`, and `ignoreLabels: dependencies`.
+
+### AC-78-3
+
+After the pull request is opened, PR workflow evidence shows that the upgraded
+action executes and passes for a compliant PR title. Evidence must show the
+`Validate conventional commits` step actually ran rather than skipped, and that
+the triggering run payload did not include an ignored label such as
+`dependencies`.
+
+### AC-78-4
+
+After the pull request is opened, PR workflow evidence shows that the upgraded
+action executes and fails for a temporary non-compliant PR title. Evidence must
+show the `Validate conventional commits` step actually ran rather than skipped,
+and that the triggering run payload did not include an ignored label such as
+`dependencies`; the PR title is restored after capturing that evidence.
+
+## Non-goals
+
+- Do not change PR-title policy, commit conventions, issue templates, or PR-body
+  requirements.
+- Do not introduce a new generated scaffold template for this workflow unless a
+  separate issue requests it. Keeping the existing static scaffold template in
+  sync is required scope.
+- Do not rewrite historical Superteam planning artifacts that mention the old
+  action version.
+
+## Implementation Notes
+
+- The expected code change is the same two-line workflow edit in both the root
+  workflow and the existing scaffold template copy.
+- The v6.1.1 action commit is
+  `48f256284bd46cdaab1048c3721360e808335d50`.
+- The PR must not carry the `dependencies` label while collecting AC-78-3 and
+  AC-78-4 evidence because the workflow skips semantic validation for that
+  label.
+
+## Adversarial Review
+
+Status: findings dispositioned.
+
+- High configuration-drift finding dispositioned by requiring the root workflow
+  and scaffold-owned template to be updated together.
+- Medium skipped-validation evidence finding dispositioned by requiring run
+  evidence that the semantic action step executed rather than skipped and that
+  the triggering run payload did not include `dependencies`.
+- Medium scope-language finding dispositioned by clarifying that no new
+  generated scaffold template is in scope, while the existing static template
+  must remain in sync.

--- a/skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml
+++ b/skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml
@@ -24,8 +24,8 @@ jobs:
           fi
 
       - name: Validate conventional commits
-        # amannn/action-semantic-pull-request@v5.5.3
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        # amannn/action-semantic-pull-request@v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
# Pull Request

## Linked issue

- Closes #78

## What changed

Context: standalone — align the skills repo PR-title action pin with the current Patina Project baseline.

- Updated the root pull-request workflow semantic-title action pin to v6.1.1 — keeps PR-title validation on the current action release.
- Updated the scaffold-repository workflow template with the same pin — prevents root/template scaffold drift.
- Added Superteam design and plan artifacts for issue #78 — records the approved ACs and implementation path.

## Test coverage

| AC | Title | Unit | CI |
| --- | --- | --- | --- |
| AC-78-1 | v6.1.1 SHA pin in both workflow copies | ✅ | ➖ |
| AC-78-2 | existing title-validation config preserved | ✅ | ➖ |
| AC-78-3 | compliant title passes with upgraded action | ➖ | ✅ |
| AC-78-4 | temporary invalid title fails with upgraded action | ➖ | ✅ |

### AC-78-1

Both workflow copies now name `amannn/action-semantic-pull-request@v6.1.1` and pin `uses:` to `48f256284bd46cdaab1048c3721360e808335d50`.

- Evidence: local `rg` over `.github/workflows/pull-request.yml` and `skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml` shows only the v6.1.1 comment and SHA.
- Evidence: `git diff --check -- .github/workflows/pull-request.yml skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml` passed.
- Gap: None.
- Manual testing needed: no.

### AC-78-2

The semantic-title step inputs and surrounding behavior are preserved in both workflow copies.

- Evidence: local diff shows only the adjacent action-version comment and full-SHA `uses:` line changed in each workflow copy.
- Evidence: `pnpm apply:scaffold-repository:check`, `pnpm verify:dogfood`, `pnpm verify:marketplace`, `pnpm verify:superteam`, and focused `pnpm exec actionlint .github/workflows/pull-request.yml skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml` passed.
- Gap: `pnpm lint:md` is not fully green because unchanged `CHANGELOG.md` has pre-existing `MD012/no-multiple-blanks` violations at lines 5 and 10.
- Manual testing needed: no.

### AC-78-3

The upgraded semantic-title action executed and passed for compliant title `ci: #78 upgrade semantic pull request action`.

- Evidence: Pull Request run https://github.com/patinaproject/skills/actions/runs/25871004958 passed; its `Validate conventional commits` log shows `Run amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50` and the existing workflow inputs.
- Evidence: PR #80 had no labels when the run was collected, and issue events show only title rename events, with no label add/remove events.
- Gap: None.
- Manual testing needed: no.

### AC-78-4

The upgraded semantic-title action executed and failed for temporary non-compliant title `ci: upgrade semantic pull request action`, then the PR title was restored.

- Evidence: Pull Request run https://github.com/patinaproject/skills/actions/runs/25871040673 failed at `Validate conventional commits`; its log shows `Run amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50` and the configured `PR title subject must start with a GitHub issue reference` guidance.
- Evidence: PR #80 had no labels when the run was collected, and issue events show only title rename events, with no label add/remove events.
- Evidence: Pull Request run https://github.com/patinaproject/skills/actions/runs/25871071328 passed after restoring title `ci: #78 upgrade semantic pull request action`.
- Gap: None.
- Manual testing needed: no.

## Testing steps

- [x] Confirm root and scaffold workflow copies use the same v6.1.1 semantic-pull-request action pin.
- [x] Confirm scaffold baseline verification passes.
- [x] Confirm the final PR title is restored to `ci: #78 upgrade semantic pull request action` after negative-title evidence is captured.
