### PR TITLE
fix: #81 auto-prepare superteam issue branches

### DIFF
--- a/docs/superpowers/plans/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-plan.md
+++ b/docs/superpowers/plans/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-plan.md
@@ -1,0 +1,57 @@
+# Plan: Superteam Creates Issue Branches in Brand-New Worktrees [#81](https://github.com/patinaproject/skills/issues/81)
+
+## Approved Design
+
+- Design artifact: `docs/superpowers/specs/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-design.md`
+- Gate 1 approval: operator explicitly approved on 2026-05-15.
+- Handoff commit: `919c80d`
+
+## Workstreams
+
+### W1: Update the portable pre-flight branch procedure
+
+Update `skills/superteam/pre-flight.md`.
+
+Tasks:
+
+- W1.1 Expand the auto-switch trigger from default-branch-only to explicit issue
+  plus branch state that is not already the matching issue branch.
+- W1.2 Define branch-state classification for default branch, detached `HEAD`,
+  and unborn/unresolvable current branch.
+- W1.3 Preserve dirty-worktree refusal before branch creation or checkout.
+- W1.4 Preserve no-op behavior for the matching issue branch.
+- W1.5 Preserve halt behavior for conflicting non-default issue branches.
+- W1.6 Make clear that normal Superteam issue prompts activate branch
+  preparation automatically; `new branch` is not required.
+
+Acceptance criteria covered: AC-81-1, AC-81-2, AC-81-3, AC-81-4, AC-81-5.
+
+### W2: Update top-level Superteam contract guardrails
+
+Update `skills/superteam/SKILL.md`.
+
+Tasks:
+
+- W2.1 Add concise pre-flight summary language for detached and unborn worktree
+  auto-branch preparation.
+- W2.2 Add rationalization resistance rows against requiring `new branch` and
+  against continuing from detached or unborn worktree states.
+- W2.3 Add red flags for artifact inspection before auto-switch from detached or
+  unborn branch state.
+
+Acceptance criteria covered: AC-81-1, AC-81-4, AC-81-5.
+
+### W3: Verify the workflow contract
+
+Tasks:
+
+- W3.1 Inspect `skills/superteam/pre-flight.md` for default, detached, unborn,
+  matching-branch, and conflicting-branch behavior.
+- W3.2 Inspect `skills/superteam/SKILL.md` for matching summary,
+  rationalization, and red-flag updates.
+- W3.3 Run `bash scripts/verify-superteam-contract.sh`.
+- W3.4 Run `pnpm lint:md`.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-design.md
+++ b/docs/superpowers/specs/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-design.md
@@ -1,0 +1,169 @@
+# Design: Superteam Creates Issue Branches in Brand-New Worktrees [#81](https://github.com/patinaproject/skills/issues/81)
+
+## Intent
+
+Make Superteam's pre-flight branch preparation handle a freshly created worktree
+that has not yet been attached to a named issue branch. The workflow should
+create or reuse the issue branch before inspecting committed artifacts or
+delegating teammate work.
+
+## Problem
+
+Superteam already auto-switches when an explicit issue is supplied and the
+current branch is the repository default branch. A brand-new worktree can also
+present as detached `HEAD` or as an unborn branch before the operator has created
+an issue branch. In those states, Superteam can fall through into artifact
+inspection and author design or plan files outside the expected issue branch.
+
+That failure is especially risky for Superteam because its durable state is
+branch-scoped: Gate 1 design artifacts, plan artifacts, implementation commits,
+review evidence, and PR publication all assume work happens on the issue branch.
+
+## Requirements
+
+- AC-81-1: Given Superteam is started for an issue from a brand-new worktree,
+  when branch preparation runs, then Superteam creates and checks out a new
+  branch for that issue before making changes.
+- AC-81-2: Given the issue has a number and title, when Superteam creates the
+  branch, then the branch name defaults to the GitHub-recommended issue branch
+  naming convention.
+- AC-81-3: Given Superteam is already on an appropriate non-default issue
+  branch, when branch preparation runs, then it does not create an unnecessary
+  replacement branch.
+- AC-81-4: Given branch creation fails, when Superteam cannot safely continue,
+  then it reports the failure clearly and stops before making implementation
+  changes.
+
+## Proposed Change
+
+Update `skills/superteam/pre-flight.md` so `## Auto-switch to issue branch`
+triggers when the active issue came from an explicit `#<n>` prompt and the
+current branch state is not already a matching issue branch. The trigger should
+include:
+
+- current branch equals the repository default branch;
+- current branch is detached `HEAD`;
+- current branch cannot be resolved because the worktree is unborn.
+
+Keep the no-op path for an existing matching issue branch. A non-default branch
+whose issue number conflicts with the explicit issue remains a halt, not an
+automatic branch replacement.
+
+Branch naming stays self-contained and deterministic:
+
+1. resolve the issue title from `gh issue view <n> --json number,title,state`;
+2. lowercase the title;
+3. replace runs of non-alphanumeric characters with hyphens;
+4. trim leading and trailing hyphens;
+5. prepend `<issue-number>-`;
+6. truncate the full string to 60 characters, preferring the previous hyphen
+   boundary, then trim trailing hyphens.
+
+This preserves the repository's existing `<issue-number>-<kebab-title>`
+convention while documenting that it is the GitHub-recommended issue branch
+shape for this workflow.
+
+## Surfaces
+
+- `skills/superteam/pre-flight.md`: authoritative portable branch procedure.
+- `skills/superteam/SKILL.md`: concise pre-flight summary, rationalization
+  table, and red flags.
+- `skills/superteam/README.md`: user-facing behavior summary if needed.
+
+No teammate role file needs new ownership. Team Lead already owns pre-flight and
+branch preparation, and the shipped Team Lead files already require pre-flight
+before delegation.
+
+## Non-Goals
+
+- Do not add a separate branch workflow dependency.
+- Do not stash, auto-commit, or rewrite the operator's dirty worktree.
+- Do not change Finisher push or PR ownership.
+- Do not create or replace branches when Superteam is already on the matching
+  issue branch.
+- Do not infer a different issue from a detached commit when the operator
+  supplied an explicit issue.
+
+## Pressure Tests
+
+1. RED: Superteam starts from detached `HEAD` in a clean new worktree with
+   prompt `#81`. Old behavior does not match the default-branch trigger and can
+   inspect artifacts before switching. GREEN: pre-flight classifies detached
+   `HEAD` as branch preparation required, creates or checks out
+   `81-superteam-should-create-issue-branches-in-brand-new-worktrees`, and only
+   then inspects artifacts.
+2. RED: Superteam starts from an unborn clean branch in a new worktree. Old
+   behavior cannot compare the current branch to the default branch and may
+   silently continue. GREEN: pre-flight treats unresolved current branch as
+   brand-new worktree state, resolves the default branch, and switches to the
+   computed issue branch or halts with a clear branch-creation failure.
+3. RED: Superteam starts on `81-superteam-should-create-issue-branches-in-brand-new-worktrees`.
+   A naive fix creates a replacement branch or rebases unnecessarily. GREEN:
+   the matching issue branch remains a no-op.
+4. RED: Superteam starts on `64-some-other-issue` while the prompt names `#81`.
+   A broad fix silently switches issues. GREEN: pre-flight halts for conflicting
+   active issue candidates.
+
+## Workflow-Contract Considerations
+
+This touches `skills/**/*.md` and Superteam's pre-flight contract, so the
+writing-skills dimensions apply.
+
+- RED/GREEN baseline obligations: the pressure tests above name the old failing
+  states and the new observable behavior.
+- Rationalization resistance: keep explicit table rows forbidding detached or
+  unborn worktree fallthrough and forbidding branch replacement on mismatched
+  non-default branches.
+- Red flags: add checks for detached or unborn branch states continuing into
+  artifact inspection.
+- Token efficiency: keep the detailed algorithm in `pre-flight.md`; keep
+  `SKILL.md` to summary, rationale, and red flags.
+- Role ownership: Team Lead owns pre-flight; no Brainstormer, Planner,
+  Executor, Reviewer, or Finisher contract gains branch ownership.
+- Stage-gate bypass paths: branch preparation still happens before artifact
+  inspection and before Gate 1 artifact creation; dirty worktrees and branch
+  conflicts halt instead of being hidden.
+
+## Adversarial Review
+
+Reviewer context: same-thread fallback.
+
+Findings:
+
+- source: adversarial-review
+  severity: material
+  location: Proposed Change
+  finding: A trigger that treats any non-matching branch as brand-new would
+  silently switch away from a real branch and mask issue conflicts.
+  disposition: Addressed by requiring no-op on matching issue branches and
+  preserving halt behavior for conflicting non-default branch issue numbers.
+- source: adversarial-review
+  severity: material
+  location: Pressure Tests
+  finding: Detached `HEAD` and unborn branch states need separate tests because
+  they fail through different Git commands.
+  disposition: Addressed by separate RED/GREEN pressure tests 1 and 2.
+- source: adversarial-review
+  severity: minor
+  location: Surfaces
+  finding: Role files should not duplicate the algorithm because Team Lead
+  already points to SKILL.md and pre-flight.
+  disposition: Addressed by keeping role files out of scope.
+
+Adversarial review status: findings dispositioned.
+
+Clean pass rationale: The revised design has falsifiable RED/GREEN cases,
+preserves Team Lead ownership, keeps detailed procedure text in the supporting
+reference, and does not weaken Gate 1, dirty-worktree, or conflicting-issue
+halts.
+
+## Verification
+
+- Inspect `skills/superteam/pre-flight.md` for default, detached, and unborn
+  branch auto-switch triggers.
+- Inspect `skills/superteam/pre-flight.md` for no-op behavior on matching issue
+  branches and halt behavior for conflicting non-default issue branches.
+- Inspect `skills/superteam/SKILL.md` for matching rationalization and red-flag
+  updates.
+- Run `pnpm lint:md`.
+- Run `bash scripts/verify-superteam-contract.sh`.

