### PR TITLE
feat: #70 add scaffold skills install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,17 @@
 
 ## [1.4.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.3.2...patinaproject-skills-v1.4.0) (2026-05-15)
 
-
 ### Features
 
 * [#87](https://github.com/patinaproject/skills/issues/87) simplify scaffold PR template ([#88](https://github.com/patinaproject/skills/issues/88)) ([f8826b3](https://github.com/patinaproject/skills/commit/f8826b3f1d282092da65b5ef54490836b6fe23d6))
 
 ## [1.3.2](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.3.1...patinaproject-skills-v1.3.2) (2026-05-15)
 
-
 ### Bug Fixes
 
 * [#81](https://github.com/patinaproject/skills/issues/81) auto-prepare superteam issue branches ([#83](https://github.com/patinaproject/skills/issues/83)) ([e942778](https://github.com/patinaproject/skills/commit/e942778b1128651f1dfc98d1371d3c3709664d3f))
 
 ## [1.3.1](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.3.0...patinaproject-skills-v1.3.1) (2026-05-15)
-
 
 ### Bug Fixes
 

--- a/docs/superpowers/plans/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-plan.md
+++ b/docs/superpowers/plans/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-plan.md
@@ -1,0 +1,325 @@
+# Teach scaffold-repository to install Patina and Superpowers skills with npx Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make scaffolded repositories document and expose a repeatable `npx skills` install path for both Patina Project skills and Superpowers skills.
+
+**Architecture:** Treat scaffold templates as the source of generated behavior. Add the portable install command to the emitted package scripts, surface it in generated README and AGENTS guidance, and teach the realignment checklist plus README verifier to catch stale scaffold outputs.
+
+**Tech Stack:** Markdown skill contracts and templates, JSON package scripts, Node verifier script, PNPM validation commands.
+
+---
+
+## Approved Inputs
+
+- Issue: [#70](https://github.com/patinaproject/skills/issues/70)
+- Design: `docs/superpowers/specs/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-design.md`
+- Gate 1 approval: operator said `lgtm`
+- Adversarial review: clean; checked AC coverage, file surface, RED/GREEN baseline, rationalization resistance, red flags, token efficiency, role ownership, and stage-gate bypass paths.
+
+## File Structure
+
+- Modify `skills/scaffold-repository/templates/core/package.json.tmpl`: add a generated `skills:install` script.
+- Modify `skills/scaffold-repository/templates/agent-plugin/README.md.tmpl`: document the portable `npx skills` path first and keep marketplace paths as host-specific alternatives.
+- Modify `skills/scaffold-repository/templates/core/AGENTS.md.tmpl`: tell Superteam-enabled repos how to install required skills before invoking Superteam.
+- Modify `skills/scaffold-repository/SKILL.md`: update the skill contract for new-repo mode, prompt semantics, plugin enablement, and emitted package scripts.
+- Modify `skills/scaffold-repository/audit-checklist.md`: add stale checks for missing `skills:install` and missing Superteam install guidance.
+- Modify `scripts/verify-scaffold-agent-plugin-readme.js`: assert the generated README and contract surfaces include the new install path.
+
+## Task 1: Add the Generated Package Script
+
+**Files:**
+
+- Modify: `skills/scaffold-repository/templates/core/package.json.tmpl`
+
+- [ ] **Step 1: Inspect the current script block**
+
+Run:
+
+```bash
+sed -n '1,80p' skills/scaffold-repository/templates/core/package.json.tmpl
+```
+
+Expected: the `scripts` object contains `prepare`, `commitlint`, `lint:md`, `sync:versions`, and `check:versions`, but no `skills:install`.
+
+- [ ] **Step 2: Add `skills:install`**
+
+Edit the `scripts` object so it contains:
+
+```json
+"skills:install": "npm_config_ignore_scripts=true npx skills@1.5.6 add patinaproject/skills -y && npm_config_ignore_scripts=true npx skills@1.5.6 add obra/superpowers -y"
+```
+
+Keep the existing scripts unchanged. Use `skills@1.5.6` to match the repository's documented CLI pin in `docs/release-flow.md`, and use `npm_config_ignore_scripts=true` to avoid nested install hooks during skill installation.
+
+- [ ] **Step 3: Verify JSON validity**
+
+Run:
+
+```bash
+node -e 'JSON.parse(require("fs").readFileSync("skills/scaffold-repository/templates/core/package.json.tmpl","utf8")); console.log("package template ok")'
+```
+
+Expected: `package template ok`.
+
+## Task 2: Update Generated README Install Guidance
+
+**Files:**
+
+- Modify: `skills/scaffold-repository/templates/agent-plugin/README.md.tmpl`
+
+- [ ] **Step 1: Inspect the current installation section**
+
+Run:
+
+```bash
+sed -n '1,90p' skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
+```
+
+Expected: installation starts with Claude Code marketplace instructions and does not lead with `npx skills`.
+
+- [ ] **Step 2: Add a portable install subsection before host sections**
+
+Under `## Installation`, replace the opening paragraph with guidance that says the portable cross-runtime path is:
+
+```bash
+pnpm skills:install
+```
+
+Then show the equivalent direct commands:
+
+```bash
+npm_config_ignore_scripts=true npx skills@1.5.6 add patinaproject/skills -y
+npm_config_ignore_scripts=true npx skills@1.5.6 add obra/superpowers -y
+```
+
+State that Superteam-capable workflows need both command sources: Patina Project skills provide the workflow skills and Superpowers provides the supporting execution/review skills.
+
+- [ ] **Step 3: Preserve host marketplace instructions**
+
+Keep `### Claude Code`, `### OpenAI Codex CLI`, and `### OpenAI Codex App`. Reframe them as host-specific marketplace alternatives after the portable `npx skills` path. Do not remove the existing Claude Code `/plugin marketplace add` and `/plugin install` commands.
+
+- [ ] **Step 4: Render-check placeholders**
+
+Run:
+
+```bash
+node scripts/verify-scaffold-agent-plugin-readme.js
+```
+
+Expected before Task 6 updates: it may fail only because the verifier has not learned the new expectations yet. Any placeholder or existing assertion failure must be fixed immediately.
+
+## Task 3: Update Generated Contributor Guidance
+
+**Files:**
+
+- Modify: `skills/scaffold-repository/templates/core/AGENTS.md.tmpl`
+
+- [ ] **Step 1: Add a Superteam install note near development commands**
+
+Add a concise bullet under `## Build, Test, and Development Commands`:
+
+```markdown
+- `pnpm skills:install`: install the Patina Project skills and Superpowers skills required for Superteam-oriented workflows.
+```
+
+- [ ] **Step 2: Add a Superteam readiness note near artifact guidance**
+
+After the Superpowers artifact filename guidance, add:
+
+```markdown
+When this repo uses the Superteam workflow, run `pnpm skills:install` before invoking Superteam. The script installs both `patinaproject/skills` and `obra/superpowers` through `npx skills`, which is the portable cross-runtime install path. Host marketplace plugin enablement may still be present, but it is not the only setup step.
+```
+
+- [ ] **Step 3: Inspect for repeated wording**
+
+Run:
+
+```bash
+rg -n "skills:install|obra/superpowers|patinaproject/skills|marketplace" skills/scaffold-repository/templates/core/AGENTS.md.tmpl
+```
+
+Expected: one command bullet and one Superteam readiness paragraph; no long duplicate install walkthrough.
+
+## Task 4: Update scaffold-repository Contract and Realignment Checks
+
+**Files:**
+
+- Modify: `skills/scaffold-repository/SKILL.md`
+- Modify: `skills/scaffold-repository/audit-checklist.md`
+
+- [ ] **Step 1: Update new-repo behavior**
+
+In `SKILL.md`, change the `<use-superteam>` behavior so it says the skill emits:
+
+- `docs/superpowers/specs/.gitkeep`
+- `docs/superpowers/plans/.gitkeep`
+- generated docs that explain `pnpm skills:install`
+- the `skills:install` package script that installs both `patinaproject/skills` and `obra/superpowers` through `npx skills`
+
+- [ ] **Step 2: Update package and plugin sections**
+
+In `SKILL.md`, add `skills:install` to the package-script convention and update `## Plugin enablement` so it says `.claude/settings.json` remains declarative host enablement while `npx skills` is the portable setup path.
+
+- [ ] **Step 3: Update Superpowers opt-in checklist**
+
+In `audit-checklist.md`, extend `Area 6 - Superpowers opt-in` with checks for:
+
+- `package.json` has `scripts.skills:install`
+- `AGENTS.md` mentions `pnpm skills:install`
+- generated install docs mention both `patinaproject/skills` and `obra/superpowers`
+
+Classify missing items as `stale`, not `missing`, when the repo already has `docs/superpowers/`.
+
+- [ ] **Step 4: Check wording**
+
+Run:
+
+```bash
+rg -n "skills:install|obra/superpowers|patinaproject/skills|enabledPlugins|declarative" skills/scaffold-repository/SKILL.md skills/scaffold-repository/audit-checklist.md
+```
+
+Expected: the contract mentions both direct sources and states that declarative plugin enablement is not the sole install path.
+
+## Task 5: Update README Verification
+
+**Files:**
+
+- Modify: `scripts/verify-scaffold-agent-plugin-readme.js`
+
+- [ ] **Step 1: Add assertions for portable install guidance**
+
+Add assertions against the rendered README:
+
+```js
+assertIncludes(rendered, "pnpm skills:install", "Portable skills install script");
+assertIncludes(rendered, "npx skills@1.5.6 add patinaproject/skills", "Patina Project skills npx install");
+assertIncludes(rendered, "npx skills@1.5.6 add obra/superpowers", "Superpowers npx install");
+```
+
+- [ ] **Step 2: Add assertions for contract and checklist**
+
+Add assertions that `skillContract` and `auditChecklist` include:
+
+```text
+skills:install
+patinaproject/skills
+obra/superpowers
+```
+
+- [ ] **Step 3: Run verifier**
+
+Run:
+
+```bash
+node scripts/verify-scaffold-agent-plugin-readme.js
+```
+
+Expected: `verify-scaffold-agent-plugin-readme: ok`.
+
+## Task 6: Run Full Verification and Commit Implementation
+
+**Files:**
+
+- Verify all modified implementation files.
+
+- [ ] **Step 1: Run targeted search checks**
+
+Run:
+
+```bash
+rg -n "npx skills@1\\.5\\.6 add patinaproject/skills|npx skills@1\\.5\\.6 add obra/superpowers|pnpm skills:install|skills:install" skills/scaffold-repository scripts/verify-scaffold-agent-plugin-readme.js
+```
+
+Expected: matches in templates, skill contract, audit checklist, and verifier.
+
+- [ ] **Step 2: Run scaffold README verifier**
+
+Run:
+
+```bash
+pnpm verify:scaffold-readme
+```
+
+Expected: `verify-scaffold-agent-plugin-readme: ok`.
+
+- [ ] **Step 3: Run dogfood and marketplace checks**
+
+Run:
+
+```bash
+pnpm verify:dogfood
+pnpm verify:marketplace
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Run scaffold baseline check**
+
+Run:
+
+```bash
+pnpm apply:scaffold-repository:check
+```
+
+Expected: `check: all scaffold-repository baseline files are in sync`. If it reports drift on root files intentionally round-tripped from templates, inspect the diff and apply the template-consistent update rather than suppressing the check.
+
+- [ ] **Step 5: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: markdownlint passes for tracked non-Superpowers Markdown files.
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git status --short
+git add skills/scaffold-repository/SKILL.md skills/scaffold-repository/audit-checklist.md skills/scaffold-repository/templates/core/package.json.tmpl skills/scaffold-repository/templates/core/AGENTS.md.tmpl skills/scaffold-repository/templates/agent-plugin/README.md.tmpl scripts/verify-scaffold-agent-plugin-readme.js
+git commit -m "feat: #70 add scaffold skills install path"
+```
+
+Expected: a feature commit containing only implementation files.
+
+## Task 7: Local Review Handoff
+
+**Files:**
+
+- Review branch diff after implementation commit.
+
+- [ ] **Step 1: Inspect branch diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: expected design, plan, and implementation files; no whitespace errors.
+
+- [ ] **Step 2: Review acceptance coverage**
+
+Run:
+
+```bash
+rg -n "AC-70|skills:install|patinaproject/skills|obra/superpowers|npx skills" docs/superpowers skills/scaffold-repository scripts/verify-scaffold-agent-plugin-readme.js
+```
+
+Expected: every acceptance criterion has an implementation or verification surface.
+
+- [ ] **Step 3: Hand off to Reviewer**
+
+Ask Reviewer to classify findings as implementation-level, plan-level, or spec-level. Because the diff touches `skills/**`, Reviewer must use `superpowers:writing-skills` dimensions when checking the skill and template changes.
+
+## Self-Review
+
+- Spec coverage: Tasks 1-5 implement `AC-70-1` through `AC-70-5`; Task 6 verifies the generated script and docs; Task 7 preserves local review routing.
+- Placeholder scan: no unresolved placeholder markers remain.
+- Type consistency: command names are consistently `skills:install`, `patinaproject/skills`, `obra/superpowers`, and `skills@1.5.6`.
+- Scope: the plan changes scaffold-repository generated behavior only; it does not change Superteam's own prerequisite warning.

--- a/docs/superpowers/specs/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-design.md
+++ b/docs/superpowers/specs/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-design.md
@@ -21,7 +21,7 @@ Use the existing scaffold templates as the product surface. The generated `READM
 Add a generated package script to `templates/core/package.json.tmpl`, tentatively named `skills:install`, that runs the two `npx skills` installs in sequence. This satisfies the helper-script/package-command portion without adding a custom shell script unless the implementation discovers quoting or portability problems in `package.json` scripts. The script should install:
 
 - Patina Project skills from `patinaproject/skills`
-- Superpowers skills from the official Superpowers source used by the existing project plugin setting
+- Superpowers skills from `obra/superpowers`, matching the Superteam prerequisite documentation
 
 The generated docs should show both the script form and the underlying direct commands, so users can recover if they are not using PNPM scripts yet.
 

--- a/docs/superpowers/specs/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-design.md
+++ b/docs/superpowers/specs/2026-05-15-70-teach-scaffold-repository-to-install-patina-and-superpowers-skills-with-npx-design.md
@@ -1,0 +1,75 @@
+# Design: Teach scaffold-repository to install Patina and Superpowers skills with npx [#70](https://github.com/patinaproject/skills/issues/70)
+
+## Context
+
+`scaffold-repository` already emits Superteam-oriented repository shape: `docs/superpowers/` skeletons and `.claude/settings.json` plugin enablement for `superteam@patinaproject-skills` and `superpowers@claude-plugins-official`. That declarative setup is useful for hosts with marketplace support, but it leaves a gap for portable skill installation across runtimes that can use the `npx skills` CLI.
+
+Issue #70 closes that gap by making the generated repository tell users how to install both the Patina Project skills and Superpowers skills through `npx skills`, and by adding a repeatable package-script path when scaffolded repos emit package commands for skill installation.
+
+## Requirements
+
+- `AC-70-1`: Generated scaffold documentation tells users how to install the Patina Project skills with `npx skills`.
+- `AC-70-2`: Generated scaffold documentation tells users how to install Superpowers skills with `npx skills`.
+- `AC-70-3`: When scaffold-repository emits package scripts or helper scripts for skill installation, those scripts install both the Patina Project skills and Superpowers skills through the `npx skills` structure.
+- `AC-70-4`: The scaffolded Superteam option no longer relies only on declarative plugin enablement or `docs/superpowers/` skeletons; it gives users a repeatable install path for the skills required to run Superteam.
+- `AC-70-5`: Existing host marketplace instructions remain available where appropriate, while `npx skills` becomes the portable cross-runtime installation structure.
+
+## Proposed Approach
+
+Use the existing scaffold templates as the product surface. The generated `README.md` for agent-plugin repositories should lead with an `npx skills` install path for portable runtime setup, then keep Claude Code and Codex marketplace instructions as host-specific alternatives. The generated `AGENTS.md` should make the Superteam opt-in explicit: if the repo uses Superteam, contributors must install both Patina Project skills and Superpowers skills through the package script or direct `npx skills` commands before expecting Superteam to run.
+
+Add a generated package script to `templates/core/package.json.tmpl`, tentatively named `skills:install`, that runs the two `npx skills` installs in sequence. This satisfies the helper-script/package-command portion without adding a custom shell script unless the implementation discovers quoting or portability problems in `package.json` scripts. The script should install:
+
+- Patina Project skills from `patinaproject/skills`
+- Superpowers skills from the official Superpowers source used by the existing project plugin setting
+
+The generated docs should show both the script form and the underlying direct commands, so users can recover if they are not using PNPM scripts yet.
+
+## Files to Change
+
+- `skills/scaffold-repository/SKILL.md`: update the Superteam opt-in and Plugin enablement sections so the skill contract says the scaffold emits a portable `npx skills` installation path, not only `.claude/settings.json` and `docs/superpowers/`.
+- `skills/scaffold-repository/templates/core/package.json.tmpl`: add `skills:install` for the repeatable install path.
+- `skills/scaffold-repository/templates/agent-plugin/README.md.tmpl`: add portable `npx skills` installation guidance for generated plugin repos, while retaining Claude Code and Codex marketplace install guidance as host-specific options.
+- `skills/scaffold-repository/templates/core/AGENTS.md.tmpl`: add contributor guidance for Superteam-enabled repos to run the skill installer path before invoking Superteam.
+- `skills/scaffold-repository/audit-checklist.md`: update the realignment checklist so repos with Superteam scaffolding are considered stale if they lack the portable install instructions or package script.
+- Root `AGENTS.md` / adjacent generated docs may need regeneration only if the scaffold self-apply check reports drift for files this repo round-trips from the templates.
+
+## Alternatives Considered
+
+### Documentation only
+
+This would satisfy the first two acceptance criteria but leave package-command generation unchanged. It is too weak because `AC-70-3` asks for emitted scripts or package scripts to install both skill sets when such commands exist.
+
+### New shell helper script
+
+A dedicated `scripts/install-skills.sh` would make command sequencing explicit, but it adds another emitted executable file and realignment surface. The package-script-first approach is smaller and fits the existing baseline unless implementation proves the command is too awkward for `package.json`.
+
+### Marketplace-only instructions
+
+Keeping only `/plugin marketplace add` and Codex marketplace instructions preserves current host flows but fails the portable runtime requirement. Marketplace guidance should remain, but it should no longer be the only documented path for Superteam readiness.
+
+## Validation Plan
+
+- Run `pnpm lint:md`.
+- Run `pnpm verify:dogfood`.
+- Run `pnpm apply:scaffold-repository:check`.
+- Run targeted `rg` checks for `npx skills`, Patina Project skills, Superpowers skills, and `skills:install` across the scaffold skill and emitted templates.
+
+## Skill-Quality Review Notes
+
+This design touches `skills/**/*.md` and scaffold templates that change future agent-facing behavior, so implementation must use the repository-required `write-a-skill` structure check before editing skill files and the Superpowers `writing-skills` quality gate for skill/workflow-contract pressure dimensions.
+
+Required checks for the implementation plan:
+
+- RED/GREEN baseline: identify the current generated repo failure mode: Superteam-oriented shape exists, but no repeatable `npx skills` installation path is emitted.
+- Rationalization resistance: block the shortcut "marketplace settings are enough" by documenting `npx skills` as the portable path.
+- Role ownership: `scaffold-repository` owns emitted repository docs and scripts; Superteam itself is not changed by this issue.
+- Stage-gate bypass: do not skip Gate 1 or implement before approval; do not treat existing `.claude/settings.json` enablement as satisfying runtime installation.
+- Token efficiency: keep generated guidance compact and avoid duplicating long host-specific marketplace docs in every section.
+
+## Self-Review
+
+- Placeholder scan: no unresolved TODO/TBD placeholders remain.
+- Consistency: requirements, file list, and validation plan all map to issue #70 acceptance criteria.
+- Scope: this is one scaffold-repository change and does not require changing the Superteam skill prerequisite warning.
+- Ambiguity: the design chooses a package-script-first helper path and keeps shell helper creation only as a fallback if implementation needs it.

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -17,6 +17,14 @@ const codexPluginTemplatePath = path.join(
   repoRoot,
   "skills/scaffold-repository/templates/agent-plugin/.codex-plugin/plugin.json.tmpl",
 );
+const corePackageTemplatePath = path.join(
+  repoRoot,
+  "skills/scaffold-repository/templates/core/package.json.tmpl",
+);
+const coreAgentsTemplatePath = path.join(
+  repoRoot,
+  "skills/scaffold-repository/templates/core/AGENTS.md.tmpl",
+);
 const skillContractPath = path.join(repoRoot, "skills/scaffold-repository/SKILL.md");
 const auditChecklistPath = path.join(repoRoot, "skills/scaffold-repository/audit-checklist.md");
 
@@ -75,6 +83,8 @@ function renderTemplate(template, replacements) {
 const template = fs.readFileSync(templatePath, "utf8");
 const skillTemplate = fs.readFileSync(skillTemplatePath, "utf8");
 const codexPluginTemplate = fs.readFileSync(codexPluginTemplatePath, "utf8");
+const corePackageTemplate = fs.readFileSync(corePackageTemplatePath, "utf8");
+const coreAgentsTemplate = fs.readFileSync(coreAgentsTemplatePath, "utf8");
 const skillContract = fs.readFileSync(skillContractPath, "utf8");
 const auditChecklist = fs.readFileSync(auditChecklistPath, "utf8");
 const rendered = renderTemplate(template, values);
@@ -85,6 +95,12 @@ const renderedCodexPlugin = renderTemplate(codexPluginTemplate, {
   "author-email": "test@example.com",
   "author-handle": "test-author",
 });
+const corePackage = JSON.parse(corePackageTemplate);
+const skillsInstallScript = corePackage.scripts?.["skills:install"];
+
+if (typeof skillsInstallScript !== "string") {
+  fail("core package template: expected scripts.skills:install to be a string");
+}
 
 assertNotIncludes(rendered, "{{", "rendered README");
 assertIncludes(rendered, "pnpm skills:install", "Portable skills install script");
@@ -123,6 +139,36 @@ assertIncludes(
 assertIncludes(skillContract, "skills:install", "Skill contract skills install script");
 assertIncludes(skillContract, "patinaproject/skills", "Skill contract Patina Project skills source");
 assertIncludes(skillContract, "obra/superpowers", "Skill contract Superpowers skills source");
+assertIncludes(
+  skillsInstallScript,
+  "npx skills@1.5.6 add patinaproject/skills",
+  "Core package template Patina Project skills install command",
+);
+assertIncludes(
+  skillsInstallScript,
+  "npx skills@1.5.6 add obra/superpowers",
+  "Core package template Superpowers skills install command",
+);
+assertIncludes(
+  coreAgentsTemplate,
+  "pnpm skills:install",
+  "Core AGENTS template skills install guidance",
+);
+assertIncludes(
+  coreAgentsTemplate,
+  "patinaproject/skills",
+  "Core AGENTS template Patina Project skills source",
+);
+assertIncludes(
+  coreAgentsTemplate,
+  "obra/superpowers",
+  "Core AGENTS template Superpowers skills source",
+);
+assertIncludes(
+  coreAgentsTemplate,
+  "Host marketplace plugin enablement may still be present, but it is not the only setup step.",
+  "Core AGENTS template marketplace-not-only guidance",
+);
 assertIncludes(
   auditChecklist,
   "skills/<primary-skill-name>/SKILL.md",

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -87,6 +87,17 @@ const renderedCodexPlugin = renderTemplate(codexPluginTemplate, {
 });
 
 assertNotIncludes(rendered, "{{", "rendered README");
+assertIncludes(rendered, "pnpm skills:install", "Portable skills install script");
+assertIncludes(
+  rendered,
+  "npx skills@1.5.6 add patinaproject/skills",
+  "Patina Project skills npx install",
+);
+assertIncludes(
+  rendered,
+  "npx skills@1.5.6 add obra/superpowers",
+  "Superpowers npx install",
+);
 assertIncludes(rendered, "/workflow-kit:issue-router", "Claude invocation");
 assertNotIncludes(rendered, "/workflow-kit:workflow-kit", "Claude invocation");
 assertIncludes(
@@ -109,6 +120,9 @@ assertIncludes(
   "must collect `<primary-skill-name>` before rendering the README and primary skill starter",
   "Primary skill render requirement",
 );
+assertIncludes(skillContract, "skills:install", "Skill contract skills install script");
+assertIncludes(skillContract, "patinaproject/skills", "Skill contract Patina Project skills source");
+assertIncludes(skillContract, "obra/superpowers", "Skill contract Superpowers skills source");
 assertIncludes(
   auditChecklist,
   "skills/<primary-skill-name>/SKILL.md",
@@ -119,6 +133,9 @@ assertIncludes(
   "`skills/.gitkeep` alone is stale for agent-plugin repos",
   "Realignment stale gitkeep check",
 );
+assertIncludes(auditChecklist, "skills:install", "Audit checklist skills install script");
+assertIncludes(auditChecklist, "patinaproject/skills", "Audit checklist Patina Project skills source");
+assertIncludes(auditChecklist, "obra/superpowers", "Audit checklist Superpowers skills source");
 assertIncludes(rendered, ".cursor/rules/workflow-kit.mdc", "Cursor rule path");
 assertNotIncludes(renderedSkill, "{{", "rendered primary skill starter");
 assertIncludes(renderedSkill, "name: issue-router", "primary skill frontmatter");

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -22,7 +22,7 @@ Behavior:
 
 - Emit the full [core baseline](#core-baseline) tree.
 - If the user answers yes to "Is this an AI agent plugin?", additionally emit the [agent-plugin surfaces](#agent-plugin-surfaces).
-- If the user answers yes to "Use the superteam workflow?" (the Superpowers-based design + plan flow), additionally emit the `docs/superpowers/specs/.gitkeep` + `docs/superpowers/plans/.gitkeep` scaffolding.
+- If the user answers yes to "Use the superteam workflow?" (the Superpowers-based design + plan flow), additionally emit the `docs/superpowers/specs/.gitkeep` + `docs/superpowers/plans/.gitkeep` scaffolding, generated docs that explain `pnpm skills:install`, and the `skills:install` package script that installs both `patinaproject/skills` and `obra/superpowers` through `npx skills`.
 - Run `pnpm install` to generate `pnpm-lock.yaml` and wire Husky.
 - Leave all emitted files staged but uncommitted so the user owns the first commit.
 
@@ -59,7 +59,7 @@ The skill collects the following inputs. Author name, author email, and the secu
 | `<repo-description>` | – | one-line description |
 | `<visibility>` | public | public \| private |
 | `<is-agent-plugin>` | no | yes emits plugin/config surfaces for every supported AI coding tool |
-| `<use-superteam>` | no | yes emits `docs/superpowers/` skeleton |
+| `<use-superteam>` | no | yes emits `docs/superpowers/` skeleton plus the portable Superteam skills install path |
 | `<primary-skill-name>` | – | required when `<is-agent-plugin>` is yes; scaffolds `skills/<name>/SKILL.md` starter |
 | `<codeowner>` | `@<owner>` | written into `.github/CODEOWNERS` |
 | `<security-contact>` | from `git config user.email` | public repos only; written into `SECURITY.md` |
@@ -136,7 +136,7 @@ Historical note: an earlier revision of the supplement also added a `notify-pati
 
 Detection is done at scaffold time from `git remote get-url origin` (or the configured `<owner>` prompt). When generating the base workflow for non-Patina-Project repos, do not add `if: github.repository_owner == 'patinaproject'` gates; emit the clean workflow without any Patina-Project-specific plumbing.
 
-## Plugin enablement
+## Plugin enablement and skill installation
 
 The emitted `.claude/settings.json` enables the canonical Patina Project plugins at the project level:
 
@@ -149,7 +149,13 @@ The emitted `.claude/settings.json` enables the canonical Patina Project plugins
 }
 ```
 
-The skill does not recommend running any commands postinstall. Plugin enablement is declarative in the emitted settings; nothing else is printed or documented as a required follow-up.
+This declarative host enablement remains available for Claude Code hosts that
+understand project `enabledPlugins`. It is not the portable setup path by
+itself. Scaffolded repos also emit `pnpm skills:install`, which runs
+`npm_config_ignore_scripts=true npx skills@1.5.6 add patinaproject/skills -y`
+and `npm_config_ignore_scripts=true npx skills@1.5.6 add obra/superpowers -y`
+so contributors can install the required Patina Project and Superpowers skills
+across runtimes.
 
 ## Conventions encoded
 
@@ -161,7 +167,7 @@ The skill does not recommend running any commands postinstall. Plugin enablement
   operator-owned pass/fail verification.
 - **Issue titles**: plain-language, no commit-style prefix.
 - **Markdown**: `markdownlint-cli2` with `.markdownlint.jsonc` + `.markdownlintignore`. `lint-staged` runs it from `pre-commit`. The lint script uses a glob that excludes `node_modules/`.
-- **PNPM**: `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, `lint:md` script.
+- **PNPM**: `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, `lint:md` script, and `skills:install` script for the portable Superteam skills install path.
 - **Line endings**: `.gitattributes` with `* text=auto eol=lf`.
 - **PR title hygiene**: `.github/workflows/pull-request.yml` validates that every PR title is ASCII-only, follows conventional commits (no scopes), starts with a `#<issue>` ref, keeps breaking-change markers consistent (`!` in title ⇔ `BREAKING CHANGE:` footer), and that the body contains a GitHub closing keyword.
 - **Markdown CI**: `.github/workflows/markdown.yml` runs `DavidAnson/markdownlint-cli2-action` on every PR as a backstop to the husky `pre-commit` hook (which can be bypassed with `--no-verify`).

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -23,7 +23,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `commitlint.config.js` | yes | present; extends `@commitlint/config-conventional`; has `ticket-required` rule |
 | `.husky/commit-msg` | yes | present; runs `pnpm exec commitlint --edit "$1"` |
 | `.husky/pre-commit` | yes | present; runs `pnpm exec lint-staged` |
-| `package.json` | yes | present; has `version`; `author.name`; `author.email`; `author.url`; `packageManager: pnpm@10.x`; `engines.node >= 24`; scripts include `lint:md`, `check:versions`, `sync:versions`; `lint-staged` block for `*.md` |
+| `package.json` | yes | present; has `version`; `author.name`; `author.email`; `author.url`; `packageManager: pnpm@10.x`; `engines.node >= 24`; scripts include `lint:md`, `check:versions`, `sync:versions`, `skills:install`; `lint-staged` block for `*.md` |
 | `pnpm-lock.yaml` | yes | present |
 | `scripts/check-plugin-versions.mjs` | yes | present; fails with non-zero exit on version drift |
 | `scripts/sync-plugin-versions.mjs` | yes | present; rewrites plugin manifests from `package.json` |
@@ -99,6 +99,9 @@ Detection: look for `docs/superpowers/`. When present, verify both subdirectorie
 |---|---|---|
 | `docs/superpowers/specs/` | yes | directory exists (may contain only `.gitkeep`) |
 | `docs/superpowers/plans/` | yes | directory exists (may contain only `.gitkeep`) |
+| `package.json` | yes | `scripts.skills:install` exists and installs both `patinaproject/skills` and `obra/superpowers` through `npx skills`; if `docs/superpowers/` already exists and this is absent, classify as `stale` |
+| `AGENTS.md` | yes | mentions `pnpm skills:install` as the Superteam readiness step; if `docs/superpowers/` already exists and this is absent, classify as `stale` |
+| Agent-plugin install docs | agent plugin only | generated install docs mention both `patinaproject/skills` and `obra/superpowers`; if `docs/superpowers/` already exists and either source is absent, classify as `stale` |
 
 ## Area 7 – GitHub repository merge settings
 

--- a/skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
+++ b/skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
@@ -13,7 +13,29 @@
 
 ## Installation
 
-`{{repo}}` ships as a Claude Code + Codex plugin. Other supported editors read the repository-level files this plugin emits (`AGENTS.md`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`) directly – those tools require no additional plugin install. Pick the section for your tool.
+Use the portable `npx skills` path first when you want the same setup across
+agent runtimes:
+
+```bash
+pnpm skills:install
+```
+
+Equivalent direct commands:
+
+```bash
+npm_config_ignore_scripts=true npx skills@1.5.6 add patinaproject/skills -y
+npm_config_ignore_scripts=true npx skills@1.5.6 add obra/superpowers -y
+```
+
+Superteam-capable workflows need both sources: `patinaproject/skills` provides
+the Patina Project workflow skills, and `obra/superpowers` provides the
+supporting execution and review skills.
+
+Host marketplace installs are still available where supported. Other supported
+editors read the repository-level files this plugin emits (`AGENTS.md`,
+`.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`) directly;
+those tools require no additional plugin install. Pick the section for your
+tool.
 
 ### Claude Code
 

--- a/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
+++ b/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
@@ -24,11 +24,14 @@ Use human-readable H1 titles inside those files:
 
 Format acceptance criteria IDs as `AC-<issue-number>-<integer>`, for example `AC-1-1`.
 
+When this repo uses the Superteam workflow, run `pnpm skills:install` before invoking Superteam. The script installs both `patinaproject/skills` and `obra/superpowers` through `npx skills`, which is the portable cross-runtime install path. Host marketplace plugin enablement may still be present, but it is not the only setup step.
+
 ## Build, Test, and Development Commands
 
 - `pnpm install`: install local tooling and initialize Husky hooks.
 - `pnpm exec commitlint --edit <path>`: validate a commit message file against repo rules.
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`.
+- `pnpm skills:install`: install the Patina Project skills and Superpowers skills required for Superteam-oriented workflows.
 - `.husky/commit-msg <path>`: run commit-message validation through the active Git hook.
 - `.husky/pre-commit`: run `lint-staged`, which invokes `markdownlint-cli2` on staged `*.md`.
 

--- a/skills/scaffold-repository/templates/core/package.json.tmpl
+++ b/skills/scaffold-repository/templates/core/package.json.tmpl
@@ -18,6 +18,7 @@
     "prepare": "husky",
     "commitlint": "commitlint",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#CHANGELOG.md\"",
+    "skills:install": "npm_config_ignore_scripts=true npx skills@1.5.6 add patinaproject/skills -y && npm_config_ignore_scripts=true npx skills@1.5.6 add obra/superpowers -y",
     "sync:versions": "node scripts/sync-plugin-versions.mjs",
     "check:versions": "node scripts/check-plugin-versions.mjs"
   },


### PR DESCRIPTION
## Linked issue

Closes #70

## What changed

Context: standalone - scaffolded Superteam repos needed a portable install path for required skills.

- Added `pnpm skills:install` to the scaffolded package template - gives generated repos a repeatable `npx skills` command for Patina Project skills and Superpowers.
- Updated generated README and AGENTS guidance - makes `npx skills` the portable cross-runtime setup path while keeping host marketplace instructions available.
- Updated scaffold-repository contract, audit checklist, and verifier coverage - realignment and CI-style checks now catch stale install guidance or missing generated script coverage.
- Cleaned release-generated `CHANGELOG.md` spacing - restores repo-wide markdown lint to green.

## Coverage and risks

| AC | Requirement | Evidence | Status |
| --- | --- | --- | --- |
| AC-70-1 | Generated docs install Patina Project skills with `npx skills` | `pnpm verify:scaffold-readme`; README template and verifier assert `npx skills@1.5.6 add patinaproject/skills` | PASS |
| AC-70-2 | Generated docs install Superpowers skills with `npx skills` | `pnpm verify:scaffold-readme`; README template and verifier assert `npx skills@1.5.6 add obra/superpowers` | PASS |
| AC-70-3 | Emitted package/helper scripts install both skill sets through `npx skills` | `templates/core/package.json.tmpl` adds `skills:install`; verifier parses the template and checks both source commands | PASS |
| AC-70-4 | Superteam scaffold no longer relies only on plugin enablement or docs skeletons | `SKILL.md`, `AGENTS.md.tmpl`, and audit checklist state `pnpm skills:install` as the readiness path | PASS |
| AC-70-5 | Marketplace instructions remain, with `npx skills` as portable structure | Generated README keeps Claude Code/Codex marketplace sections after the portable install block | PASS |

## Testing steps

- [x] Verify generated README/install assertions with `pnpm verify:scaffold-readme`.
- [x] Verify markdown lint with `pnpm lint:md`.
- [x] Verify in-repo skill discovery with `pnpm verify:dogfood`.
- [x] Verify marketplace catalog with `pnpm verify:marketplace`.
- [x] Verify Superteam contract surfaces with `pnpm verify:superteam`.
- [x] Verify scaffold baseline with `pnpm apply:scaffold-repository:check`.
- [x] Verify whitespace with `git diff --check origin/main...HEAD`.
