### PR TITLE
fix: #108 add code review oidc permission

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,4 +1,4 @@
-name: Claude Review
+name: Code Review
 
 on:
   pull_request:
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   classify:
@@ -37,7 +38,7 @@ jobs:
 
           changed_files="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
 
-          if printf '%s\n' "$changed_files" | grep -qx '.github/workflows/claude-review.yml'; then
+          if printf '%s\n' "$changed_files" | grep -qx '.github/workflows/code-review.yml'; then
             {
               echo "should_review=false"
               echo "reason=review workflow changed"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "verify:marketplace": "bash scripts/verify-marketplace.sh",
     "verify:scaffold-readme": "node scripts/verify-scaffold-agent-plugin-readme.js",
     "verify:superteam": "bash scripts/verify-superteam-contract.sh",
-    "verify:claude-review": "bash scripts/verify-claude-review-workflow.sh",
+    "verify:code-review": "bash scripts/verify-code-review-workflow.sh",
     "verify:workflow-cleanup": "bash scripts/verify-workflow-cleanup.sh",
     "apply:scaffold-repository": "node scripts/apply-scaffold-repository.js skills/scaffold-repository",
     "apply:scaffold-repository:check": "node scripts/apply-scaffold-repository.js skills/scaffold-repository --check"

--- a/scripts/verify-code-review-workflow.sh
+++ b/scripts/verify-code-review-workflow.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-WORKFLOW=".github/workflows/claude-review.yml"
+WORKFLOW=".github/workflows/code-review.yml"
 FAIL_COUNT=0
 
 fail() {
@@ -37,17 +37,19 @@ assert_file "$WORKFLOW"
 
 if [ -f "$WORKFLOW" ]; then
   assert_match "pull_request:" "$WORKFLOW"
+  assert_match "name: Code Review" "$WORKFLOW"
   assert_match "types: \\[opened, synchronize, reopened, ready_for_review\\]" "$WORKFLOW"
   assert_no_match "pull_request_target:" "$WORKFLOW"
   assert_match "contents: read" "$WORKFLOW"
   assert_match "pull-requests: write" "$WORKFLOW"
   assert_match "issues: write" "$WORKFLOW"
+  assert_match "id-token: write" "$WORKFLOW"
   assert_no_match "contents: write" "$WORKFLOW"
   assert_match "runs-on: blacksmith-2vcpu-ubuntu-2404" "$WORKFLOW"
   assert_match "github\\.event\\.pull_request\\.draft == false" "$WORKFLOW"
   assert_match "github\\.event\\.pull_request\\.head\\.repo\\.fork == false" "$WORKFLOW"
   assert_match "github\\.event\\.pull_request\\.user\\.login != 'dependabot\\[bot\\]'" "$WORKFLOW"
-  assert_match "claude-review\\.yml" "$WORKFLOW"
+  assert_match "code-review\\.yml" "$WORKFLOW"
   assert_match "CLAUDE_CODE_OAUTH_TOKEN" "$WORKFLOW"
   assert_no_match "ANTHROPIC_API_KEY|RELEASE_PLEASE_TOKEN|NPM_TOKEN|GITHUB_TOKEN:" "$WORKFLOW"
   assert_match "# anthropics/claude-code-action@v1" "$WORKFLOW"
@@ -70,8 +72,8 @@ assert_no_match "runs-on: ubuntu-latest" skills/scaffold-repository/templates/co
 
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "" >&2
-  echo "FAIL: $FAIL_COUNT Claude review workflow assertion(s) failed" >&2
+  echo "FAIL: $FAIL_COUNT code review workflow assertion(s) failed" >&2
   exit 1
 fi
 
-echo "OK: Claude review workflow assertions passed"
+echo "OK: code review workflow assertions passed"


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #108

## What changed

Context: standalone - fixes the review workflow OIDC token failure

- Renamed the passive review workflow to `.github/workflows/code-review.yml` with display name `Code Review` - matches the requested action surface.
- Added `id-token: write` to the workflow permissions - lets the pinned Claude review action fetch the OIDC token it requires.
- Renamed the local verifier and package script to `verify:code-review` - keeps repository validation aligned with the workflow name.

## Verification

- `pnpm verify:code-review` — passed
- `actionlint .github/workflows/code-review.yml` — passed
- `pnpm verify:workflow-cleanup` — passed
- `pnpm lint:md` — passed after installing lockfile dependencies with scripts disabled
- `pnpm verify:dogfood` — passed
- `pnpm verify:marketplace` — passed
- `pnpm verify:superteam` — passed
- `pnpm apply:scaffold-repository:check` — passed