--- a/docs/superpowers/specs/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-design.md
+++ b/docs/superpowers/specs/2026-05-15-81-superteam-should-create-issue-branches-in-brand-new-worktrees-design.md
@@ -5,7 +5,8 @@
 Make Superteam's pre-flight branch preparation handle a freshly created worktree
 that has not yet been attached to a named issue branch. The workflow should
 create or reuse the issue branch before inspecting committed artifacts or
-delegating teammate work.
+delegating teammate work, without requiring the operator to remember a separate
+`new branch` command.
 
 ## Problem
 
@@ -18,6 +19,9 @@ inspection and author design or plan files outside the expected issue branch.
 That failure is especially risky for Superteam because its durable state is
 branch-scoped: Gate 1 design artifacts, plan artifacts, implementation commits,
 review evidence, and PR publication all assume work happens on the issue branch.
+It is also an operator-experience failure: starting Superteam on an issue should
+be enough intent for Superteam to prepare the issue branch. The operator should
+not have to remember to type `new branch` first.
 
 ## Requirements
 
@@ -33,6 +37,10 @@ review evidence, and PR publication all assume work happens on the issue branch.
 - AC-81-4: Given branch creation fails, when Superteam cannot safely continue,
   then it reports the failure clearly and stops before making implementation
   changes.
