### PR TITLE
ci: #102 add safe Claude review workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,2 +1,3 @@
 self-hosted-runner:
-  labels: []
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,109 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  classify:
+    name: Classify PR
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: >-
+      ${{
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.fork == false &&
+        github.event.pull_request.user.login != 'dependabot[bot]'
+      }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_review: ${{ steps.changed-files.outputs.should_review }}
+      reason: ${{ steps.changed-files.outputs.reason }}
+    steps:
+      - name: Classify changed files
+        id: changed-files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
+
+          if printf '%s\n' "$changed_files" | grep -qx '.github/workflows/claude-review.yml'; then
+            {
+              echo "should_review=false"
+              echo "reason=review workflow changed"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          reviewable=false
+          while IFS= read -r file; do
+            case "$file" in
+              ""|CHANGELOG.md|pnpm-lock.yaml|package-lock.json|yarn.lock|bun.lockb|docs/superpowers/*)
+                ;;
+              *.lock|*.lockb|*.snap|*.png|*.jpg|*.jpeg|*.gif|*.webp|*.svg)
+                ;;
+              *)
+                reviewable=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [ "$reviewable" = false ]; then
+            {
+              echo "should_review=false"
+              echo "reason=only low-signal files changed"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "should_review=true"
+            echo "reason=reviewable changes detected"
+          } >> "$GITHUB_OUTPUT"
+
+  review:
+    name: Review PR
+    needs: classify
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: needs.classify.outputs.should_review == 'true'
+    steps:
+      - name: Run passive Claude review
+        # anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@855a15bff2f22a6b15d90a4ebef506b5f1da1aec
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          include_fix_links: false
+          display_report: false
+          show_full_output: false
+          use_sticky_comment: true
+          prompt: |
+            Review this pull request in the public repository ${{ github.repository }}.
+
+            Scope:
+            - Focus on correctness, security, maintainability, test coverage, GitHub Actions safety, and this repository's conventions.
+            - Do not duplicate normal CI output, formatting output, release notes, or dependency-update noise.
+            - Treat generated assets, lockfiles, changelogs, and planning artifacts as low-signal unless they reveal a concrete risk.
+
+            Security boundary:
+            - This repository is public. Do not print, summarize, infer, or request secrets, credentials, token values, or private context.
+            - Do not modify files, create commits, push branches, open pull requests, run shell commands, or suggest privileged automation.
+            - If you see a possible secret, describe the risk category without reproducing the value.
+
+            Output:
+            - Post inline comments only for critical or major findings with actionable fixes.
+            - Put minor findings in the single summary comment.
+            - Include one concise summary comment with change walkthrough, risk level, and finding counts.
+            - Avoid accidental issue autolinks in bot text; write issue references with a space after the hash, such as "# 123".
+          claude_args: |
+            --max-turns 6
+            --disallowedTools "Edit,MultiEdit,Write,Bash"

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Check out repository
         # actions/checkout@v4.3.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Enforce ASCII-only title

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release-please:
     name: Open or update release PRs
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
@@ -43,7 +43,7 @@ jobs:
     name: Apply scaffold-repository scaffolding on release
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -97,7 +97,7 @@ jobs:
     name: Enable auto-merge on release PRs
     needs: release-please
     if: needs.release-please.outputs.releases_created != 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   verify:
     name: Verify skill overlay
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [1.7.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v1.6.0...patinaproject-skills-v1.7.0) (2026-05-19)
 
-
 ### Features
 
 * [#100](https://github.com/patinaproject/skills/issues/100) deprecate superteam workflow ([#101](https://github.com/patinaproject/skills/issues/101)) ([54ce095](https://github.com/patinaproject/skills/commit/54ce0953292ff37abd9427d1c57ee455f3bf91b6))

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "verify:marketplace": "bash scripts/verify-marketplace.sh",
     "verify:scaffold-readme": "node scripts/verify-scaffold-agent-plugin-readme.js",
     "verify:superteam": "bash scripts/verify-superteam-contract.sh",
+    "verify:claude-review": "bash scripts/verify-claude-review-workflow.sh",
     "verify:workflow-cleanup": "bash scripts/verify-workflow-cleanup.sh",
     "apply:scaffold-repository": "node scripts/apply-scaffold-repository.js skills/scaffold-repository",
     "apply:scaffold-repository:check": "node scripts/apply-scaffold-repository.js skills/scaffold-repository --check"

--- a/scripts/verify-claude-review-workflow.sh
+++ b/scripts/verify-claude-review-workflow.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+WORKFLOW=".github/workflows/claude-review.yml"
+FAIL_COUNT=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_file() {
+  local file="$1"
+  test -f "$file" || fail "missing expected file: $file"
+}
+
+assert_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! rg -n --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "missing expected pattern in $file: $pattern"
+  fi
+}
+
+assert_no_match() {
+  local pattern="$1"
+  local file="$2"
+  if rg -n --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "unexpected pattern in $file: $pattern"
+  fi
+}
+
+assert_file "$WORKFLOW"
+
+if [ -f "$WORKFLOW" ]; then
+  assert_match "pull_request:" "$WORKFLOW"
+  assert_match "types: \\[opened, synchronize, reopened, ready_for_review\\]" "$WORKFLOW"
+  assert_no_match "pull_request_target:" "$WORKFLOW"
+  assert_match "contents: read" "$WORKFLOW"
+  assert_match "pull-requests: write" "$WORKFLOW"
+  assert_match "issues: write" "$WORKFLOW"
+  assert_no_match "contents: write" "$WORKFLOW"
+  assert_match "runs-on: blacksmith-2vcpu-ubuntu-2404" "$WORKFLOW"
+  assert_match "github\\.event\\.pull_request\\.draft == false" "$WORKFLOW"
+  assert_match "github\\.event\\.pull_request\\.head\\.repo\\.fork == false" "$WORKFLOW"
+  assert_match "github\\.event\\.pull_request\\.user\\.login != 'dependabot\\[bot\\]'" "$WORKFLOW"
+  assert_match "claude-review\\.yml" "$WORKFLOW"
+  assert_match "CLAUDE_CODE_OAUTH_TOKEN" "$WORKFLOW"
+  assert_no_match "ANTHROPIC_API_KEY|RELEASE_PLEASE_TOKEN|NPM_TOKEN|GITHUB_TOKEN:" "$WORKFLOW"
+  assert_match "# anthropics/claude-code-action@v1" "$WORKFLOW"
+  assert_match "uses: anthropics/claude-code-action@[0-9a-f]{40}" "$WORKFLOW"
+  assert_match "include_fix_links: false" "$WORKFLOW"
+  assert_match "display_report: false" "$WORKFLOW"
+  assert_match "show_full_output: false" "$WORKFLOW"
+  assert_match "--disallowedTools \".*Edit.*MultiEdit.*Write.*Bash.*\"" "$WORKFLOW"
+fi
+
+assert_match "blacksmith-2vcpu-ubuntu-2404" .github/actionlint.yaml
+assert_match "blacksmith-2vcpu-ubuntu-2404" skills/scaffold-repository/templates/core/.github/actionlint.yaml
+assert_no_match "runs-on: ubuntu-latest" .github/workflows/actions.yml
+assert_no_match "runs-on: ubuntu-latest" .github/workflows/markdown.yml
+assert_no_match "runs-on: ubuntu-latest" .github/workflows/pull-request.yml
+assert_no_match "runs-on: ubuntu-latest" .github/workflows/verify.yml
+assert_no_match "runs-on: ubuntu-latest" .github/workflows/release-please.yml
+assert_no_match "runs-on: ubuntu-latest" skills/scaffold-repository/templates/core/.github/workflows/actions.yml
+assert_no_match "runs-on: ubuntu-latest" skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "" >&2
+  echo "FAIL: $FAIL_COUNT Claude review workflow assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "OK: Claude review workflow assertions passed"

--- a/skills/scaffold-repository/templates/core/.github/actionlint.yaml
+++ b/skills/scaffold-repository/templates/core/.github/actionlint.yaml
@@ -1,2 +1,3 @@
 self-hosted-runner:
-  labels: []
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404

--- a/skills/scaffold-repository/templates/core/.github/workflows/actions.yml
+++ b/skills/scaffold-repository/templates/core/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml
+++ b/skills/scaffold-repository/templates/core/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Enforce ASCII-only title


### PR DESCRIPTION
## Linked issue

Closes #102

## What changed

Context: standalone - issue #102 requested a passive Claude PR review workflow with public-repo trust boundaries and Blacksmith runner usage.

- Added a same-repository Claude review workflow - gives maintainers automated semantic PR feedback while skipping drafts, forks, Dependabot PRs, self-edits to the reviewer workflow, and low-signal-only changes.
- Configured the Claude action as passive and public-repo safe - pins the action to a full SHA, passes only `CLAUDE_CODE_OAUTH_TOKEN`, disables fix links and public output surfaces, and denies mutation or shell tools.
- Moved existing workflow jobs to `blacksmith-2vcpu-ubuntu-2404` with actionlint allowlist coverage - aligns CI with the cheapest Blacksmith runner requested by the issue.
- Added a workflow contract verifier and scaffold template updates - keeps the new safety invariants and baseline-owned workflow surfaces from drifting.
- Fixed a changelog blank-line lint violation - keeps documented markdown verification green.

## Verification

- `pnpm verify:claude-review` — passed; Claude review workflow contract assertions are green.
- `pnpm lint:md` — passed; markdownlint reported 0 errors.
- `pnpm verify:dogfood` — passed; all eight in-repo skills are discoverable via flat layout.
- `pnpm verify:marketplace` — passed; Claude and Codex marketplace catalogs validated at version 1.7.0.
- `pnpm apply:scaffold-repository:check` — passed; scaffold-repository baseline files are in sync.
- `actionlint v1.7.12 .github/workflows/*.yml` — passed; workflow syntax and configured Blacksmith runner label are accepted.
