### PR TITLE
feat: #60 add PR comment workflow

### DIFF
--- a/docs/superpowers/plans/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-plan.md
+++ b/docs/superpowers/plans/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-plan.md
@@ -1,0 +1,141 @@
+# Plan: using-github should teach inline PR comment response and resolve [#60](https://github.com/patinaproject/skills/issues/60)
+
+## Approved design
+
+- Design artifact: `docs/superpowers/specs/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-design.md`
+- Gate 1 approval: operator explicitly approved with `lgtm` on 2026-05-15.
+- Handoff commit: `6f89e01529b49cb45df274a9088026e6577dc172`
+- Binding ACs: `AC-60-1` through `AC-60-8`.
+
+## Goal
+
+Teach `using-github` agents how to safely enumerate, classify, reply to, and
+optionally resolve inline PR review comments without treating replies as
+resolution, skipping pagination, replying to stale state, or bypassing
+Superteam requirement-routing gates.
+
+Requirement-changing deltas are out of scope for Executor. If implementation
+uncovers a need to change the approved ownership model, remove latest-head
+verification, weaken pagination, skip threaded replies, alter Superteam routing,
+or otherwise revise the requirements, halt and route the delta back to
+Brainstormer before continuing.
+
+## Workstreams
+
+### W1: Register the PR comments procedure
+
+Update `skills/using-github/SKILL.md`.
+
+Tasks:
+
+- W1.1 Add one concise Required Procedures bullet for PR comments.
+- W1.2 Point the bullet to `workflows/pr-comments.md`.
+- W1.3 State that agents follow the procedure before replying to, resolving, or
+  reporting PR review feedback handled.
+- W1.4 Keep detailed GitHub API mechanics out of `SKILL.md`; the main skill
+  entry point should stay concise.
+
+Acceptance criteria covered: `AC-60-1`.
+
+### W2: Add the PR comment handling workflow
+
+Add `skills/using-github/workflows/pr-comments.md`.
+
+Tasks:
+
+- W2.1 Use the existing workflow-file style: concise goal, preconditions,
+  checklist, command examples, halt conditions, and common mistakes.
+- W2.2 Define the target use case as handling inline PR review feedback in the
+  current working directory's default `gh` repository.
+- W2.3 Require agents to capture repository owner, repository name, PR number,
+  branch, and latest PR head SHA before handling comments.
+- W2.4 Require paginated GraphQL review-thread enumeration with `--paginate`.
+  The command must retain thread IDs, `isResolved`, stale/outdated context where
+  available, comment database IDs, URLs, paths, line/original-line fields, and
+  comment commit OIDs.
+- W2.5 Explicitly state that REST review comments alone are insufficient for
+  thread resolution state and that the first page must not be treated as
+  complete.
+- W2.6 Explain that a thread with replies is still unresolved when
+  `isResolved: false`; reply count and elapsed time are not completion evidence.
+- W2.7 Require current-head verification before replying to or resolving a
+  thread: inspect the relevant file and nearby lines, compare path and line
+  context, compare the comment commit OID to the current implementation, and
+  classify stale or outdated comments as non-blocking only with concrete
+  evidence.
+- W2.8 Require threaded inline replies through
+  `gh api -X POST repos/<owner>/<repo>/pulls/<n>/comments/<id>/replies`, and
+  explain that `<id>` is the numeric review comment database ID rather than the
+  GraphQL node ID.
+- W2.9 Require evidence-bearing replies. When a fix commit exists, include the
+  relevant commit SHA or short SHA and a concise latest-head explanation. When
+  no fix commit exists, include the stale, duplicate, informational, or
+  not-applicable evidence instead.
+- W2.10 Add explicit classification and routing for requirement-bearing
+  feedback. Changes to requirements, acceptance criteria, scope, user-visible
+  behavior, or workflow contracts route through
+  `Brainstormer -> Planner -> Executor` before returning to PR comment
+  handling. Implementation-detail feedback that preserves approved requirements
+  may route directly to the implementation owner, but the workflow must say that
+  classification out loud.
+- W2.11 Include optional GraphQL `resolveReviewThread` mutation guidance only
+  after current-head verification and concrete handling evidence. If resolution
+  permissions are unavailable or the mutation fails, the workflow must leave an
+  evidence-bearing threaded reply and report the thread as unresolved instead of
+  claiming it is resolved.
+- W2.12 Define "handled" as addressed and verified on latest head, replied to
+  with evidence and optionally resolved, routed through the proper Superteam
+  owner path, or classified non-blocking with evidence.
+- W2.13 Warn that silence, elapsed time, local intent, reply without
+  verification, PR creation, and green CI alone are not proof that feedback was
+  handled.
+
+Acceptance criteria covered: `AC-60-2`, `AC-60-3`, `AC-60-4`, `AC-60-5`,
+`AC-60-6`, `AC-60-7`, `AC-60-8`.
+
+### W3: Verify the skill and workflow changes
+
+Run targeted checks plus the repo-level verification relevant to a skill/docs
+change.
+
+Commands and expected outcomes:
+
+- W3.1 `pnpm exec markdownlint-cli2 skills/using-github/SKILL.md skills/using-github/workflows/pr-comments.md docs/superpowers/plans/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-plan.md`
+  should pass.
+- W3.2 `pnpm lint:md` should pass for tracked Markdown files. If unrelated
+  pre-existing lint failures appear, capture the exact file and rule, then keep
+  the targeted lint command above as the issue-owned evidence.
+- W3.3 `pnpm verify:dogfood` should pass, confirming all six in-repo skills
+  remain discoverable through the flat layout.
+- W3.4 `pnpm verify:marketplace` should pass, confirming marketplace metadata
+  remains valid after the skill documentation change.
+- W3.5 `rg -n "pr-comments.md|PR comments|Pull request comments" skills/using-github`
+  should show the `SKILL.md` Required Procedures reference and the new workflow
+  file.
+- W3.6 `rg -n -- "--paginate|isResolved|databaseId|resolveReviewThread|comments/<id>/replies|Brainstormer -> Planner -> Executor|latest head|green CI" skills/using-github/workflows/pr-comments.md`
+  should show the approved workflow mechanics and guardrails.
+
+Acceptance criteria covered: `AC-60-1` through `AC-60-8`.
+
+### W4: Prepare PR body expectations for Finisher
+
+When implementation is complete and reviewed, the PR body should use the
+current repository template contract.
+
+Tasks:
+
+- W4.1 Use `## Linked issue` with `Closes #60`.
+- W4.2 Use `## Coverage and risks` as the single AC, evidence, and risk
+  summary.
+- W4.3 Include one table row per relevant AC from `AC-60-1` through `AC-60-8`.
+- W4.4 Put operator-owned manual verification decisions, if any, under
+  `## Testing steps`.
+- W4.5 Put only pre-merge operational chores, if any, under
+  `## Do before merging`.
+- W4.6 Do not add a separate AC-to-file:line mapping table.
+
+Acceptance criteria covered: `AC-60-1` through `AC-60-8`.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-design.md
+++ b/docs/superpowers/specs/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-design.md
@@ -1,0 +1,415 @@
+# Design: using-github should teach inline PR comment response and resolve [#60](https://github.com/patinaproject/skills/issues/60)
+
+## Summary
+
+Add a focused pull request comment workflow to `using-github` so agents can
+enumerate unresolved PR review threads, distinguish threads that merely have
+replies from threads that are actually resolved, verify each comment still
+applies to the current head, reply inline with evidence, and optionally resolve
+threads through GraphQL.
+
+The recommended direction is a new supporting workflow file at
+`skills/using-github/workflows/pr-comments.md`, referenced from the
+`skills/using-github/SKILL.md` Required Procedures list. This keeps
+`SKILL.md` concise while giving agents the concrete commands and checks needed
+for safe PR comment handling.
+
+## Skill guidance
+
+This design touches `skills/**/*.md` and changes a skill/workflow surface.
+`superpowers:brainstorming` and `superpowers:writing-skills` are not installed
+in this environment, so this artifact compensates by including structured
+brainstorming and an explicit workflow-contract review. The review dimensions
+used here are:
+
+- RED/GREEN baseline obligations
+- rationalization resistance
+- red flags
+- token-efficiency targets
+- role ownership
+- stage-gate bypass paths
+
+The installed `write-a-skill` guidance was reviewed before authoring. It favors
+concise `SKILL.md` files, detailed one-level supporting workflow files for
+complex procedures, concrete examples and checklists, and no time-sensitive
+instructions.
+
+## Problem
+
+`using-github` currently tells agents how to start issues, edit issues, write
+changelogs, and prepare pull requests, but it does not teach the mechanics of
+handling inline PR review feedback. Agents therefore fall back to ad-hoc
+behavior: they may treat a replied thread as resolved, reply to stale code,
+omit fix commit evidence, resolve comments without verifying the current head,
+or implement requirement-bearing feedback directly instead of routing it through
+the proper Superteam design and planning path.
+
+Issue #60 asks for a procedure that makes inline PR comment response and
+resolution explicit and repeatable.
+
+## Goals
+
+- Add a required `using-github` procedure for PR comment handling.
+- Teach paginated enumeration of unresolved review threads and review comments.
+- Distinguish unresolved threads from threads that have merely received replies.
+- Require current-head verification before replying to or resolving a thread.
+- Standardize threaded replies through the GitHub REST replies endpoint.
+- Link replies to the fix commit SHA when available.
+- Preserve Superteam ownership by routing requirement-bearing feedback through
+  `Brainstormer -> Planner -> Executor`.
+- Allow optional GraphQL thread resolution only after the workflow has verified
+  the thread is handled.
+- Keep the main skill entry point concise by placing detailed commands and
+  checklists in a supporting workflow file.
+
+## Non-Goals
+
+- Create a separate installable `pr-comments` skill.
+- Replace Superteam's latest-head PR completion gate or Finisher ownership.
+- Auto-resolve every replied thread.
+- Add hidden workflow state, commit trailers, sidecar files, labels, or other
+  durable markers outside GitHub's visible PR surfaces.
+- Change GitHub branch protection, review requirements, or CI behavior.
+- Implement the workflow in this design step.
+
+## Recommended Direction
+
+Create `skills/using-github/workflows/pr-comments.md` as a required procedure
+and add one Required Procedures bullet in `skills/using-github/SKILL.md`, for
+example:
+
+> PR comments: follow `workflows/pr-comments.md` before replying to, resolving,
+> or reporting PR review feedback handled.
+
+The workflow file should be command-oriented and checklist-based. It should
+cover discovery, classification, current-head verification, reply drafting,
+threaded reply creation, optional GraphQL resolution, and escalation/routing.
+
+This is better than expanding `SKILL.md` because PR comment handling has enough
+GitHub API details to bloat the entry point. A supporting file follows the
+repo's existing pattern for `new-issue.md`, `edit-issue.md`, `new-branch.md`,
+and `write-changelog.md`, while keeping the trigger surface easy to scan.
+
+## Requirements
+
+### R1: Required procedure registration
+
+`skills/using-github/SKILL.md` must reference the new PR comment procedure under
+Required Procedures. The reference must make clear that agents should follow it
+before replying to, resolving, or reporting PR review feedback handled.
+
+### R2: Supporting workflow file
+
+Add `skills/using-github/workflows/pr-comments.md`. The file should be a
+supporting workflow contract, not a separate installable skill. It should use
+the same general style as the existing workflow files: concise goal,
+preconditions, checklist, explicit commands, halt conditions, and common
+mistakes.
+
+### R3: Enumerate unresolved review threads with pagination
+
+The workflow must require paginated enumeration of review threads for the target
+PR. It should prefer GraphQL for thread resolution state because REST review
+comments alone do not expose the full unresolved thread model. The procedure
+must avoid assuming the first page is complete.
+
+The workflow should include a command shape equivalent to:
+
+```bash
+gh api graphql --paginate -f owner="$owner" -f repo="$repo" -F number="$pr" -f query='
+query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first: 100) {
+            nodes {
+              id
+              databaseId
+              author { login }
+              body
+              url
+              path
+              line
+              originalLine
+              commit { oid }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+The exact implementation may adjust fields, but it must retain pagination,
+thread IDs, `isResolved`, stale/outdated context where available, comment
+database IDs for REST replies, URLs, paths, lines, and commit OIDs.
+
+### R4: Distinguish unresolved from merely replied
+
+The workflow must explicitly state that a thread with replies is not necessarily
+resolved. `isResolved: false` remains unresolved even if the agent or author has
+already replied. Agents must inspect thread resolution state, not infer closure
+from reply count or elapsed time.
+
+### R5: Verify referenced state against current HEAD
+
+Before replying to or resolving a thread, the workflow must require agents to
+verify whether the referenced state still applies to the current head. The
+procedure should instruct agents to:
+
+- capture the latest head SHA for the PR branch
+- inspect the relevant file/path and nearby lines in the working tree
+- compare the comment's path, line/original line, and comment commit OID to the
+  current implementation
+- classify stale or outdated comments as non-blocking only with concrete
+  evidence
+- route comments that still apply to the proper owner before replying as if the
+  work is complete
+
+### R6: Threaded inline replies through REST
+
+The workflow must use threaded replies for inline PR review comments, using the
+GitHub REST endpoint:
+
+```bash
+gh api -X POST repos/<owner>/<repo>/pulls/<n>/comments/<id>/replies \
+  -f body="$body"
+```
+
+The workflow must explain that `<id>` is the numeric review comment database ID,
+not the GraphQL node ID, and must include guidance for extracting it from the
+thread inventory.
+
+### R7: Link replies to fix commit SHA when available
+
+When a fix commit exists, replies should include the relevant commit SHA or
+short SHA and a concise explanation of how the latest head addresses the
+comment. If no fix commit exists because the comment is stale, duplicate,
+informational, or not applicable, the reply must state the evidence for that
+classification instead.
+
+### R8: Requirement-bearing feedback routes through Superteam owners
+
+The workflow must warn that feedback changing requirements, acceptance criteria,
+scope, user-visible behavior, or workflow contracts cannot route straight to an
+implementation reply. It must go through `Brainstormer -> Planner -> Executor`
+before `Finisher` or the acting GitHub owner returns to PR comment handling.
+
+Implementation-detail feedback that preserves requirements and acceptance
+intent may route directly to the implementation owner, but the workflow should
+make that classification explicit.
+
+### R9: Optional GraphQL resolution after handling
+
+The workflow may include optional thread resolution through GraphQL, but only
+after current-head verification and either a concrete fix, a concrete
+non-blocking classification, or the required Superteam routing path. The
+procedure should include the mutation shape:
+
+```bash
+gh api graphql -f threadId="$thread_id" -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}'
+```
+
+If GraphQL resolution fails or permissions are unavailable, the workflow should
+fall back to leaving a threaded reply and reporting the thread as unresolved
+instead of claiming it is resolved.
+
+### R10: Completion and reporting standard
+
+The workflow must define what "handled" means for a PR comment:
+
+- addressed in code, tests, docs, or workflow contracts and verified on latest
+  head
+- replied to with evidence and optionally resolved through GraphQL
+- routed through the proper Superteam owner path when requirement-bearing
+- classified non-blocking with evidence
+
+The workflow must warn that silence, elapsed time, a local intent to fix, a
+reply without verification, or green CI alone is not proof that feedback was
+handled.
+
+## Acceptance Criteria
+
+### AC-60-1
+
+Given an agent uses `using-github` for PR review feedback, when they inspect
+Required Procedures in `skills/using-github/SKILL.md`, then they see a PR
+comments procedure pointing to `workflows/pr-comments.md`.
+
+### AC-60-2
+
+Given a PR has more than one page of review threads, when the workflow
+enumerates unresolved feedback, then it uses paginated GitHub API calls and does
+not treat the first page as complete.
+
+### AC-60-3
+
+Given a review thread has replies but `isResolved` remains false, when the
+workflow classifies the thread, then it treats the thread as unresolved rather
+than assuming replies equal resolution.
+
+### AC-60-4
+
+Given a PR review comment references an older path, line, or commit, when the
+agent prepares to reply or resolve it, then the workflow requires verification
+against the current PR head before claiming the comment is handled.
+
+### AC-60-5
+
+Given an inline PR review comment should receive a response, when the workflow
+posts the response, then it uses the REST threaded replies endpoint with the
+numeric review comment database ID and includes the fix commit SHA when
+available.
+
+### AC-60-6
+
+Given PR feedback changes requirements, acceptance criteria, scope, user-visible
+behavior, or workflow contracts, when the workflow classifies the feedback, then
+it routes through `Brainstormer -> Planner -> Executor` before returning to PR
+comment handling.
+
+### AC-60-7
+
+Given a comment has been verified as fixed, stale, duplicate, informational, or
+otherwise non-blocking with evidence, when the agent has permission to resolve
+the thread, then the workflow may optionally use GraphQL `resolveReviewThread`;
+otherwise it leaves an evidence-bearing threaded reply and reports the remaining
+unresolved state.
+
+### AC-60-8
+
+Given the workflow reports PR feedback handled, when a reviewer audits the
+response, then the report is based on latest-head verification, concrete reply
+or resolution evidence, and any required Superteam routing rather than silence,
+elapsed time, or green CI alone.
+
+## Alternatives Considered
+
+### Leave PR comment handling ad-hoc
+
+Rejected. The issue exists because ad-hoc handling leaves too much room for
+unsafe shortcuts: replying to stale code, skipping pagination, treating replies
+as resolution, or bypassing requirement routing.
+
+### Put the full procedure in `SKILL.md`
+
+Rejected. The workflow needs API examples, pagination details, classification
+rules, and common mistakes. Putting all of that in `SKILL.md` would bloat the
+skill entry point and violate the `write-a-skill` preference for concise main
+files with detailed references split out.
+
+### Create a separate `pr-comments` skill
+
+Rejected. PR comment handling is part of GitHub work and should remain under
+the `using-github` entry point. A separate skill would fragment ownership and
+make it easier for agents to miss shared repo rules, templates, and leak-guard
+expectations.
+
+### Auto-resolve every handled thread
+
+Rejected. Some runs will not have permission to resolve threads, and some
+reviewers may prefer explicit replies without agent resolution. Resolution
+should be optional and evidence-gated.
+
+## Risks and Tradeoffs
+
+- GraphQL review thread enumeration is more complex than REST-only comment
+  listing, but it is necessary to see thread resolution state.
+- GitHub API fields and permissions vary by token. The workflow must define
+  fallback behavior when resolution is unavailable instead of pretending the
+  thread is closed.
+- Current-head verification costs time, but it prevents misleading replies on
+  stale or outdated comments.
+- Requiring Superteam routing for requirement-bearing feedback adds process, but
+  it preserves the design and planning gates that keep scope changes deliberate.
+- Including command examples in a workflow file adds maintenance surface. The
+  examples should use stable GitHub CLI/API shapes and avoid time-sensitive
+  repository-specific values.
+
+## Workflow-Contract Self-Review
+
+### RED/GREEN baseline obligations
+
+RED cases:
+
+- A workflow that lists only the first page of review threads is insufficient.
+- A workflow that treats "has replies" as resolved is insufficient.
+- A workflow that resolves comments without current-head verification is
+  insufficient.
+- A workflow that implements requirement changes directly without
+  `Brainstormer -> Planner -> Executor` routing is insufficient.
+
+GREEN cases:
+
+- The new workflow requires paginated thread inventory, resolution-state
+  inspection, latest-head verification, threaded replies, optional
+  evidence-gated resolution, and explicit Superteam routing for
+  requirement-bearing feedback.
+
+### Rationalization resistance
+
+The design closes likely shortcuts: "the first page was enough", "I replied so
+it is resolved", "CI is green so the comment is handled", "the code probably
+still matches", and "this requirement change is small enough to implement
+directly." Each shortcut is countered by a requirement or acceptance criterion.
+
+### Red flags
+
+Implementation should be reviewed for these failure modes:
+
+- `SKILL.md` absorbs detailed API instructions instead of linking to the
+  workflow file.
+- The workflow uses REST review comments only and never inspects GraphQL
+  `isResolved`.
+- The workflow omits pagination.
+- The workflow omits current-head verification before replies or resolution.
+- The workflow resolves a thread without evidence in a reply or report.
+- Requirement-bearing feedback routes straight to implementation.
+
+### Token-efficiency targets
+
+The main skill should gain only a short Required Procedures bullet. Detailed
+commands, examples, and checklists belong in `workflows/pr-comments.md`. The
+workflow should be concise enough to execute, but complete enough that agents do
+not need to rediscover GitHub API mechanics from the issue body.
+
+### Role ownership
+
+`using-github` owns the generic GitHub procedure. In Superteam contexts,
+`Finisher` or the acting GitHub owner owns PR feedback intake and thread
+handling, while `Brainstormer`, `Planner`, and `Executor` own remediation after
+feedback is classified and routed. The workflow must not let the comment
+handler absorb requirement-bearing changes.
+
+### Stage-gate bypass paths
+
+The design blocks stage-gate bypass by requiring requirement-bearing PR feedback
+to return to `Brainstormer -> Planner -> Executor` before PR comment handling
+resumes. It also prevents completion-style claims until comment handling is
+based on latest-head verification and visible GitHub evidence.
+
+## Light Self-Review Findings
+
+No approval-blocking findings remain from self-review. The required issue
+content is represented in requirements and ACs, the design recommends a
+supporting workflow file instead of bloating `SKILL.md`, and the
+workflow-contract review dimensions are explicit.
+
+Self-review is not the Team Lead adversarial pass required before Gate 1
+approval. It is a same-thread Brainstormer check to reduce obvious misses before
+handoff.

--- a/skills/using-github/SKILL.md
+++ b/skills/using-github/SKILL.md
@@ -30,6 +30,8 @@ supporting workflow contracts for this skill, not separate installable skills.
 - Existing issue edit: follow `workflows/edit-issue.md`.
 - Start issue work: follow `workflows/new-branch.md`.
 - Milestone changelog: follow `workflows/write-changelog.md`.
+- PR comments: follow `workflows/pr-comments.md` before replying to,
+  resolving, or reporting PR review feedback handled.
 - Pull request: read `.github/pull_request_template.md`, use the repo's PR
   title format, and include acceptance-criteria verification when the issue
   defines acceptance criteria.

--- a/skills/using-github/workflows/pr-comments.md
+++ b/skills/using-github/workflows/pr-comments.md
@@ -1,0 +1,319 @@
+# Pull request comments Workflow
+
+**Goal:** Handle inline PR review feedback in the current working directory's
+default `gh` repository by enumerating review threads, verifying each comment
+against the latest head, replying with evidence, and optionally resolving only
+threads that are actually handled.
+
+REST review comments alone are insufficient for this workflow because they do
+not expose the full review-thread resolution model. Use GraphQL review threads
+for thread state and REST only for threaded inline replies.
+
+---
+
+## Preconditions
+
+Operate only in the current working directory's default `gh` repository.
+Before replying to, resolving, or reporting feedback handled, capture:
+
+- Repository owner and name.
+- Pull request number.
+- Pull request branch.
+- Latest PR head SHA.
+- The current working tree contents for the referenced files.
+
+Resolve the target PR:
+
+```bash
+gh repo view --json nameWithOwner --jq .nameWithOwner
+gh pr view "$pr" \
+  --json number,headRefName,headRefOid,url \
+  --jq '{number, headRefName, headRefOid, url}'
+```
+
+Store the latest head as `$head_sha`. Re-fetch it immediately before final
+reporting if time has passed or new commits may have landed.
+
+---
+
+## Checklist (use TodoWrite)
+
+Create todos for each step before starting:
+
+- [ ] Step 1: Resolve repo, PR number, branch, and latest head SHA
+- [ ] Step 2: Enumerate review threads with paginated GraphQL
+- [ ] Step 3: Classify unresolved, resolved, outdated, and non-blocking items
+- [ ] Step 4: Route requirement-bearing feedback through Superteam owners
+- [ ] Step 5: Verify each handled item against the latest head
+- [ ] Step 6: Post evidence-bearing threaded replies through REST
+- [ ] Step 7: Optionally resolve eligible threads through GraphQL
+- [ ] Step 8: Report handled, unresolved, routed, and non-blocking feedback
+
+---
+
+## Step 1: Resolve Current PR State
+
+Capture the repository and PR metadata from the current working directory's
+default `gh` repository:
+
+```bash
+repo_json="$(gh repo view --json nameWithOwner \
+  --jq '{nameWithOwner}')"
+owner="$(printf '%s\n' "$repo_json" | jq -r '.nameWithOwner | split("/")[0]')"
+repo="$(printf '%s\n' "$repo_json" | jq -r '.nameWithOwner | split("/")[1]')"
+
+pr_json="$(gh pr view "$pr" \
+  --json number,headRefName,headRefOid,url \
+  --jq '{number, headRefName, headRefOid, url}')"
+head_sha="$(printf '%s\n' "$pr_json" | jq -r '.headRefOid')"
+```
+
+If any value is empty, halt:
+
+> "Could not resolve repo, PR, branch, and latest head SHA from the current
+> `gh` repository; refusing to handle PR comments."
+
+---
+
+## Step 2: Enumerate Review Threads
+
+Use paginated GraphQL. Do not treat the first page as complete.
+
+```bash
+gh api graphql --paginate \
+  -f owner="$owner" \
+  -f repo="$repo" \
+  -F number="$pr" \
+  -f query='
+query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first: 100) {
+            nodes {
+              id
+              databaseId
+              author { login }
+              body
+              url
+              path
+              line
+              originalLine
+              commit { oid }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Retain this inventory for every relevant thread:
+
+- Thread GraphQL `id`.
+- Thread `isResolved`.
+- Thread `isOutdated` where GitHub returns it.
+- Thread path, line, and original-line fields.
+- Each comment's numeric `databaseId`.
+- Each comment's GraphQL `id`, URL, author, and body.
+- Each comment path, line, original-line fields, and commit OID.
+
+If a thread has more than 100 comments or the returned shape appears truncated,
+re-query that thread before replying. Do not infer resolution from REST comment
+lists.
+
+---
+
+## Step 3: Classify Thread State
+
+Classify each thread before any mutation:
+
+| State | Classification |
+|---|---|
+| `isResolved: true` | Already resolved; report only if relevant. |
+| `isResolved: false` | Unresolved, even if it already has replies. |
+| `isOutdated: true` | Potentially stale; verify before calling non-blocking. |
+| Missing `isOutdated` | Unknown freshness; verify against latest head. |
+
+Replies do not equal resolution. A thread with replies remains unresolved when
+`isResolved: false`; reply count and elapsed time are not completion evidence.
+
+---
+
+## Step 4: Route Requirement-Bearing Feedback
+
+Before fixing or replying, classify the substance of the feedback.
+
+Route through `Brainstormer -> Planner -> Executor` when feedback changes any
+of these:
+
+- Requirements.
+- Acceptance criteria.
+- Scope.
+- User-visible behavior.
+- Workflow contracts.
+
+Do not implement or reply as complete until that route has happened and PR
+comment handling resumes with the approved outcome.
+
+Implementation-detail feedback that preserves approved requirements and
+acceptance intent may route directly to the implementation owner. Say that
+classification out loud in the report or reply evidence.
+
+---
+
+## Step 5: Verify Against Latest Head
+
+Before replying to or resolving a thread, verify whether the referenced state
+still applies to the latest head.
+
+Required checks:
+
+1. Reconfirm the PR head SHA if new commits may have landed.
+2. Inspect the referenced file and nearby lines in the working tree.
+3. Compare the thread path and comment path to the current path.
+4. Compare `line` and `originalLine` context to the current implementation.
+5. Compare the comment commit OID to `$head_sha` and the current diff.
+6. If stale or outdated, classify as non-blocking only with concrete evidence.
+7. If still applicable, fix or route it before replying as handled.
+
+Useful commands:
+
+```bash
+gh pr view "$pr" --json headRefOid --jq .headRefOid
+git rev-parse HEAD
+git show --stat --oneline "$head_sha"
+git blame -L "$start,$end" -- "$path"
+sed -n "${start},${end}p" "$path"
+```
+
+If the working tree does not reflect the PR head, state the mismatch and halt
+instead of replying or resolving.
+
+---
+
+## Step 6: Reply Inline Through REST
+
+Use the REST threaded replies endpoint for inline PR review comments:
+
+```bash
+gh api -X POST \
+  "repos/$owner/$repo/pulls/$pr/comments/$comment_database_id/replies" \
+  -f body="$body"
+```
+
+`$comment_database_id` is the numeric review comment `databaseId` from the
+GraphQL inventory, not the GraphQL node ID. When documenting the endpoint, use
+the shape `repos/<owner>/<repo>/pulls/<n>/comments/<id>/replies`.
+
+Replies must include evidence:
+
+- If a fix commit exists, include the relevant commit SHA or short SHA and a
+  concise explanation of how the latest head addresses the comment.
+- If no fix commit exists because the comment is stale, duplicate,
+  informational, or not applicable, state the concrete evidence for that
+  classification.
+- If the item was routed through Superteam owners, state the routing result or
+  that handling is still pending.
+
+Do not post a reply that says the item is handled based only on local intent,
+silence, elapsed time, PR creation, or green CI.
+
+---
+
+## Step 7: Optionally Resolve the Thread
+
+Only after current-head verification and concrete handling evidence, optionally
+resolve the thread through GraphQL:
+
+```bash
+gh api graphql \
+  -f threadId="$thread_id" \
+  -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}'
+```
+
+Eligible threads must be one of:
+
+- Fixed in code, tests, docs, or workflow contracts and verified on latest head.
+- Stale, duplicate, informational, or otherwise non-blocking with evidence.
+- Routed through the required Superteam owner path and returned with a handled
+  outcome.
+
+If the mutation fails or permissions are unavailable, leave the
+evidence-bearing threaded reply in place and report the thread as still
+unresolved. Do not claim GraphQL resolution happened unless the mutation returns
+the thread with `isResolved: true`.
+
+---
+
+## Step 8: Report Handling Status
+
+A PR comment is "handled" only when it is one of:
+
+- Addressed in code, tests, docs, or workflow contracts and verified on latest
+  head.
+- Replied to with evidence and optionally resolved through GraphQL.
+- Routed through the proper Superteam owner path when requirement-bearing.
+- Classified non-blocking with concrete evidence.
+
+Final reports should include:
+
+- Latest head SHA used for verification.
+- Thread URL or comment URL.
+- Thread ID and resolution state when available.
+- Numeric review comment database ID used for replies.
+- Fix SHA, routing outcome, or non-blocking evidence.
+- Any threads that remain unresolved because resolution was unavailable.
+
+Silence, elapsed time, local intent, reply without verification, PR creation,
+and green CI are not proof that PR feedback was handled.
+
+---
+
+## Halt and Refusal Conditions
+
+Stop and do not reply, resolve, or report feedback handled when:
+
+1. The repo, PR number, branch, or latest head SHA cannot be resolved.
+2. Review threads were not enumerated through paginated GraphQL.
+3. The relevant thread lacks retained IDs, paths, line context, URLs, and commit
+   OIDs needed for verification.
+4. The working tree does not match the PR head being reported.
+5. The comment still applies but has not been fixed or routed.
+6. Requirement-bearing feedback has not gone through
+   `Brainstormer -> Planner -> Executor`.
+7. Resolution permissions are unavailable and no evidence-bearing threaded
+   reply has been left.
+8. The only evidence is silence, elapsed time, local intent, PR creation, or
+   green CI.
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Listing REST review comments only | Use GraphQL review threads with `--paginate`. |
+| Treating the first GraphQL page as complete | Keep paginating until `hasNextPage` is false. |
+| Treating a reply as resolution | Check `isResolved`; replies alone do not close threads. |
+| Replying to an old line without checking current code | Compare path, line context, and commit OID to latest head. |
+| Using a GraphQL node ID in the REST reply URL | Use the numeric `databaseId` review comment ID. |
+| Omitting fix evidence | Include a fix SHA or concrete non-blocking evidence. |
+| Resolving before verification | Resolve only after latest-head handling evidence exists. |
+| Implementing requirement changes directly | Route through `Brainstormer -> Planner -> Executor`. |
+| Reporting green CI as handled feedback | Report latest-head verification and GitHub-visible evidence. |


### PR DESCRIPTION
## Linked issue

Closes #60

## What changed

Context: standalone - issue #60 identified repeated ad-hoc inline PR review comment handling.

- Added a `using-github` PR comments procedure reference - makes the workflow discoverable before agents reply to, resolve, or report PR review feedback handled.
- Added `workflows/pr-comments.md` - gives agents a concrete, evidence-gated procedure for paginated thread discovery, latest-head verification, threaded replies, optional resolution, and Superteam routing.
- Added Superteam design and plan artifacts - preserves the approved issue workflow and AC trail for this change.

## Coverage and risks

Legend for status cells:

- PASS - required validation passed with no known relevant gap.
- WARN - sufficient to merge with a known non-blocking gap in Risks.
- BLOCKED - missing, failing, pending, or merge-blocking.
- N/A - not relevant to this AC.

The `AC` column references acceptance-criteria IDs from linked issues in
`AC-<issue>-<n>` form.

| AC | Requirement | Evidence | Status |
| --- | --- | --- | --- |
| AC-60-1 | Required Procedures references PR comments workflow | `rg -n "pr-comments.md|PR comments|Pull request comments" skills/using-github` | PASS |
| AC-60-2 | Review-thread inventory uses pagination | `rg -n -- "--paginate" skills/using-github/workflows/pr-comments.md` | PASS |
| AC-60-3 | Replies are not treated as resolution | `rg -n -- "isResolved|reply count|Replies do not equal resolution" skills/using-github/workflows/pr-comments.md` | PASS |
| AC-60-4 | Comments are verified against latest head | `rg -n -- "latest head|head_sha|Verify Against Latest Head" skills/using-github/workflows/pr-comments.md` | PASS |
| AC-60-5 | Inline replies use REST database IDs and fix evidence | `rg -n -- "databaseId|comments/<id>/replies|fix commit" skills/using-github/workflows/pr-comments.md` | PASS |
| AC-60-6 | Requirement-bearing feedback routes through Superteam owners | `rg -n -- "Brainstormer -> Planner -> Executor|Requirement-Bearing" skills/using-github/workflows/pr-comments.md` | PASS |
| AC-60-7 | Optional GraphQL resolution is evidence-gated | `rg -n -- "resolveReviewThread|permissions are unavailable|isResolved: true" skills/using-github/workflows/pr-comments.md` | PASS |
| AC-60-8 | Handled reports require latest-head evidence, not silence or green CI | `rg -n -- "handled|green CI|silence|latest head" skills/using-github/workflows/pr-comments.md` | PASS |

### Risks

- `pnpm lint:md` currently fails on pre-existing root `CHANGELOG.md` MD012 blank-line issues at lines 5, 12, and 19. Targeted Markdown lint for the changed skill/workflow/plan files passes, and the failing file is outside this issue scope.

## Testing steps

- [x] `pnpm exec markdownlint-cli2 skills/using-github/SKILL.md skills/using-github/workflows/pr-comments.md docs/superpowers/plans/2026-05-15-60-using-github-should-teach-inline-pr-comment-response-and-resolve-plan.md` passed with 0 errors.
- [x] `pnpm verify:dogfood` passed.
- [x] `pnpm verify:marketplace` passed.
- [x] Targeted `rg` checks confirmed the Required Procedures reference and approved PR comment handling mechanics.
- [x] Review the noted pre-existing `CHANGELOG.md` lint failure if repo-wide `pnpm lint:md` is required before merge.