+- AC-81-5: Given the operator asks Superteam to work on an explicit issue, when
+  the current worktree has no matching issue branch checked out, then Superteam
+  performs branch preparation automatically without requiring a separate
+  operator phrase such as `new branch`.
 
 ## Proposed Change
 
@@ -48,6 +56,11 @@ include:
 Keep the no-op path for an existing matching issue branch. A non-default branch
 whose issue number conflicts with the explicit issue remains a halt, not an
 automatic branch replacement.
+
+The trigger belongs to every normal Superteam invocation that resolves an
+explicit issue, including prompts phrased as "work on this", "run superteam on
+#N", or equivalent. `new branch` is allowed as harmless operator wording, but it
+must not be required to activate the branch-preparation path.
 
 Branch naming stays self-contained and deterministic:
 
@@ -87,9 +100,10 @@ before delegation.
 ## Pressure Tests
 
 1. RED: Superteam starts from detached `HEAD` in a clean new worktree with
-   prompt `#81`. Old behavior does not match the default-branch trigger and can
-   inspect artifacts before switching. GREEN: pre-flight classifies detached
-   `HEAD` as branch preparation required, creates or checks out
+   prompt `work on #81`. Old behavior does not match the default-branch trigger
+   and can inspect artifacts before switching unless the operator remembers a
+   separate branch command. GREEN: pre-flight classifies detached `HEAD` as
+   branch preparation required, creates or checks out
    `81-superteam-should-create-issue-branches-in-brand-new-worktrees`, and only
    then inspects artifacts.
 2. RED: Superteam starts from an unborn clean branch in a new worktree. Old
