### PR TITLE
feat: #87 simplify scaffold PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,11 +17,12 @@
 
 ## Linked issue
 
-- `Closes #<issue>` for each issue this PR completes.
+- At least one GitHub closing keyword is required for normal PRs:
+  `Closes #<issue>`, `Fixes #<issue>`, or `Resolves #<issue>`.
+- Add one closing-keyword line for each issue this PR completes.
 - `Related to #<issue>` / `Blocks #<issue>` / `Partially satisfies #<issue>`
-  for each additional issue, with a short explanation when the relationship is
-  not obvious.
-- `None` when no issue applies.
+  are additional references, not replacements for the required closing keyword.
+  Include a short explanation when the relationship is not obvious.
 
 ## What changed
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,27 +17,29 @@
 
 ## Linked issue
 
-- `Closes #<issue>` when this PR is intended to complete the issue
-- Otherwise: `Related to #<issue>` plus a short explanation of why this PR does not close it yet
-- `None` when no issue applies
+- `Closes #<issue>` for each issue this PR completes.
+- `Related to #<issue>` / `Blocks #<issue>` / `Partially satisfies #<issue>`
+  for each additional issue, with a short explanation when the relationship is
+  not obvious.
+- `None` when no issue applies.
 
 ## What changed
 
-Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `standalone — <reason>` when there is none>
+Context: <prior PR, prior QA pass, follow-up issue, or `standalone - <reason>`>
 
-- <change> — <why>
+- <change> - <why>
 
 <!--
-  The rendered `Context:` line and `- <change> — <why>` bullet shape are the
+  The rendered `Context:` line and `- <change> - <why>` bullet shape are the
   structural placeholders this section requires. Replace `<...>` with actual
   values; do not delete the `Context:` line. When this PR has no prior
