### PR TITLE
fix: #82 surface brainstorming handoff output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## [1.3.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.2.0...patinaproject-skills-v1.3.0) (2026-05-14)
 
-
 ### Features
 
 * [#71](https://github.com/patinaproject/skills/issues/71) make non-interactive superteam autonomous ([#77](https://github.com/patinaproject/skills/issues/77)) ([42b15d1](https://github.com/patinaproject/skills/commit/42b15d10e959f683a3b40d6f7f732f6c918cb555))
-
 
 ### Bug Fixes
 

--- a/docs/superpowers/plans/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-plan.md
+++ b/docs/superpowers/plans/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-plan.md
@@ -1,0 +1,82 @@
+# Plan: Superteam brainstorming step does not surface useful output [#82](https://github.com/patinaproject/skills/issues/82)
+
+## Approved design
+
+- Design artifact: `docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md`
+- Gate 1 approval: operator explicitly approved on 2026-05-15.
+- Handoff commit: `bde04f4`
+
+## Goal
+
+Make Superteam Gate 1 handoffs show Brainstormer's useful decision trail in a
+concise, conversational approval request instead of a noisy status report.
+
+## Workstreams
+
+### W1: Add Brainstormer output to the cross-role contract
+
+Update `skills/superteam/SKILL.md`.
+
+Tasks:
+
+- W1.1 Add `brainstorming_output` to the Gate 1 evidence required before asking
+  for approval.
+- W1.2 Define `brainstorming_output` in the Brainstormer done-report contract
+  as problem framing, directions considered, recommended direction, notable
+  tradeoffs, and open risks or questions.
+- W1.3 Tighten Gate 1 rendering guidance so Team Lead keeps the required
+  artifact path, full requirement set, adversarial-review result, reviewer
+  context, and clean-pass rationale, but renders them as a short,
+  decision-focused handoff rather than a field dump.
+- W1.4 Add a rationalization-table entry and red flag for treating
+  "conversational" as permission to omit required evidence.
+
+Acceptance criteria covered: AC-82-1, AC-82-2, AC-82-3, AC-82-4.
+
+### W2: Align Brainstormer role surfaces
+
+Update both supported Brainstormer role files.
+
+Files:
+
+- `skills/superteam/.claude/agents/brainstormer.md`
+- `skills/superteam/agents/brainstormer.openai.yaml`
+
+Tasks:
+
+- W2.1 Add a non-negotiable rule requiring Brainstormer to include
+  `brainstorming_output` in the SKILL.md-owned done report.
+- W2.2 State that the field is a concise decision trail, not a raw transcript.
+- W2.3 Keep the role files pointing back to SKILL.md for the full done-report
+  field set rather than restating every field.
+
+Acceptance criteria covered: AC-82-1, AC-82-5.
+
+### W3: Extend contract verification
+
+Update `scripts/verify-superteam-contract.sh`.
+
+Tasks:
+
+- W3.1 Assert `skills/superteam/SKILL.md` contains `brainstorming_output`.
+- W3.2 Assert both Brainstormer role surfaces contain
+  `brainstorming_output`.
+- W3.3 Assert `skills/superteam/SKILL.md` contains the conversational
+  rendering guardrail.
+
+Acceptance criteria covered: AC-82-4, AC-82-5, AC-82-6.
+
+### W4: Verify
+
+Tasks:
+
+- W4.1 Run `pnpm lint:md`.
+- W4.2 Run `pnpm verify:superteam`.
+- W4.3 Inspect the modified contract text to confirm it keeps required Gate 1
+  evidence while reducing operator-facing noise.
+
+Acceptance criteria covered: AC-82-6.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md
+++ b/docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md
@@ -10,7 +10,8 @@ tradeoffs, risks, and open questions.
 
 This is a workflow-contract change. The durable artifact still remains the
 source of truth, but Team Lead must carry Brainstormer's user-facing
-brainstorming output into the Gate 1 approval request.
+brainstorming output into the Gate 1 approval request in a conversational,
+low-noise form.
 
 ## Skill guidance
 
@@ -40,10 +41,18 @@ not guarantee that the default brainstorming output reaches the user. A concise
 intent summary can compress away the useful design exploration: alternatives,
 why the chosen direction won, tradeoffs, risks, and unresolved questions.
 
+The first Gate 1 revision for this issue also exposed a second failure mode:
+even when all required evidence is technically present, a rigid approval packet
+can drown the operator in labels, lists, and workflow noise. The contract should
+make clear that required evidence is not a license to dump every field into
+chat. Team Lead should tell the operator what matters, why it matters, and what
+decision is needed.
+
 ## Goals
 
 - Require Brainstormer to hand off a concise `brainstorming_output` summary.
 - Require Team Lead to include that output in the Gate 1 approval request.
+- Make the Gate 1 handoff conversational and operator-useful by default.
 - Preserve the durable design artifact as the authoritative review target.
 - Keep the output natural and concise; avoid forcing raw transcripts or bulky
   status-report shells into chat.
@@ -83,11 +92,18 @@ a vague fallback summary.
 
 ### AC-82-4
 
+Given Team Lead presents Gate 1 for approval, when required evidence is included
+in the operator-facing message, then it is rendered as a concise conversational
+handoff focused on the approval decision, not as a verbose field dump or fixed
+status-report template.
+
+### AC-82-5
+
 Given a teammate or future maintainer reads the Superteam role contracts, when
 they inspect both Claude Code and Codex Brainstormer surfaces, then both surfaces
 name the `brainstorming_output` handoff obligation consistently.
 
-### AC-82-5
+### AC-82-6
 
 Given the workflow-contract change is implemented, when verification runs, then
 the Superteam contract check and Markdown lint pass.
@@ -101,6 +117,10 @@ Update `skills/superteam/SKILL.md` in two places:
 - Brainstormer done-report contract: add a `brainstorming_output` field with a
   tight definition: problem framing, options or directions considered,
   recommendation, tradeoffs, and open risks or questions.
+- Gate 1 rendering guidance: require Team Lead to render approval requests as
+  natural, decision-focused conversation. Required evidence must be present, but
+  implementation should avoid field labels, exhaustive checklist dumps, and
+  verification noise unless those details affect the approval decision.
 
 Update Brainstormer role surfaces in both supported hosts:
 
@@ -138,6 +158,12 @@ The change should be phrased as evidence, not as a fixed chat template. The
 existing operator-facing output rule still stands: handoffs should read
 naturally and focus on the decision being requested.
 
+A good Gate 1 handoff should usually read like a short note from Team Lead:
+"I think this is ready to approve; here is the decision trail and the few
+requirements that matter." It can mention the artifact path and review result,
+but it should not make those mechanics the main event. Verification details
+belong in the handoff only when they change the operator's decision.
+
 ## Adversarial review
 
 ### RED/GREEN baseline obligations
@@ -157,6 +183,8 @@ design got there and what alternatives or risks matter.
 
 - Gate 1 handoff includes a spec path but no options, tradeoffs, risks, or open
   questions.
+- Gate 1 handoff includes the new field but buries it inside a noisy report
+  shell that still makes the operator hunt for the decision.
 - Brainstormer reports done without the new field.
 - Team Lead treats `brainstorming_output` as optional because the design doc is
   linked.
@@ -167,7 +195,8 @@ design got there and what alternatives or risks matter.
 
 The field should fit in a normal approval handoff. If it grows too large, Team
 Lead should split or condense it into clean sections while preserving the useful
-decision trail.
+decision trail. The default output should prefer short prose over mechanical
+field-by-field rendering.
 
 ### Role ownership
 
@@ -187,5 +216,5 @@ approval request more useful before explicit approval.
 - Run `pnpm lint:md`.
 - Run `pnpm verify:superteam`.
 - Inspect `skills/superteam/SKILL.md` for the new Gate 1 evidence and
-  Brainstormer done-report field.
+  conversational rendering guidance.
 - Inspect both Brainstormer role surfaces for consistent handoff guidance.

--- a/docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md
+++ b/docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md
@@ -1,0 +1,191 @@
+# Design: Superteam brainstorming step does not surface useful output [#82](https://github.com/patinaproject/skills/issues/82)
+
+## Summary
+
+Make Gate 1 surface Brainstormer's actual brainstorming substance, not just the
+branch, spec path, commit, verification status, and approval prompt. The
+approval handoff should include the useful decision trail the operator needs to
+review quickly: problem framing, directions considered, recommendation,
+tradeoffs, risks, and open questions.
+
+This is a workflow-contract change. The durable artifact still remains the
+source of truth, but Team Lead must carry Brainstormer's user-facing
+brainstorming output into the Gate 1 approval request.
+
+## Skill guidance
+
+This change uses the repo-required `write-a-skill` structure review. After
+`pnpm install` restored the vendored Superpowers skills, the
+`superpowers:writing-skills` guidance was also read before finalizing the
+workflow-contract review dimensions:
+
+- RED/GREEN baseline obligations
+- rationalization resistance
+- red flags
+- token-efficiency targets
+- role ownership
+- stage-gate bypass paths
+
+## Problem
+
+Issue #82 reports that the current Gate 1 handoff can look complete while
+omitting the actual brainstorming output. The operator sees a procedural status
+report with a design path and verification results, then is asked to approve the
+spec. That forces the operator to open the artifact just to understand what
+Brainstormer thought through.
+
+The existing contract already requires an artifact path, intent summary,
+requirements, and adversarial-review evidence. Those are necessary, but they do
+not guarantee that the default brainstorming output reaches the user. A concise
+intent summary can compress away the useful design exploration: alternatives,
+why the chosen direction won, tradeoffs, risks, and unresolved questions.
+
+## Goals
+
+- Require Brainstormer to hand off a concise `brainstorming_output` summary.
+- Require Team Lead to include that output in the Gate 1 approval request.
+- Preserve the durable design artifact as the authoritative review target.
+- Keep the output natural and concise; avoid forcing raw transcripts or bulky
+  status-report shells into chat.
+- Keep Claude Code and Codex role surfaces aligned.
+
+## Non-goals
+
+- Do not make Gate 1 approval depend on raw brainstorming transcripts.
+- Do not require every intermediate thought or discarded idea to be shown.
+- Do not weaken the existing artifact path, requirement set, or adversarial
+  review evidence requirements.
+- Do not change Planner, Executor, Reviewer, or Finisher ownership.
+- Do not alter branch, model-selection, execution-mode, or shutdown behavior.
+
+## Requirements
+
+### AC-82-1
+
+Given Brainstormer completes a design artifact, when Brainstormer reports done,
+then the done report includes `brainstorming_output` with problem framing,
+directions considered, recommended direction, notable tradeoffs, and open risks
+or questions.
+
+### AC-82-2
+
+Given Team Lead presents Gate 1 for approval, when the approval request reaches
+the operator, then it includes the `brainstorming_output` substance in addition
+to the exact artifact path, concise intent summary, full requirement set, and
+adversarial-review result.
+
+### AC-82-3
+
+Given `brainstorming_output` would be too large for a clean approval message,
+when Team Lead prepares the approval request, then Team Lead splits or condenses
+the brainstorming output into reviewable sections rather than replacing it with
+a vague fallback summary.
+
+### AC-82-4
+
+Given a teammate or future maintainer reads the Superteam role contracts, when
+they inspect both Claude Code and Codex Brainstormer surfaces, then both surfaces
+name the `brainstorming_output` handoff obligation consistently.
+
+### AC-82-5
+
+Given the workflow-contract change is implemented, when verification runs, then
+the Superteam contract check and Markdown lint pass.
+
+## Proposed change
+
+Update `skills/superteam/SKILL.md` in two places:
+
+- Gate 1 approval evidence: add `brainstorming_output` as required approval
+  evidence before asking the operator to approve the design.
+- Brainstormer done-report contract: add a `brainstorming_output` field with a
+  tight definition: problem framing, options or directions considered,
+  recommendation, tradeoffs, and open risks or questions.
+
+Update Brainstormer role surfaces in both supported hosts:
+
+- `skills/superteam/.claude/agents/brainstormer.md`
+- `skills/superteam/agents/brainstormer.openai.yaml`
+
+The role surfaces should not restate every SKILL.md field, but they should add a
+non-negotiable Brainstormer-specific rule that the default brainstorming output
+must reach the done report and Gate 1 handoff through the SKILL.md-owned
+`brainstorming_output` field.
+
+If `scripts/verify-superteam-contract.sh` encodes the Brainstormer done-report
+field list, update it so the contract check covers the new field. If the check
+is pattern-based and already follows SKILL.md dynamically, no script change is
+needed.
+
+## Design notes
+
+`brainstorming_output` should be concise, not exhaustive. It is the operator
+facing decision trail, not a hidden chain-of-thought dump and not a replacement
+for the design document. A good value is usually a short set of bullets covering:
+
+- the problem framing Brainstormer used
+- options or directions considered
+- the recommended direction
+- notable tradeoffs
+- open risks or questions
+
+This field belongs in the Brainstormer done report because Brainstormer owns the
+design exploration. Team Lead owns rendering it in the Gate 1 approval request.
+That split preserves role ownership: Brainstormer supplies the substance; Team
+Lead ensures the operator sees it before approval.
+
+The change should be phrased as evidence, not as a fixed chat template. The
+existing operator-facing output rule still stands: handoffs should read
+naturally and focus on the decision being requested.
+
+## Adversarial review
+
+### RED/GREEN baseline obligations
+
+The RED case is the example in issue #82: Gate 1 can ask for approval while only
+showing procedural status and a terse design coverage sentence. The GREEN case
+requires a Gate 1 approval packet that includes the design decision trail in
+chat before asking for approval.
+
+### Rationalization resistance
+
+The contract should close the loophole that "intent summary" is enough. Intent
+summary states what the artifact changes; `brainstorming_output` states how the
+design got there and what alternatives or risks matter.
+
+### Red flags
+
+- Gate 1 handoff includes a spec path but no options, tradeoffs, risks, or open
+  questions.
+- Brainstormer reports done without the new field.
+- Team Lead treats `brainstorming_output` as optional because the design doc is
+  linked.
+- The implementation adds a verbose raw transcript requirement instead of a
+  concise reviewable summary.
+
+### Token-efficiency targets
+
+The field should fit in a normal approval handoff. If it grows too large, Team
+Lead should split or condense it into clean sections while preserving the useful
+decision trail.
+
+### Role ownership
+
+Brainstormer owns producing `brainstorming_output`. Team Lead owns verifying the
+approval packet includes it. Planner must continue to consume the approved
+design artifact, not ad hoc chat summaries.
+
+### Stage-gate bypass paths
+
+Gate 1 remains closed until the design artifact is committed, adversarial review
+is clean or dispositioned, and the approval request includes the required
+evidence. The new field does not allow Planner to start earlier; it makes the
+approval request more useful before explicit approval.
+
+## Verification
+
+- Run `pnpm lint:md`.
+- Run `pnpm verify:superteam`.
+- Inspect `skills/superteam/SKILL.md` for the new Gate 1 evidence and
+  Brainstormer done-report field.
+- Inspect both Brainstormer role surfaces for consistent handoff guidance.

--- a/docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md
+++ b/docs/superpowers/specs/2026-05-15-82-superteam-brainstorming-step-does-not-surface-useful-output-design.md
@@ -159,10 +159,12 @@ existing operator-facing output rule still stands: handoffs should read
 naturally and focus on the decision being requested.
 
 A good Gate 1 handoff should usually read like a short note from Team Lead:
-"I think this is ready to approve; here is the decision trail and the few
-requirements that matter." It can mention the artifact path and review result,
-but it should not make those mechanics the main event. Verification details
-belong in the handoff only when they change the operator's decision.
+"I think this is ready to approve; here is the decision trail, the requirement
+set, and the review result." It must still include the exact artifact path, full
+requirement set, adversarial-review result, reviewer context, and clean-pass
+rationale when clean. The mechanics should be present without becoming the main
+event. Verification details belong in the handoff only when they change the
+operator's decision.
 
 ## Adversarial review
 
@@ -185,6 +187,9 @@ design got there and what alternatives or risks matter.
   questions.
 - Gate 1 handoff includes the new field but buries it inside a noisy report
   shell that still makes the operator hunt for the decision.
+- Gate 1 handoff uses "conversational" as an excuse to omit the exact artifact
+  path, full requirement set, adversarial-review result, reviewer context, or
+  clean-pass rationale.
 - Brainstormer reports done without the new field.
 - Team Lead treats `brainstorming_output` as optional because the design doc is
   linked.

--- a/scripts/verify-superteam-contract.sh
+++ b/scripts/verify-superteam-contract.sh
@@ -45,9 +45,20 @@ for needle in \
   "## Latest-head PR completion gate" \
   "latest_head_feedback_inventory" \
   "latest_head_check_status_inventory" \
-  "Finisher completion/status report"
+  "Finisher completion/status report" \
+  "brainstorming_output" \
+  "noisy field dump"
 do
   require_text skills/superteam/SKILL.md "$needle"
+done
+
+for file in \
+  skills/superteam/agents/brainstormer.openai.yaml \
+  skills/superteam/.claude/agents/brainstormer.md
+do
+  require_text "$file" "brainstorming_output"
+  require_text "$file" "concise decision trail"
+  require_text "$file" "not a raw transcript"
 done
 
 for file in \

--- a/skills/superteam/.claude/agents/brainstormer.md
+++ b/skills/superteam/.claude/agents/brainstormer.md
@@ -28,6 +28,7 @@ superpowers:brainstorming
 7. Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass.
 8. Commit the design artifact before reporting done or handing off to Planner. Do not report done while the artifact exists only as uncommitted workspace state.
 9. If adversarial review changes the design, commit the revised artifact before handoff.
+10. Include `brainstorming_output` in the SKILL.md-owned done report: a concise decision trail with problem framing, directions considered, recommended direction, notable tradeoffs, and open risks or questions. This is not a raw transcript.
 
 ## Done-report contract reference
 

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -234,15 +234,16 @@ Before asking for approval:
 1. Verify the design artifact exists at the exact reported path.
 2. Return the exact artifact path under review.
 3. Include a concise intent summary of what the artifact changes or decides.
-4. Include the full requirement set currently under review.
-5. Include `adversarial_review_findings[]` as the single approval-finding surface, including Brainstormer-originated concerns and adversarial-review findings.
-6. Preserve finding provenance with `source: brainstormer | adversarial-review`.
-7. Require an explicit adversarial-review result before approval can advance: `clean`, `findings dispositioned`, or `blocked`.
-8. Include `reviewer_context`: `fresh subagent`, `parallel specialists`, or `same-thread fallback`.
-9. Include `clean_pass_rationale` with checked dimensions when no blocker or material findings remain.
-10. Halt approval when any blocker or material finding is still open.
+4. Include `brainstorming_output`: concise problem framing, directions considered, recommended direction, notable tradeoffs, and open risks or questions.
+5. Include the full requirement set currently under review.
+6. Include `adversarial_review_findings[]` as the single approval-finding surface, including Brainstormer-originated concerns and adversarial-review findings.
+7. Preserve finding provenance with `source: brainstormer | adversarial-review`.
+8. Require an explicit adversarial-review result before approval can advance: `clean`, `findings dispositioned`, or `blocked`.
+9. Include `reviewer_context`: `fresh subagent`, `parallel specialists`, or `same-thread fallback`.
+10. Include `clean_pass_rationale` with checked dimensions when no blocker or material findings remain.
+11. Halt approval when any blocker or material finding is still open.
 
-The evidence above is required gate data, not a required chat template. The operator-facing approval request should read naturally and focus on the decision being requested. It may summarize a clean review as no approval-blocking findings remaining instead of replaying closed or dispositioned findings.
+The evidence above is required gate data, not a required chat template. The operator-facing approval request should read naturally and focus on the decision being requested: what Brainstormer concluded, why that direction won, what requirements are under review, and whether any approval-blocking findings remain. Keep the exact artifact path, full requirement set, adversarial-review result, reviewer context, and clean-pass rationale present, but do not render them as a noisy field dump. It may summarize a clean review as no approval-blocking findings remaining instead of replaying closed or dispositioned findings.
 
 Before Gate 1 approval is presented, `Team Lead` must run or dispatch an adversarial design review against the committed design artifact. Fresh-context or parallel specialist review is preferred for workflow-critical or broad designs when the runtime supports it; same-thread review is the portable fallback. Brainstormer-originated findings alone do not satisfy this gate.
 
@@ -290,6 +291,7 @@ Artifact-producing teammate done reports must anchor on committed handoff state 
 - `design_doc_path`: exact path to the written design doc
 - `ac_ids[]`: ordered list of active AC IDs
 - `intent_summary`: concise summary of what the artifact changes or decides
+- `brainstorming_output`: concise problem framing, directions considered, recommended direction, notable tradeoffs, and open risks or questions
 - `requirements[]`: full requirement set currently under review
 - `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
 - `reviewer_context`: `fresh subagent` | `parallel specialists` | `same-thread fallback`
@@ -373,7 +375,8 @@ Completion language is allowed only after the latest-head PR completion gate pas
 | Excuse | Reality |
 |--------|---------|
 | "The design file probably exists if Brainstormer says it does." | Gate 1 requires verifying the artifact exists at the reported path before approval. |
-| "I can summarize the approval request in one short fallback blurb." | Approval packets must include artifact path, concise intent summary, and full requirement set; split oversized packets instead of collapsing them. |
+| "I can summarize the approval request in one short fallback blurb." | Approval packets must include artifact path, concise intent summary, brainstorming output, and full requirement set; split oversized packets instead of collapsing them. |
+| "The design doc has the brainstorming details, so chat can just link to it." | Gate 1 chat must surface `brainstorming_output` so the operator sees the decision trail before approval. |
 | "I can replay the whole approval request after a small revision." | Re-fired approval after revisions must be delta-only. |
 | "Just pick the most likely interpretation and proceed." | Ambiguous or contradictory observable state halts the run with an explicit blocker per `## Failure handling`. Resume requires explicit operator clarification of the intended issue, branch, or phase. Not even when there is a deadline. Not even when an authority claim is cited. |
 | "The prompt is short/ambiguous, but the operator clearly meant approval — just advance the gate." | Ambiguous prompts during an open gate are feedback to the active teammate per `routing-table.md`. Approval requires an explicit token (`approve`, `lgtm`, etc.). Not even when an authority claim is cited. Not even when the prior in-session approval feels binding. |
@@ -402,7 +405,7 @@ Completion language is allowed only after the latest-head PR completion gate pas
 | "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
 | "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
 | "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
-| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
+| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Artifact path, full requirement set, brainstorming output, review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
 | "The shipped agent file already says it; I can prune it from SKILL.md too." | Orchestration invariants (gates, done-report contracts, routing, halt conditions) STAY in SKILL.md and are referenced from agent files. Per-role procedure moves; cross-role invariants do not. |
 | "The project delta replaces the shipped system prompt because the project knows better." | Deltas are append-only. There is no `replace` mode. Stripping shipped guardrails is forbidden by design. |
 | "I applied a delta but it's the same as the default, so I don't need to log it." | Delta application is always logged: `superteam delta applied`, `superteam delta empty`, or (during pre-flight) `superteam delta orphan`. Silent layering is forbidden. |
@@ -419,7 +422,9 @@ Completion language is allowed only after the latest-head PR completion gate pas
 
 - Using older stage-only language where the canonical teammate roster should be used.
 - Asking for design approval before verifying the cited artifact exists.
-- Approval requests that omit the artifact path, concise intent summary, or full requirement set.
+- Approval requests that omit the artifact path, concise intent summary, brainstorming output, or full requirement set.
+- Approval requests that hide Brainstormer's decision trail behind a spec link instead of surfacing `brainstorming_output`.
+- Approval requests that use "conversational" as an excuse to omit required Gate 1 evidence.
 - Gate 1 approval packet has `adversarial_review_findings[]` entries but no evidence that an adversarial-review pass occurred.
 - Adversarial review reports `clean` without `reviewer_context`, checked dimensions, or `clean_pass_rationale`.
 - `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.

--- a/skills/superteam/agents/brainstormer.openai.yaml
+++ b/skills/superteam/agents/brainstormer.openai.yaml
@@ -19,6 +19,7 @@ system_prompt: |
   7. Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass.
   8. Commit the design artifact before reporting done or handing off to Planner. Do not report done while the artifact exists only as uncommitted workspace state.
   9. If adversarial review changes the design, commit the revised artifact before handoff.
+  10. Include `brainstorming_output` in the SKILL.md-owned done report: a concise decision trail with problem framing, directions considered, recommended direction, notable tradeoffs, and open risks or questions. This is not a raw transcript.
 
   ## Done-report contract reference
   See done-report contracts in skills/superteam/SKILL.md (#done-report-contracts). This file does not restate the fields.


### PR DESCRIPTION
# Pull Request

## Linked issue

- Closes #82

## What changed

Context: standalone — issue #82 reported that Superteam Gate 1 surfaced procedural status while hiding Brainstormer's useful output.

- Added `brainstorming_output` to the Superteam Gate 1 and Brainstormer done-report contracts — so approval handoffs include the decision trail the operator needs.
- Tightened Gate 1 rendering guidance — so the handoff stays conversational and decision-focused without dropping required evidence.
- Aligned Claude Code and Codex Brainstormer role surfaces — so both hosts require the same concise decision-trail field.
- Extended the Superteam contract verifier — so the new field and low-noise rendering guardrail are checked.
- Fixed pre-existing `CHANGELOG.md` blank-line lint failures — so `pnpm lint:md` passes for this PR.

## Test coverage

| AC | Title | Unit | Docs/Contract |
| --- | --- | --- | --- |
| AC-82-1 | Brainstormer reports decision trail | ✅ | ✅ |
| AC-82-2 | Gate 1 includes brainstorming substance | ✅ | ✅ |
| AC-82-3 | Oversized output is split or condensed | ✅ | ✅ |
| AC-82-4 | Handoff is conversational, not a field dump | ✅ | ✅ |
| AC-82-5 | Claude and Codex surfaces are aligned | ✅ | ✅ |
| AC-82-6 | Verification passes | ✅ | ✅ |

### AC-82-1

Brainstormer done reports now include `brainstorming_output`, defined as concise problem framing, directions considered, recommended direction, notable tradeoffs, and open risks or questions.

- Evidence: `pnpm verify:superteam`, local, verified the contract assertions include `brainstorming_output`.
- Gap: None.
- Manual testing needed: No; this is contract text plus verifier coverage.

### AC-82-2

Gate 1 approval evidence now requires `brainstorming_output` before asking the operator to approve the design.

- Evidence: `pnpm verify:superteam`, local, verified the Superteam contract includes the field.
- Gap: None.
- Manual testing needed: No; this is workflow-contract behavior.

### AC-82-3

The approved design and SKILL.md guidance preserve the existing rule to split oversized approval packets instead of collapsing them into vague summaries.

- Evidence: `pnpm lint:md` and `pnpm verify:superteam`, local.
- Gap: None.
- Manual testing needed: No.

### AC-82-4

Gate 1 guidance now says required evidence must be present but rendered naturally, focused on the decision, and not as a noisy field dump.

- Evidence: `pnpm verify:superteam`, local, checks for the conversational rendering guardrail.
- Gap: None.
- Manual testing needed: No.

### AC-82-5

Both Brainstormer role surfaces require `brainstorming_output` as a concise decision trail and explicitly reject raw transcript output.

- Evidence: `pnpm verify:superteam`, local, checks both Claude Code and Codex Brainstormer files.
- Gap: None.
- Manual testing needed: No.

### AC-82-6

All required local verification passed.

- Evidence: `pnpm lint:md`, `pnpm verify:superteam`, `pnpm verify:dogfood`, and `pnpm verify:marketplace`, local.
- Gap: None.
- Manual testing needed: No.

## Testing steps

- [x] Run `pnpm lint:md` and expect `Summary: 0 error(s)`.
- [x] Run `pnpm verify:superteam` and expect `OK: superteam contract assertions passed`.
- [x] Run `pnpm verify:dogfood` and expect all six in-repo skills discoverable via flat layout.
- [x] Run `pnpm verify:marketplace` and expect marketplace catalogs validated.