@@ -103,6 +117,10 @@ before delegation.
 4. RED: Superteam starts on `64-some-other-issue` while the prompt names `#81`.
    A broad fix silently switches issues. GREEN: pre-flight halts for conflicting
    active issue candidates.
+5. RED: Superteam starts from a clean brand-new worktree with prompt `work on
+   #81` and no `new branch` wording. A narrow fix only runs branch preparation
+   when the operator says `new branch`. GREEN: branch preparation runs because
+   the explicit issue and worktree state are sufficient.
 
 ## Workflow-Contract Considerations
 
@@ -113,7 +131,8 @@ writing-skills dimensions apply.
   states and the new observable behavior.
 - Rationalization resistance: keep explicit table rows forbidding detached or
   unborn worktree fallthrough and forbidding branch replacement on mismatched
-  non-default branches.
+  non-default branches. Also forbid requiring the operator to type `new branch`
+  as a hidden trigger.
 - Red flags: add checks for detached or unborn branch states continuing into
   artifact inspection.
 - Token efficiency: keep the detailed algorithm in `pre-flight.md`; keep
@@ -149,13 +168,22 @@ Findings:
   finding: Role files should not duplicate the algorithm because Team Lead
   already points to SKILL.md and pre-flight.
   disposition: Addressed by keeping role files out of scope.
+- source: brainstormer
+  severity: material
+  location: Intent and Proposed Change
+  finding: The original design did not explicitly say the operator should never
+  have to remember `new branch`; that could let an implementation hide the fix
+  behind a magic phrase.
+  disposition: Addressed by adding AC-81-5, updating the trigger description,
+  and adding pressure test 5.
 
 Adversarial review status: findings dispositioned.
 
 Clean pass rationale: The revised design has falsifiable RED/GREEN cases,
 preserves Team Lead ownership, keeps detailed procedure text in the supporting
 reference, and does not weaken Gate 1, dirty-worktree, or conflicting-issue
-halts.
+halts. The feedback delta makes automatic branch preparation an explicit
+requirement rather than an optional operator command path.
 
 ## Verification
 

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -85,6 +85,10 @@ At the top of every `/superteam` invocation, before any teammate delegation, `Te
 Summary of the sequence:
 
 - Resolve the active issue (explicit `#<n>` in prompt, then branch `<n>-<slug>`, then operator).
+- When an explicit issue is supplied and the worktree is on the default branch,
+  detached `HEAD`, or an unborn branch, auto-switch to the issue branch before
+  artifact inspection. Normal issue-work prompts are enough; `new branch` is
+  not required.
 - Inspect committed artifacts on the branch (design doc, plan doc) at the canonical specs and plans paths.
 - Inspect PR state on origin (open / merged / absent).
 - Derive the detected phase per the rules below.
@@ -394,6 +398,8 @@ Completion language is allowed only after the latest-head PR completion gate pas
 | "The operator said 'go faster' — that's basically asking for Sonnet." | Ambiguous framing is NOT an operator override (R26, parallel to R14). Only canonical tokens (`model: opus`, `model: sonnet`, `model: haiku`, or `use <model>` / `with <model>`) override the per-role default. "Go faster" routes to the per-role default; for `Executor` that is already Sonnet. |
 | "Brainstormer's default is Opus, but the operator typed `model: sonnet`, so I'll keep Opus because the design needs reasoning." | Operator override always wins for the delegation it targets. `Team Lead` does not second-guess the operator's explicit token. Override scope is the next delegation only. |
 | "The operator is on the default branch on purpose; they clearly meant to start work here." | When the active issue resolves from the operator prompt and the current branch is the repository default branch, pre-flight MUST auto-switch to the per-issue branch before committed-artifact inspection. Operator intent is captured by the `#<n>` reference, not by the branch they happened to be on. Not even when the operator is the maintainer. Not even under deadline pressure. |