-  context, write `Context: standalone — <reason>` (e.g.
-  `Context: standalone — first pass on the new lint rule`). One bullet per
-  change; the `— <why>` half states the rationale (user-visible reason or
+  context, write `Context: standalone - <reason>` (e.g.
+  `Context: standalone - first pass on the new lint rule`). One bullet per
+  change; the `- <why>` half states the rationale (user-visible reason or
   triggering observation), not a restatement of the change.
 
   Include this section only when PR-level operator steps that do not belong to
-  a specific AC must happen after review and before merge:
+  QA, coverage gaps, or pending CI must happen after review and before merge:
 
   ## Do before merging
 
@@ -50,78 +52,45 @@ Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `sta
   steps.`
 -->
 
-## Test coverage
+## Coverage and risks
 
 Legend for status cells:
 
-- ✅ — required validation passed with no known relevant gap for this column.
-- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
-- ❌ — required validation is missing, failing, pending, or merge-blocked.
-- ➖ — not relevant to this AC.
+- PASS - required validation passed with no known relevant gap.
+- WARN - sufficient to merge with a known non-blocking gap in Risks.
+- BLOCKED - missing, failing, pending, or merge-blocking.
+- N/A - not relevant to this AC.
 
-The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.
+The `AC` column references acceptance-criteria IDs from linked issues in
+`AC-<issue>-<n>` form.
 
 <!--
   When showing a partial example outside a PR body, label the whole example as
-  an excerpt before the first omitted section or table. Actual PR bodies must
-  not omit relevant AC headings.
-
-  Include one matrix row per relevant AC, then one subsection per AC with only
-  tester-useful coverage context: what was validated, where it ran, evidence,
-  known gaps or caveats, and whether manual testing is still needed. Keep the
-  `Unit` column, then add one column per supported platform affected by this
-  PR. Each cell summarizes the required-validation state for that AC and
-  column. Use only these symbols in status cells:
-  ✅ = required validation passed, with no known relevant gap for this column
-  ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
-       gap documented under this AC
-  ❌ = required validation is missing, failing, pending, or blocked by a
-       merge-blocking gap
-  ➖ = not relevant to this AC
-
-  Use `➖` only when that verification type is not relevant to the AC. If an AC
-  includes evidence or a gap that clearly maps to a matrix column, that cell
-  must not be `➖`. If a known non-blocking gap remains after sufficient
-  validation, use `⚠️` and document the gap under the AC in prose. If required
-  validation is missing, failing, pending, blocked by an unresolved concern, or
-  otherwise cannot yet be trusted for merge, use `❌` and document the gap under
-  the AC in prose. Do not use checkboxes in this section; tester actions belong
-  under `## Testing steps`.
+  an excerpt before the first omitted section or table. Actual PR bodies should
+  include one table row per relevant AC when linked issues define ACs. The
+  table is the primary AC summary; add prose only when it changes reviewer
+  judgment. Report coverage so humans and agents can identify remaining risk,
+  not as an inventory of every passed test command. Do not use checkboxes in
+  this section.
 -->
-| AC | Title | Unit | <Platform> |
+| AC | Requirement | Evidence | Status |
 | --- | --- | --- | --- |
-| AC-<issue>-<n> | <short title> | ➖ | ➖ |
+| AC-<issue>-<n> | <short title> | <command, job, manual source, or doc review> | PASS |
 
-### AC-<issue>-<n>
+<!-- Omit this subsection when there are no notable risks or gaps. -->
+### Risks
 
-Coverage summary focused on what helps a human tester understand the state of this AC.
-
-- Evidence: `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
-- Gap: <missing, pending, or non-blocking validation, or `None`>.
-- Manual testing needed: <yes/no and why>.
-
-<!--
-  Repeat one subsection per relevant AC. Keep this section evidence-only and
-  checkbox-free. Include only information that helps a reviewer or tester
-  understand coverage, gaps, and whether manual exercise is still needed.
--->
-
-<!--
-  Deferred or out-of-scope ACs still get a subsection so reviewers can see why
-  no testing is reported for them:
-
-  ### AC-<issue>-<n>
-
-  Deferred to `<repo-or-follow-up>`.
--->
+- <warning, missing coverage, merge blocker, manual-only validation, deferred
+  check, or caveat>
 
 ## Testing steps
 
 <!--
-  Add concrete tester actions here. Use checkboxes only in this section or in
-  `## Do before merging`. Steps should cover any `❌` or `⚠️` gaps called out
-  in `## Test coverage` when a human can close or evaluate the gap. If no
-  manual testing is needed, include one checked row explaining why.
+  List every operator-owned verification step here in the order the operator
+  should perform or inspect it. Use checkboxes for pass/fail verification
+  decisions or outcomes, not for every individual UI action. Anything the
+  operator needs to see or manually verify belongs here. If no manual testing is
+  needed, include one checked row explaining why.
 -->
 
-- [ ] <imperative testing step and expected result>
+- [ ] Verify <observable outcome> after <minimal action context>.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,10 @@ For squash-and-merge workflows, PR titles must match the commitlint commit forma
 Bot-generated release-please PRs from `release-please--*` branches and bot-generated release
 bump PRs from `bot/bump-*` branches are the only no-issue exceptions.
 
-When an issue defines acceptance criteria, include an `Acceptance Criteria` section in the
-PR description.
+When linked issues define acceptance criteria, use the PR template's
+`Coverage and risks` section as the single AC, evidence, and risk summary.
 
-- Use one `### AC-<issue>-<n>` heading per relevant AC
-- Put a short outcome summary directly under each heading
-- Put verification steps under the AC they validate
+- Put one table row per relevant `AC-<issue>-<n>` in `Coverage and risks`
+- Add prose only when it changes reviewer judgment
+- Put operator-owned manual verification decisions in `Testing steps`
+- Put only pre-merge operational chores in `Do before merging`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,9 @@ pnpm lint:md
 
 - Keep the PR title in commitlint format.
 - Fill in the [PR template](./.github/pull_request_template.md).
-- Include an `Acceptance Criteria` section when the linked issue defines ACs.
+- Use `Coverage and risks` for AC evidence and risks when linked issues define
+  ACs.
+- Use `Testing steps` for operator-owned verification decisions.
 - Bot-generated release bump PRs from `bot/bump-*` branches are the only no-issue exception.
 
 ## Further reading

--- a/docs/superpowers/plans/2026-05-15-87-require-operator-owned-testing-steps-in-scaffold-pr-template-plan.md
+++ b/docs/superpowers/plans/2026-05-15-87-require-operator-owned-testing-steps-in-scaffold-pr-template-plan.md
@@ -1,0 +1,215 @@
+# Plan: Require operator-owned testing steps in scaffold PR template [#87](https://github.com/patinaproject/skills/issues/87)
+
+## Approved design
+
+- Design artifact: `docs/superpowers/specs/2026-05-15-87-require-operator-owned-testing-steps-in-scaffold-pr-template-design.md`
+- Gate 1 approval: operator explicitly approved on 2026-05-15.
+- Handoff commit: `00a859243c4282223aa9086e9a2a42d144362eb9`
+- Binding ACs: `AC-87-1` through `AC-87-16`.
+
+## Goal
+
+Make the scaffolded PR-body contract shorter and clearer by moving all
+operator-owned pass/fail verification into ordered `## Testing steps`, replacing
+the old `## Test coverage` plus per-AC prose pattern with one combined
+`## Coverage and risks` section, supporting multiple linked issues, and keeping
+CI out of operator checkbox completion.
+
+Requirement-changing deltas are out of scope for Executor. If implementation
+uncovers a need to rename sections differently, add new CI behavior, remove AC
+coverage, or otherwise change the approved ownership model, halt and route the
+delta back to Brainstormer.
+
+## Workstreams
+
+### W1: Update the root and scaffolded PR templates
+
+Update both PR template surfaces together so this repo keeps dogfooding the
+baseline emitted by `scaffold-repository`.
+
+Files:
+
+- `.github/pull_request_template.md`
+- `skills/scaffold-repository/templates/core/.github/pull_request_template.md`
+
+Tasks:
+
+- W1.1 Preserve the section order from the approved design: `Linked issue`,
+  `What changed`, optional `Do before merging`, `Coverage and risks`, and
+  `Testing steps`.
+- W1.2 Update `Linked issue` guidance so authors can include multiple issue
+  relationships, including `Closes #<issue>`, `Related to #<issue>`,
+  `Blocks #<issue>`, and `Partially satisfies #<issue>`, plus `None` when no
+  issue applies.
+- W1.3 Replace `## Test coverage` with `## Coverage and risks`.
+- W1.4 Make the coverage table the primary AC summary with columns for AC,
+  requirement, evidence, and status.
+- W1.5 Include compact status guidance for pass, warning, blocked, and not
+  applicable states; ASCII labels are acceptable and avoid symbol rendering
+  variance.
+- W1.6 Add an optional bottom `### Risks` subsection for warnings, missing
+  coverage, merge-blocking gaps, manual-only validation, deferred checks, and
+  caveats, with comments instructing authors to omit it when empty.
+- W1.7 Remove the one-prose-subsection-per-AC requirement while preserving the
+  requirement to report AC coverage when linked issues define ACs.
+- W1.8 Keep `## Testing steps` named exactly, with instructions that every
+  operator-owned verification step belongs there in the order the operator
+  should perform or inspect it.
+- W1.9 Require checkboxes for operator-owned pass/fail verification decisions or
+  outcomes, and tell authors not to put a checkbox on every individual UI
+  action.
+- W1.10 Use direct checklist example wording that names an observable outcome and
+  does not repeat a prefix such as `Operator check:`.
+- W1.11 Keep `Do before merging` limited to PR-level operator chores, not manual
+  QA, AC gaps, or pending CI checks.
+
+Acceptance criteria covered: AC-87-1, AC-87-2, AC-87-3, AC-87-4, AC-87-5,
+AC-87-6, AC-87-7, AC-87-8, AC-87-9, AC-87-10, AC-87-11, AC-87-12, AC-87-13,
+AC-87-15.
+
+### W2: Align generated AGENTS guidance
+
+Update generated contributor guidance so downstream agents follow the new PR
+body contract.
+
+File:
+
+- `skills/scaffold-repository/templates/core/AGENTS.md.tmpl`
+
+Tasks:
+
+- W2.1 Change `.github` template guidance so `Do before merging`, when present,
+  sits between `What changed` and `Coverage and risks`.
+- W2.2 Replace references to the template's `Test coverage` section with
+  `Coverage and risks`.
+- W2.3 Remove the rule requiring one `### AC-<issue>-<n>` heading per relevant
+  AC.
+- W2.4 State that AC rows belong in the coverage table and that extra prose is
+  only for reader-useful context that changes reviewer judgment.
+- W2.5 Route anything the operator needs to see or manually verify to
+  `Testing steps`.
+- W2.6 Keep checkbox ownership narrow: operator pass/fail verification outcomes
+  in `Testing steps`, pre-merge chores in `Do before merging`, no checkboxes in
+  `Coverage and risks`.
+- W2.7 Update the Round-trip discipline reference if it still names the old
+  `skills/bootstrap/templates/core/AGENTS.md.tmpl` path in a way that conflicts
+  with the current `skills/scaffold-repository` source of truth.
+
+Acceptance criteria covered: AC-87-2, AC-87-3, AC-87-4, AC-87-5, AC-87-6,
+AC-87-7, AC-87-8, AC-87-10, AC-87-11, AC-87-13, AC-87-16.
+
+### W3: Align helper docs and adjacent scaffold guidance
+
+Update only adjacent docs that would otherwise contradict the new contract.
+Keep edits minimal.
+
+Files to inspect and update as needed:
+
+- `skills/scaffold-repository/pr-body-template.md`
+- `skills/scaffold-repository/SKILL.md`
+- `skills/scaffold-repository/audit-checklist.md`
+- `skills/scaffold-repository/templates/core/CONTRIBUTING.md.tmpl`
+
+Tasks:
+
+- W3.1 In `pr-body-template.md`, replace the stale instruction to put AC-54-7
+  parity grep output under an `Acceptance criteria` entry. Route passing parity
+  evidence to the `Coverage and risks` table, and route non-empty blocking
+  output to the `Risks` subsection.
+- W3.2 In `SKILL.md`, update the PR body convention summary so it names multiple
+  linked-issue guidance, `Coverage and risks`, and `Testing steps` ownership
+  instead of `Closes #<issue>` plus an AC block.
+- W3.3 In `audit-checklist.md`, update the PR-template baseline check so it
+  expects multiple linked-issue guidance, `Coverage and risks`, exact
+  `## Testing steps`, and no stale one-subsection-per-AC requirement.
+- W3.4 In `CONTRIBUTING.md.tmpl`, replace the instruction to include an
+  `Acceptance criteria` section with guidance to fill the template's
+  `Coverage and risks` table and use `Testing steps` for operator-owned
+  verification.
+- W3.5 Search adjacent scaffold docs for stale `Test coverage`,
+  `Acceptance criteria`, `Testing steps`, `Coverage and risks`, `checkbox`, and
+  `Linked issue` wording. Update only references that describe the scaffolded PR
+  body contract.
+
+Acceptance criteria covered: AC-87-6, AC-87-7, AC-87-8, AC-87-9, AC-87-10,
+AC-87-11, AC-87-15, AC-87-16.
+
+### W4: Audit scaffolded CI checkbox behavior
+
+Confirm the scaffolded baseline has no unchecked-operator-checkbox failure path,
+and avoid adding one.
+
+Files to inspect:
+
+- `skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml`
+- Other scaffolded workflow or script files surfaced by search.
+
+Tasks:
+
+- W4.1 Confirm `pull-request.yml` still validates PR title shape, closing
+  keywords, and breaking-change marker consistency only.
+- W4.2 Confirm no scaffolded script or workflow such as
+  `check-pr-template-checkboxes.mjs` fails because `## Testing steps` or
+  `## Do before merging` contains unchecked boxes.
+- W4.3 If future structure validation is discovered, keep or adjust it only so
+  it validates headings or duplicate-section structure without requiring
+  operator-owned checkboxes to be checked.
+- W4.4 Do not add any new CI gate that checks off operator work or pressures
+  authors to pre-check manual verification before the operator performs it.
+
+Acceptance criteria covered: AC-87-14, AC-87-16.
+
+### W5: Verify implementation
+
+Run the full scaffold and Markdown verification set, plus targeted contract
+searches.
+
+Commands and expected outcomes:
+
+- W5.1 `rg -n "## Test coverage|## Acceptance criteria|Acceptance criteria entry|one subsection per AC|Operator check:" .github skills/scaffold-repository`
+  should return no stale scaffolded PR-body contract requirements. If matches
+  remain, each must be unrelated historical context or explicitly not part of
+  the scaffolded PR-body contract.
+- W5.2 `rg -n "Coverage and risks|## Testing steps|Partially satisfies|Risks" .github/pull_request_template.md skills/scaffold-repository`
+  should show the new section names and multiple linked-issue guidance on the
+  root template, scaffolded template, and helper guidance.
+- W5.3 `rg -n "check-pr-template-checkboxes|unchecked|Testing steps.*checkbox|Do before merging.*checkbox" skills/scaffold-repository/templates/core/.github skills/scaffold-repository/scripts scripts`
+  should show no CI path that fails merely because operator-owned checkboxes are
+  unchecked. It may show instructional text that permits unchecked operator
+  work.
+- W5.4 `pnpm apply:scaffold-repository:check` should pass, proving the current
+  repo remains aligned with the emitted scaffold baseline.
+- W5.5 `pnpm verify:dogfood` should pass, confirming the six in-repo skills are
+  still discoverable through the flat layout.
+- W5.6 `pnpm verify:marketplace` should pass, confirming marketplace metadata
+  remains valid.
+- W5.7 `pnpm lint:md` should pass. No approved-design-specific pre-existing lint
+  caveat is known; if lint fails on unrelated pre-existing files, capture the
+  exact file and rule, then also run targeted lint on the files changed for this
+  issue.
+
+Acceptance criteria covered: AC-87-1 through AC-87-16.
+
+### W6: Prepare PR body expectations for Finisher
+
+When implementation is complete and reviewed, the PR body should itself use the
+new template contract.
+
+Tasks:
+
+- W6.1 Use `## Linked issue` with `Closes #87`.
+- W6.2 Use `## Coverage and risks` as the single AC/evidence/risk section.
+- W6.3 Include one table row per AC from `AC-87-1` through `AC-87-16`; do not add
+  a separate `## Acceptance criteria` section or one prose subsection per AC.
+- W6.4 Include `### Risks` only if implementation leaves a warning, caveat,
+  missing coverage, manual-only validation, deferred check, or merge blocker.
+- W6.5 Put operator-owned manual verification decisions, if any, under
+  `## Testing steps` as ordered pass/fail checkboxes naming observable outcomes.
+- W6.6 Do not mark unchecked `Testing steps` boxes as CI failures or merge
+  approval.
+
+Acceptance criteria covered: AC-87-1 through AC-87-16.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-15-87-require-operator-owned-testing-steps-in-scaffold-pr-template-design.md
+++ b/docs/superpowers/specs/2026-05-15-87-require-operator-owned-testing-steps-in-scaffold-pr-template-design.md
@@ -1,0 +1,410 @@
+# Design: Require operator-owned testing steps in scaffold PR template [#87](https://github.com/patinaproject/skills/issues/87)
+
+## Intent
+
+Clean up the scaffold-repository PR body contract so operator-owned QA work is
+visible, ordered, and actionable without making reviewers reconcile three
+overlapping evidence sections. The scaffolded PR template should keep
+`## Testing steps` as the only section for human verification actions, replace
+the current split `## Test coverage` plus per-AC prose pattern with a combined
+coverage and risk section, support multiple linked issues, and avoid any
+scaffolded CI gate that fails merely because operator-owned testing checkboxes
+remain unchecked.
+
+## Skill guidance
+
+This design applies the repo-required `write-a-skill` structure review because
+the implementation will touch scaffold-repository skill and template surfaces.
+The design also applies `writing-skills` as a workflow-contract quality gate
+because the PR template, generated `AGENTS.md` guidance, and helper docs teach
+future agents how to report verification. The review dimensions are recorded
+below: RED/GREEN baseline obligations, rationalization resistance, red flags,
+token-efficiency targets, role ownership, and stage-gate bypass paths.
+
+## Problem
+
+The current scaffolded PR template has three places that can describe the same
+validation story:
+
+- `## Testing steps` for human tester actions;
+- `## Test coverage` with a matrix plus one prose subsection per AC;
+- acceptance-criteria detail in generated contributor guidance or downstream PR
+  bodies that repeats the same pass state again.
+
+That shape makes downstream PRs bulky. It also creates failure modes that matter
+to both humans and agents: manual checks can be buried in prose, every UI click
+can become a noisy checkbox, every passed unit test can get narrated, and
+operator-owned testing checkboxes can be treated as automated merge gates even
+though the operator still owns those decisions.
+
+## Requirements
+
+### AC-87-1
+
+The scaffold-repository PR template contains a section named exactly
+`## Testing steps`.
+
+### AC-87-2
+
+The `## Testing steps` instructions require all operator-owned verification
+steps to be included in the order needed to verify the changes.
+
+### AC-87-3
+
+The template requires every operator-owned pass/fail verification decision to
+use a checkbox.
+
+### AC-87-4
+
+The template instructs authors not to put a checkbox on every individual UI
+action, and to reserve checkboxes for verification decisions or outcomes.
+
+### AC-87-5
+
+The template states that anything the operator needs to see or manually verify
+belongs in `## Testing steps`.
+
+### AC-87-6
+
+The scaffolded PR body no longer has separate `## Test coverage` and
+`## Acceptance criteria` sections that duplicate the same validation story.
+
+### AC-87-7
+
+The template provides one combined reader-friendly section for acceptance
+criteria, validation evidence, and known gaps.
+
+### AC-87-8
+
+The combined coverage/acceptance-criteria section uses the table as the primary
+AC summary and provides a bottom `Risks` subsection for warnings, missing
+coverage, merge-blocking gaps, manual-only validation, deferred checks, or
+caveats.
+
+### AC-87-9
+
+The `Risks` subsection is omitted when there are no notable risks, gaps,
+warnings, or caveats to report.
+
+### AC-87-10
+
+The template does not require one prose subsection per AC when the coverage
+table already communicates the pass state.
+
+### AC-87-11
+
+The template guides authors to report test coverage in a way that helps humans
+and agents identify remaining risk, not simply inventory every passed test
+command.
+
+### AC-87-12
+
+`## Testing steps` examples use direct checklist wording and do not repeat a
+redundant prefix such as `Operator check:` on every item.
+
+### AC-87-13
+
+Each `## Testing steps` checkbox names an observable pass/fail outcome rather
+than merely listing UI actions.
+
+### AC-87-14
+
+Scaffolded CI does not fail a PR merely because `## Testing steps` contains
+unchecked operator-owned verification checkboxes.
+
+### AC-87-15
+
+The `## Linked issue` guidance supports multiple issue references, including
+combinations such as `Closes #<issue>` and `Related to #<issue>`.
+
+### AC-87-16
+
+Any scaffold-repository PR-body helper docs or generated PR-body templates that
+describe linked issues, testing steps, test coverage, acceptance-criteria
+reporting, risks, or checkbox validation are consistent with this contract.
+
+## Proposed change
+
+Update the scaffolded PR body contract at
+`skills/scaffold-repository/templates/core/.github/pull_request_template.md`.
+Because the root `.github/pull_request_template.md` currently mirrors the
+scaffolded baseline, update it in the implementation as well so this repository
+continues to dogfood the emitted shape. Keep the section order:
+
+1. `## Linked issue`
+2. `## What changed`
+3. optional `## Do before merging`
+4. combined `## Coverage and risks`
+5. `## Testing steps`
+
+Do not add a separate `## Acceptance criteria` section. Do not leave the old
+`## Test coverage` section name in scaffolded PR bodies unless the Planner
+explicitly chooses to preserve the name and can still satisfy AC-87-6 through
+AC-87-8. The recommended direction is a new `## Coverage and risks` section
+because the issue asks for one combined reader-friendly section whose table is
+the primary AC summary and whose bottom `Risks` subsection carries caveats.
+
+Update `skills/scaffold-repository/templates/core/AGENTS.md.tmpl` so generated
+agent guidance names the combined coverage section, removes the one-subsection
+per-AC rule, and routes human QA work to `Testing steps`.
+
+Update `skills/scaffold-repository/pr-body-template.md` so its helper note no
+longer tells authors to put AC-54-7 parity grep output under an
+`Acceptance criteria` entry. The replacement should route parity evidence to
+the combined coverage table or the `Risks` subsection when non-empty output is
+a blocker.
+
+Audit adjacent scaffold-repository docs that mention PR body shape, especially
+`skills/scaffold-repository/SKILL.md`, `audit-checklist.md`, and
+`templates/core/CONTRIBUTING.md.tmpl`. Keep edits minimal and only update text
+that would otherwise contradict the new contract.
+
+## Proposed PR template shape
+
+```markdown
+# Pull Request
+
+## Linked issue
+
+- `Closes #<issue>` for each issue this PR completes.
+- `Related to #<issue>` / `Blocks #<issue>` / `Partially satisfies #<issue>`
+  for each additional issue, with a short explanation when the relationship is
+  not obvious.
+- `None` when no issue applies.
+
+## What changed
+
+Context: <prior PR, prior QA pass, follow-up issue, or `standalone - <reason>`>
+
+- <change> - <why>
+
+<!-- Optional, include only for PR-level operator work before merge. -->
+## Do before merging
+
+- [ ] <imperative pre-merge action not covered by QA or CI>
+
+## Coverage and risks
+
+Legend for status cells:
+
+- PASS - required validation passed with no known relevant gap.
+- WARN - sufficient to merge with a known non-blocking gap in Risks.
+- BLOCKED - missing, failing, pending, or merge-blocking.
+- N/A - not relevant to this AC.
+
+| AC | Requirement | Evidence | Status |
+| --- | --- | --- | --- |
+| AC-<issue>-<n> | <short title> | <command, job, manual source, or doc review> | PASS |
+
+<!-- Omit this subsection when there are no notable risks or gaps. -->
+### Risks
+
+- <warning, missing coverage, merge blocker, manual-only validation, deferred
+  check, or caveat>
+
+## Testing steps
+
+<!--
+  List every operator-owned verification step here in the order the operator
+  should perform or inspect it. Use checkboxes for pass/fail verification
+  decisions or outcomes, not for every individual UI action. Anything the
+  operator needs to see or manually verify belongs here.
+-->
+
+- [ ] Verify <observable outcome> after <minimal action context>.
+```
+
+The implementation can choose compact status labels or the existing symbols if
+Markdown lint and downstream readability are better that way. The design
+requirement is the section ownership: the table summarizes AC coverage, the
+optional bottom `Risks` subsection carries caveats, and `Testing steps` carries
+operator-owned pass/fail work.
+
+## QA, merge chores, coverage, and risks
+
+`## Testing steps` is for QA decisions the operator can perform or verify. It
+should use direct imperative checklist wording and name observable outcomes:
+`Verify the preview updates within one refresh after changing the template`, not
+`Operator check: click through the page`.
+
+`## Do before merging` is narrower. It is only for PR-level operator chores that
+must happen after review and before merge, such as rotating a secret, toggling a
+GitHub repository setting, or coordinating a release window. It must not repeat
+testing steps, AC coverage gaps, or pending CI checks.
+
+`## Coverage and risks` is for reviewer evidence. It should help humans and
+agents answer: which ACs are covered, by what evidence, what is warning-level,
+what is missing, and what blocks merge. It should not narrate every passed test
+command or require one prose subsection per AC when the table is already clear.
+
+`### Risks` belongs at the bottom of the combined coverage section and is
+omitted when there are no notable risks, gaps, warnings, or caveats. Use it for
+warnings, missing coverage, merge-blocking gaps, manual-only validation,
+deferred checks, or caveats that change reviewer judgment.
+
+## CI checkbox decision
+
+The scaffolded baseline should not include CI enforcement that fails a PR merely
+because an operator-owned checkbox under `## Testing steps` is unchecked. Those
+checkboxes are operator work, not an automated assertion that a bot can close.
+
+The current scaffolded `pull-request.yml` validates PR title shape, closing
+keywords, and breaking-change marker consistency. It does not currently ship a
+`check-pr-template-checkboxes.mjs` gate. Preserve that by avoiding any new
+unchecked-checkbox failure path. If future structure validation is added, it may
+check for required section headings or disallowed duplicate sections, but it
+must not require `Testing steps` checkboxes to be checked before CI passes.
+
+The design intentionally allows unchecked `Do before merging` and
+`Testing steps` checkboxes to remain visible in a PR. Reviewers and operators
+can use them as collaboration state. CI should not force authors to pre-check
+human-owned verification before the operator has performed it.
+
+## RED/GREEN baseline
+
+RED baseline behavior:
+
+- A PR body can contain `Testing steps`, a dense `Test coverage` matrix, and
+  separate AC prose that repeat the same pass state.
+- Human QA can be hidden under coverage prose instead of appearing as ordered
+  operator-owned steps.
+- A manual checklist can become noisy by placing a checkbox on every UI click or
+  prefixing every item with `Operator check:`.
+- A CI checkbox linter can make unchecked operator-owned testing steps fail the
+  PR, pressuring authors to pre-check work that the operator has not verified.
+- A single `Linked issue` slot can make related, blocked, or partially satisfied
+  issues awkward to report.
+
+GREEN target behavior:
+
+- The scaffolded template has one `## Testing steps` section containing all
+  operator-owned verification decisions in order.
+- Each testing checkbox names an observable pass/fail outcome.
+- The combined coverage section uses the table as the primary AC summary and
+  only adds `Risks` when caveats exist.
+- The template no longer requires per-AC prose subsections that duplicate the
+  table's pass state.
+- Scaffolded CI permits unchecked operator-owned testing checkboxes.
+- Linked-issue guidance supports multiple issue relationships naturally.
+
+## Rationalization resistance
+
+| Rationalization | Design response |
+| --- | --- |
+| "The coverage table already implies manual QA." | Anything the operator needs to see or manually verify belongs in `Testing steps`. |
+| "Every click is safer as a checkbox." | Checkboxes mark verification decisions or outcomes, not individual UI actions. |
+| "One AC subsection per criterion is more complete." | Completeness comes from the table plus `Risks`; per-AC prose is optional only when it adds reader-useful context. |
+| "Unchecked boxes should fail CI so nobody forgets." | Operator-owned checkboxes are collaboration state; CI may validate structure but must not require those boxes to be checked. |
+| "A single closing issue is enough." | PRs can close one issue while relating to, blocking, or partially satisfying others. |
+
+## Red flags
+
+- A scaffolded PR body includes both `## Test coverage` and
+  `## Acceptance criteria` sections that restate the same validation story.
+- `## Testing steps` is absent, renamed, unordered, or contains prose-only human
+  verification with no pass/fail checkboxes.
+- Testing checklist items start with repeated labels such as `Operator check:`.
+- Testing checklist items only list UI actions and do not name observable
+  outcomes.
+- The combined coverage section inventories every successful command but makes
+  warnings, missing coverage, manual-only validation, or blockers hard to find.
+- `Risks` appears as an empty or placeholder subsection.
+- Scaffolded CI fails because a `Testing steps` checkbox is unchecked.
+- Helper docs still tell authors to add an `Acceptance criteria` section or a
+  prose subsection for every AC.
+
+## Token-efficiency targets
+
+Keep the template comments short and operational. The template should teach the
+section ownership once, use one compact example row or checklist item, and avoid
+repeating the same instruction in visible body text and HTML comments. Move
+long-form explanation into generated `AGENTS.md` only if a future Planner finds
+the template too terse for agents to follow.
+
+The combined coverage section should reduce PR body size by making the table the
+primary summary. Extra prose belongs only where it changes reviewer judgment.
+
+## Role ownership
+
+PR authors own filling the template. Operators own completing or rejecting
+human verification decisions under `Testing steps` and pre-merge chores under
+`Do before merging`. Reviewers own evaluating the coverage table, risks, and
+remaining unchecked operator work. CI owns structure, commit-title, closing
+keyword, and marker consistency checks only; CI does not own operator checkbox
+completion.
+
+Within Superteam, Brainstormer owns this design artifact, Planner owns the
+implementation plan, Executor owns template and helper-doc edits, Reviewer owns
+local review, and Finisher owns PR publication and latest-head follow-through.
+
+## Stage-gate bypass paths
+
+Gate 1 must not advance unless this design is committed and adversarial review
+is clean or dispositioned. Implementation must not start from this design until
+the operator explicitly approves it.
+
+During implementation, do not treat the new combined section as permission to
+drop acceptance-criteria coverage. AC rows remain required when an issue defines
+ACs. Do not treat unchecked operator checkboxes as merge approval. Do not move
+operator-owned QA into `Do before merging` to avoid visible testing gaps.
+
+## Adversarial review
+
+Reviewer context: same-thread fallback.
+
+Findings:
+
+- source: brainstormer
+  severity: material
+  location: Proposed change
+  finding: Keeping the section name `## Test coverage` could technically be a
+  combined section, but it risks preserving the old mental model and missing
+  the issue's request for a reader-friendly coverage, AC, and risk section.
+  disposition: Addressed by recommending `## Coverage and risks` while noting
+  the only acceptable alternative would still need to satisfy AC-87-6 through
+  AC-87-8.
+- source: adversarial-review
+  severity: material
+  location: CI checkbox decision
+  finding: The design could accidentally remove all PR-body structure checks
+  while trying to avoid unchecked-checkbox enforcement.
+  disposition: Addressed by allowing structure validation but forbidding CI from
+  requiring operator-owned testing checkboxes to be checked.
+- source: adversarial-review
+  severity: material
+  location: QA, merge chores, coverage, and risks
+  finding: `Do before merging` can become a loophole for moving manual QA out of
+  `Testing steps`.
+  disposition: Addressed by defining `Do before merging` as pre-merge chores
+  only and listing manual-QA relocation as a stage-gate bypass path.
+- source: adversarial-review
+  severity: minor
+  location: Proposed PR template shape
+  finding: ASCII status labels avoid emoji/symbol rendering variance, but the
+  existing template already uses symbols. Over-specifying labels could create an
+  unnecessary implementation constraint.
+  disposition: Addressed by making status labels flexible while keeping section
+  ownership binding.
+
+Adversarial review status: findings dispositioned.
+
+Clean pass rationale: The design has falsifiable RED/GREEN behavior, closes the
+main rationalizations from the issue, keeps the user-facing template concise,
+preserves author/operator/reviewer/CI ownership boundaries, and blocks the
+specific bypass paths that would hide manual QA or make unchecked operator-owned
+checkboxes fail CI. No approval-blocking findings remain.
+
+## Verification
+
+- Inspect `skills/scaffold-repository/templates/core/.github/pull_request_template.md`
+  for exact `## Testing steps` heading, ordered operator-step guidance, checkbox
+  outcome wording, multiple linked-issue guidance, and the combined coverage
+  plus optional risks shape.
+- Inspect root `.github/pull_request_template.md` for the same dogfood shape.
+- Inspect `skills/scaffold-repository/templates/core/AGENTS.md.tmpl` and
+  `skills/scaffold-repository/pr-body-template.md` for consistent PR-body
+  guidance and no stale `Acceptance criteria` entry requirement.
+- Inspect scaffolded workflows and scripts to confirm no CI path fails merely
+  because `## Testing steps` contains unchecked operator-owned checkboxes.
+- Run `pnpm lint:md`.
+- Run `pnpm apply:scaffold-repository:check`.

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -155,7 +155,9 @@ The skill does not recommend running any commands postinstall. Plugin enablement
 
 - **Commits**: Conventional Commits with no scope, required `#<issue>` tag, 72-char max. Enforced by commitlint + husky `commit-msg`.
 - **PR titles**: same format, so squash commits reuse them verbatim.
-- **PR body**: `Closes #<issue>` guidance and `### AC-<issue>-<n>` block.
+- **PR body**: multiple linked-issue relationships (`Closes`, `Related to`,
+  `Blocks`, `Partially satisfies`), a `Coverage and risks` AC/evidence table,
+  and ordered `Testing steps` for operator-owned pass/fail verification.
 - **Issue titles**: plain-language, no commit-style prefix.
 - **Markdown**: `markdownlint-cli2` with `.markdownlint.jsonc` + `.markdownlintignore`. `lint-staged` runs it from `pre-commit`. The lint script uses a glob that excludes `node_modules/`.
 - **PNPM**: `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, `lint:md` script.

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -155,9 +155,10 @@ The skill does not recommend running any commands postinstall. Plugin enablement
 
 - **Commits**: Conventional Commits with no scope, required `#<issue>` tag, 72-char max. Enforced by commitlint + husky `commit-msg`.
 - **PR titles**: same format, so squash commits reuse them verbatim.
-- **PR body**: multiple linked-issue relationships (`Closes`, `Related to`,
-  `Blocks`, `Partially satisfies`), a `Coverage and risks` AC/evidence table,
-  and ordered `Testing steps` for operator-owned pass/fail verification.
+- **PR body**: required closing keywords for normal PRs, additional
+  linked-issue relationships (`Related to`, `Blocks`, `Partially satisfies`), a
+  `Coverage and risks` AC/evidence table, and ordered `Testing steps` for
+  operator-owned pass/fail verification.
 - **Issue titles**: plain-language, no commit-style prefix.
 - **Markdown**: `markdownlint-cli2` with `.markdownlint.jsonc` + `.markdownlintignore`. `lint-staged` runs it from `pre-commit`. The lint script uses a glob that excludes `node_modules/`.
 - **PNPM**: `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, `lint:md` script.

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -34,7 +34,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 
 | File | Required | Check |
 |---|---|---|
-| `.github/pull_request_template.md` | yes | present; includes multiple linked-issue guidance, `## Coverage and risks`, exact `## Testing steps`, and `type: #123 short description` rule; has no AC-specific prose subsection requirement |
+| `.github/pull_request_template.md` | yes | present; includes required closing-keyword guidance plus additional linked-issue guidance, `## Coverage and risks`, exact `## Testing steps`, and `type: #123 short description` rule; has no AC-specific prose subsection requirement |
 | `.github/ISSUE_TEMPLATE/bug_report.md` | yes | present with frontmatter |
 | `.github/ISSUE_TEMPLATE/feature_request.md` | yes | present with frontmatter |
 | `.github/CODEOWNERS` | yes | present; at least one non-comment rule |

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -34,7 +34,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 
 | File | Required | Check |
 |---|---|---|
-| `.github/pull_request_template.md` | yes | present; includes `Closes #<issue>`, `### AC-<issue>-<n>`, `type: #123 short description` rule |
+| `.github/pull_request_template.md` | yes | present; includes multiple linked-issue guidance, `## Coverage and risks`, exact `## Testing steps`, and `type: #123 short description` rule; has no AC-specific prose subsection requirement |
 | `.github/ISSUE_TEMPLATE/bug_report.md` | yes | present with frontmatter |
 | `.github/ISSUE_TEMPLATE/feature_request.md` | yes | present with frontmatter |
 | `.github/CODEOWNERS` | yes | present; at least one non-comment rule |

--- a/skills/scaffold-repository/pr-body-template.md
+++ b/skills/scaffold-repository/pr-body-template.md
@@ -1,9 +1,9 @@
 # PR Body Template
 
-`bootstrap` does not produce PRs itself. When a change to this repository is driven by the `superteam` workflow, use the PR template at `.github/pull_request_template.md` at the repository root. It is the canonical PR body format for every Patina Project repository and is what the emitted baseline includes.
+`scaffold-repository` does not produce PRs itself. When a change to this repository is driven by the `superteam` workflow, use the PR template at `.github/pull_request_template.md` at the repository root. It is the canonical PR body format for every Patina Project repository and is what the emitted baseline includes.
 
 This file exists so downstream skills that inspect adjacent skill files find a predictable set of supporting docs.
 
 ## Commit-type guidance validation reminder
 
-When a PR touches commit-type guidance (any of `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`, or the per-tool surfaces under `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md` and their templates), include the AC-54-7 parity grep output under the relevant `Acceptance criteria` entry – or write `empty output verified` if the grep produced no output. Non-empty output is a hard blocker. Use `Do before merging` only when a human operator still has a work-specific action to perform before merge.
+When a PR touches commit-type guidance (any of `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`, or the per-tool surfaces under `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md` and their templates), include the AC-54-7 parity grep output as evidence in the relevant `Coverage and risks` table row, or write `empty output verified` if the grep produced no output. Non-empty blocking output belongs in the `Risks` subsection and is a hard blocker. Use `Do before merging` only when a human operator still has a work-specific action to perform before merge.

--- a/skills/scaffold-repository/templates/core/.github/pull_request_template.md
+++ b/skills/scaffold-repository/templates/core/.github/pull_request_template.md
@@ -17,11 +17,12 @@
 
 ## Linked issue
 
-- `Closes #<issue>` for each issue this PR completes.
+- At least one GitHub closing keyword is required for normal PRs:
+  `Closes #<issue>`, `Fixes #<issue>`, or `Resolves #<issue>`.
+- Add one closing-keyword line for each issue this PR completes.
 - `Related to #<issue>` / `Blocks #<issue>` / `Partially satisfies #<issue>`
-  for each additional issue, with a short explanation when the relationship is
-  not obvious.
-- `None` when no issue applies.
+  are additional references, not replacements for the required closing keyword.
+  Include a short explanation when the relationship is not obvious.
 
 ## What changed
 

--- a/skills/scaffold-repository/templates/core/.github/pull_request_template.md
+++ b/skills/scaffold-repository/templates/core/.github/pull_request_template.md
@@ -17,27 +17,29 @@
 
 ## Linked issue
 
-- `Closes #<issue>` when this PR is intended to complete the issue
-- Otherwise: `Related to #<issue>` plus a short explanation of why this PR does not close it yet
-- `None` when no issue applies
+- `Closes #<issue>` for each issue this PR completes.
+- `Related to #<issue>` / `Blocks #<issue>` / `Partially satisfies #<issue>`
+  for each additional issue, with a short explanation when the relationship is
+  not obvious.
+- `None` when no issue applies.
 
 ## What changed
 
-Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `standalone — <reason>` when there is none>
+Context: <prior PR, prior QA pass, follow-up issue, or `standalone - <reason>`>
 
-- <change> — <why>
+- <change> - <why>
 
 <!--
-  The rendered `Context:` line and `- <change> — <why>` bullet shape are the
+  The rendered `Context:` line and `- <change> - <why>` bullet shape are the
   structural placeholders this section requires. Replace `<...>` with actual
   values; do not delete the `Context:` line. When this PR has no prior
-  context, write `Context: standalone — <reason>` (e.g.
-  `Context: standalone — first pass on the new lint rule`). One bullet per
-  change; the `— <why>` half states the rationale (user-visible reason or
+  context, write `Context: standalone - <reason>` (e.g.
+  `Context: standalone - first pass on the new lint rule`). One bullet per
+  change; the `- <why>` half states the rationale (user-visible reason or
   triggering observation), not a restatement of the change.
 
   Include this section only when PR-level operator steps that do not belong to
-  a specific AC must happen after review and before merge:
+  QA, coverage gaps, or pending CI must happen after review and before merge:
 
   ## Do before merging
 
@@ -50,78 +52,45 @@ Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `sta
   steps.`
 -->
 
-## Test coverage
+## Coverage and risks
 
 Legend for status cells:
 
-- ✅ — required validation passed with no known relevant gap for this column.
-- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
-- ❌ — required validation is missing, failing, pending, or merge-blocked.
-- ➖ — not relevant to this AC.
+- PASS - required validation passed with no known relevant gap.
+- WARN - sufficient to merge with a known non-blocking gap in Risks.
+- BLOCKED - missing, failing, pending, or merge-blocking.
+- N/A - not relevant to this AC.
 
-The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.
+The `AC` column references acceptance-criteria IDs from linked issues in
+`AC-<issue>-<n>` form.
 
 <!--
   When showing a partial example outside a PR body, label the whole example as
-  an excerpt before the first omitted section or table. Actual PR bodies must
-  not omit relevant AC headings.
-
-  Include one matrix row per relevant AC, then one subsection per AC with only
-  tester-useful coverage context: what was validated, where it ran, evidence,
-  known gaps or caveats, and whether manual testing is still needed. Keep the
-  `Unit` column, then add one column per supported platform affected by this
-  PR. Each cell summarizes the required-validation state for that AC and
-  column. Use only these symbols in status cells:
-  ✅ = required validation passed, with no known relevant gap for this column
-  ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
-       gap documented under this AC
-  ❌ = required validation is missing, failing, pending, or blocked by a
-       merge-blocking gap
-  ➖ = not relevant to this AC
-
-  Use `➖` only when that verification type is not relevant to the AC. If an AC
-  includes evidence or a gap that clearly maps to a matrix column, that cell
-  must not be `➖`. If a known non-blocking gap remains after sufficient
-  validation, use `⚠️` and document the gap under the AC in prose. If required
-  validation is missing, failing, pending, blocked by an unresolved concern, or
-  otherwise cannot yet be trusted for merge, use `❌` and document the gap under
-  the AC in prose. Do not use checkboxes in this section; tester actions belong
-  under `## Testing steps`.
+  an excerpt before the first omitted section or table. Actual PR bodies should
+  include one table row per relevant AC when linked issues define ACs. The
+  table is the primary AC summary; add prose only when it changes reviewer
+  judgment. Report coverage so humans and agents can identify remaining risk,
+  not as an inventory of every passed test command. Do not use checkboxes in
+  this section.
 -->
-| AC | Title | Unit | <Platform> |
+| AC | Requirement | Evidence | Status |
 | --- | --- | --- | --- |
-| AC-<issue>-<n> | <short title> | ➖ | ➖ |
+| AC-<issue>-<n> | <short title> | <command, job, manual source, or doc review> | PASS |
 
-### AC-<issue>-<n>
+<!-- Omit this subsection when there are no notable risks or gaps. -->
+### Risks
 
-Coverage summary focused on what helps a human tester understand the state of this AC.
-
-- Evidence: `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
-- Gap: <missing, pending, or non-blocking validation, or `None`>.
-- Manual testing needed: <yes/no and why>.
-
-<!--
-  Repeat one subsection per relevant AC. Keep this section evidence-only and
-  checkbox-free. Include only information that helps a reviewer or tester
-  understand coverage, gaps, and whether manual exercise is still needed.
--->
-
-<!--
-  Deferred or out-of-scope ACs still get a subsection so reviewers can see why
-  no testing is reported for them:
-
-  ### AC-<issue>-<n>
-
-  Deferred to `<repo-or-follow-up>`.
--->
+- <warning, missing coverage, merge blocker, manual-only validation, deferred
+  check, or caveat>
 
 ## Testing steps
 
 <!--
-  Add concrete tester actions here. Use checkboxes only in this section or in
-  `## Do before merging`. Steps should cover any `❌` or `⚠️` gaps called out
-  in `## Test coverage` when a human can close or evaluate the gap. If no
-  manual testing is needed, include one checked row explaining why.
+  List every operator-owned verification step here in the order the operator
+  should perform or inspect it. Use checkboxes for pass/fail verification
+  decisions or outcomes, not for every individual UI action. Anything the
+  operator needs to see or manually verify belongs here. If no manual testing is
+  needed, include one checked row explaining why.
 -->
 
-- [ ] <imperative testing step and expected result>
+- [ ] Verify <observable outcome> after <minimal action context>.

--- a/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
+++ b/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
@@ -70,7 +70,7 @@ The `autorelease: pending` and `autorelease: tagged` labels are reserved for Rel
 
 This repo ships canonical templates for issues and pull requests. Agents must use them – do not invent parallel structure.
 
-- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings in the order the template defines, even when the body is passed inline via `--body`. Include `Do before merging` only when work-specific operator steps exist; when present, it belongs between `What changed` and `Test coverage`.
+- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings in the order the template defines, even when the body is passed inline via `--body`. Include `Do before merging` only when work-specific operator steps exist; when present, it belongs between `What changed` and `Coverage and risks`.
 - Issues: `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`. Pick the one that matches the report and reproduce its sections in order.
 
 Recommended `gh` patterns:
@@ -78,7 +78,7 @@ Recommended `gh` patterns:
 - PRs: `gh pr create --body-file <path-to-rendered-body>` is the safest path. The rendered body must already follow the template. If you pass `--body` inline, copy every template section name and order verbatim before filling them in.
 - Issues: `gh issue create --template bug_report.md` or `--template feature_request.md` lets `gh` start from the canonical file. If you pass `--body` inline, mirror the template's headings the same way.
 
-Do not invent alternative section names when the template uses different ones – extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Test coverage` and `Testing steps` sections, not a replacement for them.
+Do not invent alternative section names when the template uses different ones – extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Coverage and risks` and `Testing steps` sections, not a replacement for them.
 
 ## GitHub Actions pinning
 
@@ -114,7 +114,7 @@ Pick the commit type by **path**, not by file extension or self-judged "intent".
 **Product-surface globs:**
 
 - `skills/**`
-- `skills/bootstrap/templates/**`
+- `skills/scaffold-repository/templates/**`
 - `.claude-plugin/**`, `.codex-plugin/**`
 - `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
 - `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
@@ -139,7 +139,7 @@ Changes that should produce a release must not use non-bumping types such as `do
 |-----------------|---------|
 | "It's just Markdown." | Markdown on `skills/**`, plugin manifests, or agent-instruction surfaces is the shipped product. Type by path, not by file extension. |
 | "I'm only aligning wording with the source of truth." | If the source of truth is itself a product surface (skill, template, agent instruction), wording IS behavior. Use `feat:`. |
-| "It's just a template change." | Templates under `skills/bootstrap/templates/**` ship to every bootstrapped repo on the next realignment. They are product. Use `feat:` / `fix:`. |
+| "It's just a template change." | Templates under `skills/scaffold-repository/templates/**` ship to every scaffolded repo on the next realignment. They are product. Use `feat:` / `fix:`. |
 | "I'm only adding a non-goal or an example to a skill." | Examples and non-goals on a `SKILL.md` change how the skill is interpreted by agents. Product. `feat:`. |
 | "I'm fixing a typo in a skill body." | Path-only rule: any edit inside `skills/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, or `.github/copilot-instructions.md` is `fix:` when correcting wrong shipped content and `feat:` when adding or changing shipped content. Do not assess "whether it affects how the skill is read" – the path test already settled it. `chore:` is only available when the diff touches zero product-surface globs. |
 | "It's a plugin manifest version bump." | Release-please owns version bumps under `chore: release X.Y.Z`. Hand-editing a manifest version outside that flow is a `fix:` (lockstep correction) or a release-PR commit, never `docs:`. Other manifest edits (description, homepage, keywords) are `feat:` because they change marketplace-visible product. |
@@ -166,19 +166,19 @@ The verb "standardize" combined with a diff under `skills/**` and `.codex-plugin
 
 #### Round-trip discipline
 
-On this repo the canonical "Commit type selection" section is shipped through `skills/bootstrap/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `bootstrap` skill in realignment mode. Mistyped commits silently suppress releases – see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
+On this repo the canonical "Commit type selection" section is shipped through `skills/scaffold-repository/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `scaffold-repository` skill in realignment mode. Mistyped commits silently suppress releases – see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
 
-Pull requests should include linked issue (`None` when no issue applies), what changed, test coverage matrix, and acceptance-criteria outcomes. Include a `Do before merging` section only when work-specific operator pre-merge steps exist.
+Pull requests should include linked issue references (`None` when no issue applies), what changed, a `Coverage and risks` table, and `Testing steps` for operator-owned verification. Include a `Do before merging` section only when work-specific operator pre-merge steps exist.
 
 For squash-and-merge workflows, PR titles must exactly match the commit format. Use the final intended squash commit title as the PR title.
 
 GitHub issue titles are different: write them as plain-language summaries of the problem or request. Do not use conventional-commit prefixes like `docs:` or `feat:` in issue titles.
 
-When an issue defines acceptance criteria, include matching AC entries in the PR description's `Test coverage` section and put human tester actions in `Testing steps`.
+When an issue defines acceptance criteria, include matching AC rows in the PR description's `Coverage and risks` table and put human tester actions in `Testing steps`.
 
-- Use one `### AC-<issue>-<n>` heading per relevant AC inside `Test coverage`, with the heading containing only the AC ID.
-- Put only tester-useful coverage context under each AC: what was validated, where it ran, evidence, gaps or caveats, and whether manual testing is still needed.
-- Do not use checkboxes in `Test coverage`.
-- Use checkboxes for human tester actions only in `Testing steps`, and for pre-merge operator actions only in `Do before merging`.
-- Make `Testing steps` cover any `❌` or `⚠️` coverage gaps when a human can close or evaluate the gap.
-- If an AC is deferred or out of scope for the repo, say so under its `Test coverage` heading and do not add fake checkboxes.
+- Put AC coverage in the table. Add extra prose only when it gives reader-useful context that changes reviewer judgment.
+- Use `### Risks` at the bottom of `Coverage and risks` for warnings, missing coverage, merge-blocking gaps, manual-only validation, deferred checks, or caveats. Omit it when empty.
+- Do not use checkboxes in `Coverage and risks`.
+- Use checkboxes for operator-owned pass/fail verification outcomes only in `Testing steps`, and for pre-merge operator chores only in `Do before merging`.
+- Do not put a checkbox on every individual UI action. Anything the operator needs to see or manually verify belongs in `Testing steps`, in the order the operator should perform or inspect it.
+- If an AC is deferred or out of scope for the repo, report that in the coverage table or `### Risks`; do not add fake checkboxes.

--- a/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
+++ b/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
@@ -168,7 +168,7 @@ The verb "standardize" combined with a diff under `skills/**` and `.codex-plugin
 
 On this repo the canonical "Commit type selection" section is shipped through `skills/scaffold-repository/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `scaffold-repository` skill in realignment mode. Mistyped commits silently suppress releases – see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
 
-Pull requests should include linked issue references (`None` when no issue applies), what changed, a `Coverage and risks` table, and `Testing steps` for operator-owned verification. Include a `Do before merging` section only when work-specific operator pre-merge steps exist.
+Pull requests should include at least one GitHub closing keyword for normal PRs, any additional linked issue references, what changed, a `Coverage and risks` table, and `Testing steps` for operator-owned verification. Include a `Do before merging` section only when work-specific operator pre-merge steps exist.
 
 For squash-and-merge workflows, PR titles must exactly match the commit format. Use the final intended squash commit title as the PR title.
 

--- a/skills/scaffold-repository/templates/core/CONTRIBUTING.md.tmpl
+++ b/skills/scaffold-repository/templates/core/CONTRIBUTING.md.tmpl
@@ -28,7 +28,7 @@ Pick the commit type by **path**, not by file extension. If any file in the diff
 **Product-surface globs:**
 
 - `skills/**`
-- `skills/bootstrap/templates/**`
+- `skills/scaffold-repository/templates/**`
 - `.claude-plugin/**`, `.codex-plugin/**`
 - `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
 - `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
@@ -61,7 +61,8 @@ pnpm lint:md
 
 - Keep the PR title in commitlint format.
 - Fill in the [PR template](./.github/pull_request_template.md).
-- Include an `Acceptance criteria` section when the linked issue defines ACs.
+- Fill the template's `Coverage and risks` table when linked issues define ACs.
+- Put operator-owned verification decisions in `Testing steps`.
 
 ## Further reading
 


### PR DESCRIPTION
## Linked issue

Closes #87

## What changed

Context: standalone - scaffold PR description template cleanup driven by issue #87.

- Simplified the root and scaffolded PR templates - gives QA steps, AC coverage, risks, and pre-merge chores one clear home.
- Aligned scaffold-repository contributor guidance and helper docs - keeps generated AGENTS, CONTRIBUTING, audit, and PR-body guidance consistent with the new template contract.
- Documented the design and implementation plan - preserves Superteam approval and execution context for future reviewers.

## Coverage and risks

Legend for status cells:

- PASS - required validation passed with no known relevant gap.
- WARN - sufficient to merge with a known non-blocking gap in Risks.
- BLOCKED - missing, failing, pending, or merge-blocking.
- N/A - not relevant to this AC.

| AC | Requirement | Evidence | Status |
| --- | --- | --- | --- |
| AC-87-1 | Scaffold PR template has exact `## Testing steps` section | Template inspection, targeted search | PASS |
| AC-87-2 | Operator-owned steps are included in verification order | Template and AGENTS guidance inspection | PASS |
| AC-87-3 | Pass/fail operator decisions use checkboxes | Template inspection | PASS |
| AC-87-4 | Checkboxes are reserved for decisions, not every UI action | Template and generated AGENTS guidance inspection | PASS |
| AC-87-5 | Anything operator-visible/manual belongs in `Testing steps` | Template and generated AGENTS guidance inspection | PASS |
| AC-87-6 | Separate duplicate `Test coverage` / `Acceptance criteria` sections removed | Stale-contract `rg` search | PASS |
| AC-87-7 | One combined reader-friendly AC/evidence/gap section exists | `Coverage and risks` template inspection | PASS |
| AC-87-8 | Table is primary AC summary with bottom `Risks` for caveats | Template inspection | PASS |
| AC-87-9 | `Risks` is omitted when empty | Template comment inspection | PASS |
| AC-87-10 | No required prose subsection per AC | Template and AGENTS guidance inspection | PASS |
| AC-87-11 | Coverage reporting emphasizes remaining risk, not passed-test inventory | Template and AGENTS guidance inspection | PASS |
| AC-87-12 | Testing examples avoid `Operator check:` prefix | Stale-contract `rg` search | PASS |
| AC-87-13 | Testing checkboxes name observable outcomes | Template example inspection | PASS |
| AC-87-14 | Scaffolded CI does not fail unchecked operator-owned checkboxes | Workflow/script search, scaffold workflow inspection | PASS |
| AC-87-15 | Linked issue guidance supports multiple relationships | Template inspection | PASS |
| AC-87-16 | Helper docs/templates are consistent with the contract | Scaffold docs inspection, stale-contract `rg` search | PASS |

### Risks

- Repo-wide `pnpm lint:md` still reports pre-existing `CHANGELOG.md` MD012 blank-line errors at lines 5 and 12. Targeted markdown lint on the files changed for #87 passed.

## Testing steps

- [x] Verify scaffold alignment with `pnpm apply:scaffold-repository:check`; expected: root and scaffolded PR templates stay in sync.
- [x] Verify skill discovery and marketplace metadata with `pnpm verify:dogfood` and `pnpm verify:marketplace`; expected: both pass.
- [x] Verify no scaffolded CI path fails unchecked operator-owned `Testing steps` checkboxes; expected: targeted search finds no checkbox-completion gate.
