### PR TITLE
chore: #103 run Matt Pocock skills setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ Use GitHub issues as the durable product and design record. Do not add committed
 design/plan artifacts for routine issue work; put durable context on the issue
 or in normal docs when it is broadly useful beyond one issue.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in this repository's GitHub Issues using `gh`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage roles map to this repository's existing GitHub labels, without inventing new labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repository; domain docs are optional and created lazily when useful. See `docs/agents/domain.md`.
+
 ## Build, Test, and Development Commands
 
 - `pnpm install`: install dev tooling and initialize Husky

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [1.7.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.6.0...patinaproject-skills-v1.7.0) (2026-05-19)
 
-
 ### Features
 
 * [#100](https://github.com/patinaproject/skills/issues/100) deprecate superteam workflow ([#101](https://github.com/patinaproject/skills/issues/101)) ([54ce095](https://github.com/patinaproject/skills/commit/54ce0953292ff37abd9427d1c57ee455f3bf91b6))

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,26 @@
+# Domain Docs
+
+This is a single-context repository for Patina Project skill marketplace and installation documentation.
+
+## Before exploring, read these when present
+
+- `AGENTS.md` for repository workflow, release, GitHub, and skill-authoring rules.
+- `docs/` for contributor documentation such as file structure and release flow.
+- `CONTEXT.md` at the repository root, if it exists.
+- `docs/adr/`, if it exists.
+
+If `CONTEXT.md` or `docs/adr/` does not exist, proceed silently. Do not create domain docs just because they are absent; create them only when a term, workflow decision, or architectural decision needs durable documentation.
+
+## Layout
+
+Use a single-context layout unless the repository later adds `CONTEXT-MAP.md`:
+
+```text
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+└── skills/
+```
+
+When output names a repository concept, prefer the vocabulary already used in `AGENTS.md`, `docs/`, and the relevant skill `SKILL.md`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,16 @@
+# Issue tracker: GitHub
+
+Issues, PRDs, and durable product/design context for this repository live in GitHub Issues for `patinaproject/skills`. Use the `gh` CLI from inside this checkout so it resolves the repository from `origin`.
+
+## Conventions
+
+- Create issues with the canonical templates in `.github/ISSUE_TEMPLATE/`.
+- Read issues with `gh issue view <number> --comments --json number,title,body,labels,comments,state,url`.
+- List issues with `gh issue list --state open --json number,title,labels,url`.
+- Comment with `gh issue comment <number> --body "..."`
+- Apply labels only from `gh label list`; do not invent new labels.
+- Use same-repo issue references such as `#103`; do not use cross-repo issue links for workflow relationships.
+
+## Publishing
+
+When a skill says to publish to the issue tracker, create or update a GitHub issue in this repository. Use GitHub issues as the durable record for routine design and planning context instead of adding committed one-off plan files.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual GitHub label vocabulary used by this repository.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning |
+| -------------------------- | -------------------- | ------- |
+| `needs-triage`             | none; leave unlabeled until classified | Maintainer needs to evaluate this issue |
+| `needs-info`               | `question` | Waiting on the reporter for more information |
+| `ready-for-agent`          | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human`          | `help wanted` | Requires human implementation or attention |
+| `wontfix`                  | `wontfix` | Will not be actioned |
+
+Before applying labels, refresh the canonical list with `gh label list` and rely on each label's `description`. Reserved release automation labels such as `autorelease: pending` and `autorelease: tagged` are not triage labels.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,11 +49,23 @@
       "skillPath": "skills/brainstorming/SKILL.md",
       "computedHash": "8df9b47092524833138b58682d03f2e153a242e550d1693657afdbee0cc9cdb0"
     },
+    "caveman": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/caveman/SKILL.md",
+      "computedHash": "934433479903febc585bf6deb5f0cebc63137e3f86b7babe0aab1ecb94d6d7a4"
+    },
     "cli-creator": {
       "source": "openai/skills",
       "sourceType": "github",
       "skillPath": "skills/.curated/cli-creator/SKILL.md",
       "computedHash": "bd8f6db9268abf0483e17215ae6a39852a8780429c54b65658780c6f94bb4f61"
+    },
+    "diagnose": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/diagnose/SKILL.md",
+      "computedHash": "15939a26f86edec2d4862042b8564e5a062cb81d04e047a0cea6305c8830b5f5"
     },
     "dispatching-parallel-agents": {
       "source": "obra/superpowers",
@@ -85,6 +97,24 @@
       "skillPath": "skills/productivity/grill-me/SKILL.md",
       "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
     },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "1adf321072f53cce3dcaf5357d91b8230d4aa647bb8a51756745337a6ee567b8"
+    },
+    "handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/handoff/SKILL.md",
+      "computedHash": "d543685cbfb0c64b7bc51a8dc3465975528da9b64f987f863765973b2f3867ab"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "c77b86b4332919499608f9af1880074e1fec65a59b95c70c27a9f39cd137865e"
+    },
     "migrate-to-codex": {
       "source": "openai/skills",
       "sourceType": "github",
@@ -97,6 +127,12 @@
       "skillPath": "skills/.system/plugin-creator/SKILL.md",
       "computedHash": "f6cd2ab74e30276067cb68aa2f41d56a762b41fe9dfb9dd914f2dbc27d0010f9"
     },
+    "prototype": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/prototype/SKILL.md",
+      "computedHash": "e4d0c8f8cb3fc096ee99405a15491da466545cf4a3694bee5a0c9db2fa621a43"
+    },
     "receiving-code-review": {
       "source": "obra/superpowers",
       "sourceType": "github",
@@ -108,6 +144,12 @@
       "sourceType": "github",
       "skillPath": "skills/requesting-code-review/SKILL.md",
       "computedHash": "874f3786b05007a8b4a60452a4cd89b9917c645d34b6b1e40ea05037d12f0e67"
+    },
+    "setup-matt-pocock-skills": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/setup-matt-pocock-skills/SKILL.md",
+      "computedHash": "0164a8b1ef998abca426056c6ed8a7716a9d4692fc6daa5378f68381a6dafd24"
     },
     "skill-creator": {
       "source": "openai/skills",
@@ -133,11 +175,35 @@
       "skillPath": "skills/systematic-debugging/SKILL.md",
       "computedHash": "7246fdd3a795fc3daff0af72044ca99bf836e4e6a46844742858786fdfb86488"
     },
+    "tdd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/tdd/SKILL.md",
+      "computedHash": "15a7b5e36383ebadb2dec5e586679e55e9663d292da418926b8da6fc0ef27d84"
+    },
     "test-driven-development": {
       "source": "obra/superpowers",
       "sourceType": "github",
       "skillPath": "skills/test-driven-development/SKILL.md",
       "computedHash": "126f1ebf6ccd414f42544f6e83d8cc5adb089e1108eaffb7c400701e37eecd9f"
+    },
+    "to-issues": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-issues/SKILL.md",
+      "computedHash": "47f648f3414848ccfc62cb41d2828b7e575fb5e7cbd6c4bdf630c063b5dc5e82"
+    },
+    "to-prd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-prd/SKILL.md",
+      "computedHash": "6d741474efd4bc3db55fabc2722ed78ca9c374cabcb6212936d79d4fd4a30fcb"
+    },
+    "triage": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/triage/SKILL.md",
+      "computedHash": "2b6efb6da12d92551772fcc04acf331f4e0e6f7bd9d4cb23ce0b301e0b128feb"
     },
     "using-git-worktrees": {
       "source": "obra/superpowers",
@@ -174,6 +240,12 @@
       "sourceType": "github",
       "skillPath": "skills/writing-skills/SKILL.md",
       "computedHash": "c0a92e629e39ea91b1f54da67a6aa92723008a8ef5b500c6de078f55485937c7"
+    },
+    "zoom-out": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/zoom-out/SKILL.md",
+      "computedHash": "8357aeaece3b709c442eab67e64b86844e05e2f1ea95b109565eba50b6def36e"
     }
   }
 }


### PR DESCRIPTION
## Linked issue

Closes #103

## What changed

Context: standalone - align this repository with the Matt Pocock skills setup workflow

- Added repository-specific Agent skills guidance and `docs/agents/` setup docs - gives installed engineering skills durable issue tracker, triage label, and domain-doc context
- Added Matt Pocock skills to `skills-lock.json` - records the installed skill set for restore workflows
- Fixed a generated changelog blank-line lint issue - keeps the documented Markdown lint command green

## Verification

- `pnpm lint:md` — passed
- `pnpm verify:dogfood` — passed
- `pnpm verify:marketplace` — passed
- `git diff --check` — passed