+| "The operator forgot to type `new branch`, so stay on detached HEAD or an unborn worktree." | `new branch` is not the trigger. An explicit issue in a normal Superteam prompt is enough. Detached `HEAD`, unborn branch, and default-branch states MUST auto-switch before committed-artifact inspection. |
+| "This non-default branch is not for the issue, but auto-switching is probably fine." | A conflicting non-default branch is not a brand-new worktree signal. Halt for disambiguation instead of silently replacing the operator's branch context. |
 | "Skipping the auto-switch saves a step; we can branch later." | Skipping authors Gate 1 artifacts on the wrong base and forces `Finisher` to rewrite history or push from the default branch. The rule is not optional. |
 | "Dirty working tree? I can stash and continue." | The `superteam` issue-branch procedure refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does NOT stash on the operator's behalf. |
 | "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The `superteam` issue-branch procedure forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
@@ -449,6 +455,9 @@ Completion language is allowed only after the latest-head PR completion gate pas
 - Treating ambiguous "faster" / "inline-ish" / "forever" framing as an inline override.
 - Halting a non-execute route solely because execution-mode capability is unavailable.
 - `Team Lead` proceeding to committed-artifact inspection while the current branch is the repository default branch and the active issue was resolved from an explicit `#<n>` in the prompt.
+- `Team Lead` proceeding to committed-artifact inspection while the current branch is detached `HEAD` or unborn and the active issue was resolved from an explicit `#<n>` in the prompt.
+- `Team Lead` requiring the operator to type `new branch` before auto-switching from a default, detached, or unborn worktree state for an explicit issue.
+- `Team Lead` silently switching away from a conflicting non-default branch instead of halting for issue disambiguation.
 - `Team Lead` performing `git stash` or any auto-stash variant as part of the auto-switch path.
 - `Team Lead` running `git rebase --abort` after a rebase conflict on the existing issue branch.
 - `pre-flight.md` depending on an external branch workflow instead of the self-contained issue-branch procedure.

--- a/skills/superteam/pre-flight.md
+++ b/skills/superteam/pre-flight.md
@@ -30,26 +30,61 @@ Run this pre-flight at the top of every `/superteam` invocation, before any team
 
 ## Auto-switch to issue branch
 
-Trigger (both MUST hold): issue came from source 1; current branch equals the default branch from `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`.
+Trigger: issue came from source 1 and branch state is not already the matching
+issue branch. A normal Superteam prompt that names an issue, such as "work on
+#N" or "run superteam on #N", is enough to activate this procedure. The operator
+does not need to type `new branch`.
+
+Branch-state classification:
+
+- **matching issue branch**: current branch matches `<n>-<slug>` for the active
+  issue number. No-op.
+- **conflicting issue branch**: current branch matches `<m>-<slug>` and `m != n`.
+  Halt with condition 3.
+- **default branch**: current branch equals the default branch from
+  `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. Run the
+  algorithm below.
+- **detached HEAD**: current branch resolves to `HEAD`, empty output, or any
+  other detached-state signal from `git rev-parse --abbrev-ref HEAD` /
+  `git branch --show-current`. Run the algorithm below.
+- **unborn or unresolvable branch**: current branch cannot be resolved because
+  the worktree has no checked-out branch yet. Run the algorithm below after the
+  dirty-worktree and default-branch checks.
+- **other non-default branch**: halt with condition 3 unless the operator
+  explicitly disambiguates before continuing.
 
 Algorithm:
 
-1. Refuse a dirty working tree. If `git status --porcelain` is non-empty, halt with condition 5.
-2. Resolve the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If it fails or returns empty, halt with condition 6.
-3. Resolve the issue title with `gh issue view <n> --json number,title,state`. If it fails, halt with condition 8. If the issue is not open, ask the operator before continuing.
-4. Compute the issue branch as `<issue-number>-<kebab-title>`:
+1. Refuse a dirty working tree. If `git status --porcelain` is non-empty, halt
+   with condition 5.
+2. Resolve the default branch with
+   `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If it
+   fails or returns empty, halt with condition 6.
+3. Resolve the current branch state using `git branch --show-current` and
+   `git rev-parse --abbrev-ref HEAD`. Treat command failure, empty output, and
+   `HEAD` as brand-new worktree states when the active issue came from source 1.
+4. If the current branch is the matching issue branch, no-op. If the current
+   branch is another non-default issue branch or any other non-default named
+   branch, halt with condition 3 unless the operator explicitly disambiguates.
+5. Resolve the issue title with `gh issue view <n> --json number,title,state`.
+   If it fails, halt with condition 8. If the issue is not open, ask the operator
+   before continuing.
+6. Compute the issue branch as `<issue-number>-<kebab-title>`:
    - lowercase the title
    - replace each run of non-`[a-z0-9]` characters with one hyphen
    - trim leading and trailing hyphens
    - prepend `<issue-number>-`
    - truncate the full string to 60 characters, preferring the previous hyphen boundary, then trim trailing hyphens
-5. Fetch `origin/<defaultBranch>`.
-6. If the branch does not exist locally, check out `-b <branch> origin/<defaultBranch>`.
-7. If the branch exists locally, check it out and rebase onto `origin/<defaultBranch>`.
-8. If rebase conflicts occur, halt with condition 7 and do not run `git rebase --abort`.
-9. Skip dependency installation; pre-flight needs branch state only. Re-run committed-artifact inspection on the new branch.
+7. Fetch `origin/<defaultBranch>`.
+8. If the branch does not exist locally, check out `-b <branch> origin/<defaultBranch>`.
+9. If the branch exists locally, check it out and rebase onto `origin/<defaultBranch>`.
+10. If rebase conflicts occur, halt with condition 7 and do not run `git rebase --abort`.
+11. Skip dependency installation; pre-flight needs branch state only. Re-run committed-artifact inspection on the new branch.
 
-No-op on `<n>-<slug>` matching the issue, or sources 2/3. Mismatched `<n>` fires halt 3.
+No-op on `<n>-<slug>` matching the issue, or sources 2/3. Mismatched `<n>`
+fires halt 3. Detached `HEAD`, unborn branch, and default branch states are not
+operator intent to stay branchless; the explicit issue reference is the branch
+preparation signal.
 
 Forbidden: auto-stash; `git rebase --abort`; silent fallback on `gh repo view` failure; external branch-workflow dependency.
 
@@ -59,7 +94,10 @@ Halt with the exact blocker string `superteam halted at Team Lead: <reason>` whe
 
 1. The operator prompt or branch name implies `phase=plan` but no design doc exists on the branch at the canonical specs path.
 2. The detected phase is `finish` but no PR exists for the branch on origin.
-3. Multiple candidate active issues are detected and cannot be reconciled (e.g. an explicit `#<n>` in the prompt disagrees with the branch's `<n>-<slug>` and operator does not disambiguate).
+3. Multiple candidate active issues are detected and cannot be reconciled, or a
+   non-default named branch does not match the explicit issue (e.g. an explicit
+   `#<n>` in the prompt disagrees with the branch's `<n>-<slug>` and operator
+   does not disambiguate).
 4. Committed artifacts and PR state cannot be reconciled (e.g. a merged PR exists but the branch has no plan doc, or a plan doc references a different issue than the PR).
 5. `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`.
 6. `superteam halted at Team Lead: default-branch lookup failed; cannot determine whether auto-switch is required`.
@@ -78,7 +116,8 @@ Order:
 
 If multiple candidates conflict, halt per halt condition 3 above.
 
-On default branch with source 1, run `## Auto-switch to issue branch` before step 3.
+On default branch, detached `HEAD`, or unborn branch with source 1, run
+`## Auto-switch to issue branch` before step 3.
 
 ## Local-review resume safety
 

--- a/skills/superteam/pre-flight.md
+++ b/skills/superteam/pre-flight.md
@@ -65,11 +65,14 @@ Algorithm:
    - trim leading and trailing hyphens
    - prepend `<issue-number>-`
    - truncate the full string to 60 characters, preferring the previous hyphen boundary, then trim trailing hyphens
-7. Fetch `origin/<defaultBranch>`.
-8. If the branch does not exist locally, check out `-b <branch> origin/<defaultBranch>`.
-9. If the branch exists locally, check it out and rebase onto `origin/<defaultBranch>`.
-10. If rebase conflicts occur, halt with condition 7 and do not run `git rebase --abort`.
-11. Skip dependency installation; pre-flight needs branch state only. Re-run committed-artifact inspection on the new branch.
+7. Fetch `origin/<defaultBranch>` and probe `origin/<branch>`.
+8. If the branch exists locally, check it out and rebase onto `origin/<defaultBranch>`.
+9. If the branch does not exist locally but `origin/<branch>` exists, check out
+   `-b <branch> --track origin/<branch>`.
+10. If the branch does not exist locally or remotely, check out
+   `-b <branch> origin/<defaultBranch>`.
+11. If rebase conflicts occur, halt with condition 7 and do not run `git rebase --abort`.
+12. Skip dependency installation; pre-flight needs branch state only. Re-run committed-artifact inspection on the new branch.
 
 No-op on `<n>-<slug>` matching the issue, or sources 2/3. Mismatched `<n>`
 fires halt 3. Detached `HEAD`, unborn branch, and default branch states are not

--- a/skills/superteam/pre-flight.md
+++ b/skills/superteam/pre-flight.md
@@ -30,28 +30,18 @@ Run this pre-flight at the top of every `/superteam` invocation, before any team
 
 ## Auto-switch to issue branch
 
-Trigger: issue came from source 1 and branch state is not already the matching
-issue branch. A normal Superteam prompt that names an issue, such as "work on
-#N" or "run superteam on #N", is enough to activate this procedure. The operator
-does not need to type `new branch`.
+Trigger: issue came from source 1 and the current branch state needs issue-branch
+preparation. A normal Superteam prompt that names an issue, such as "work on
+#N" or "run superteam on #N", is enough; the operator does not need to type
+`new branch`.
 
-Branch-state classification:
+Branch states:
 
-- **matching issue branch**: current branch matches `<n>-<slug>` for the active
-  issue number. No-op.
-- **conflicting issue branch**: current branch matches `<m>-<slug>` and `m != n`.
-  Halt with condition 3.
-- **default branch**: current branch equals the default branch from
-  `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. Run the
-  algorithm below.
-- **detached HEAD**: current branch resolves to `HEAD`, empty output, or any
-  other detached-state signal from `git rev-parse --abbrev-ref HEAD` /
-  `git branch --show-current`. Run the algorithm below.
-- **unborn or unresolvable branch**: current branch cannot be resolved because
-  the worktree has no checked-out branch yet. Run the algorithm below after the
-  dirty-worktree and default-branch checks.
-- **other non-default branch**: halt with condition 3 unless the operator
-  explicitly disambiguates before continuing.
+- No-op when the current branch already starts with `<n>-`.
+- Run this procedure from the default branch, detached `HEAD`, or an unborn /
+  unresolvable branch.
+- Halt with condition 3 from any other named branch, including a branch for a
+  different issue, unless the operator explicitly disambiguates.
 
 Algorithm:
 
@@ -63,9 +53,9 @@ Algorithm:
 3. Resolve the current branch state using `git branch --show-current` and
    `git rev-parse --abbrev-ref HEAD`. Treat command failure, empty output, and
    `HEAD` as brand-new worktree states when the active issue came from source 1.
-4. If the current branch is the matching issue branch, no-op. If the current
-   branch is another non-default issue branch or any other non-default named
-   branch, halt with condition 3 unless the operator explicitly disambiguates.
+4. If the current branch already starts with `<n>-`, no-op. If it is any other
+   named non-default branch, halt with condition 3 unless the operator
+   explicitly disambiguates.
 5. Resolve the issue title with `gh issue view <n> --json number,title,state`.
    If it fails, halt with condition 8. If the issue is not open, ask the operator
    before continuing.


### PR DESCRIPTION
## Linked issue

- Closes #81

## What changed

Context: standalone — first pass on automatic Superteam issue-branch preparation for brand-new worktrees.

- Expanded Superteam pre-flight branch-state handling — so explicit issue prompts automatically prepare an issue branch from default, detached, or unborn worktree states without requiring `new branch`.
- Preserved matching-branch no-op and conflicting-branch halt behavior — so Superteam does not replace an already-correct issue branch or silently switch away from unrelated work.
- Added durable design and plan artifacts — so the workflow-contract change has Gate 1 evidence, RED/GREEN pressure tests, and an implementation handoff.

## Test coverage

Legend for status cells:

- ✅ — required validation passed with no known relevant gap for this column.
- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ — required validation is missing, failing, pending, or merge-blocked.
- ➖ — not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | Contract docs |
| --- | --- | --- | --- |
| AC-81-1 | Create/check out issue branch from brand-new worktree | ➖ | ✅ |
| AC-81-2 | Use issue-number kebab-title branch naming | ➖ | ✅ |
| AC-81-3 | Avoid replacement on matching issue branch | ➖ | ✅ |
| AC-81-4 | Halt clearly when branch prep cannot safely continue | ➖ | ✅ |
| AC-81-5 | Do not require `new branch` wording | ➖ | ✅ |

### AC-81-1

Coverage summary focused on what helps a human tester understand the state of this AC.

- Evidence: `Contract docs` inspection: `skills/superteam/pre-flight.md` now classifies default, detached `HEAD`, and unborn/unresolvable branch states as branch-preparation paths before committed-artifact inspection.
- Gap: No runtime harness exists for Superteam pre-flight; validation is contract-level documentation and verifier coverage.
- Manual testing needed: No, unless the reviewer wants to exercise the workflow manually from a temporary worktree.

### AC-81-2

Coverage summary focused on what helps a human tester understand the state of this AC.

- Evidence: `Contract docs` inspection: `skills/superteam/pre-flight.md` keeps the existing `<issue-number>-<kebab-title>` computation, including lowercase normalization, non-alphanumeric hyphen replacement, trimming, prepending the issue number, and 60-character truncation.
- Gap: None.
- Manual testing needed: No.

### AC-81-3

Coverage summary focused on what helps a human tester understand the state of this AC.

- Evidence: `Contract docs` inspection: `skills/superteam/pre-flight.md` defines matching issue branches as a no-op and `skills/superteam/SKILL.md` adds a rationalization row against silent switching from conflicting non-default branches.
- Gap: None.
- Manual testing needed: No.

### AC-81-4

Coverage summary focused on what helps a human tester understand the state of this AC.

- Evidence: `bash scripts/verify-superteam-contract.sh`, local worktree, passed; `skills/superteam/pre-flight.md` preserves dirty-worktree, default-branch lookup, active-issue lookup, and rebase-conflict halt strings.
- Gap: None.
- Manual testing needed: No.

### AC-81-5

Coverage summary focused on what helps a human tester understand the state of this AC.

- Evidence: `Contract docs` inspection: `skills/superteam/pre-flight.md` says normal issue prompts such as `work on #N` activate branch preparation and `new branch` is not required; `skills/superteam/SKILL.md` adds matching rationalization and red-flag guardrails.
- Gap: None.
- Manual testing needed: No.

## Testing steps

- [x] Run `bash scripts/verify-superteam-contract.sh` and expect `OK: superteam contract assertions passed`.
- [x] Run `bash scripts/verify-dogfood.sh` and expect all six in-repo skills to be discoverable.
- [x] Run `bash scripts/verify-marketplace.sh` and expect Claude + Codex marketplace catalogs to validate.
- [x] Run `node scripts/apply-scaffold-repository.js skills/scaffold-repository --check` and expect the scaffold baseline to be in sync.
- [x] Run `pnpm lint:md`; current result fails on pre-existing `CHANGELOG.md` MD012 blank-line issues at lines 5 and 10 that are already present on `origin/main`.
