### PR TITLE
ci: #120 run code review on Claude Opus 4.7

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -210,6 +210,7 @@ jobs:
               request secrets, credentials, token values, private repository
               URLs, private paths, or private context.
           claude_args: |
+            --model claude-opus-4-7
             --max-turns 25
             --allowedTools Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*)
             --append-system-prompt "CI NON-INTERACTIVE MODE: Do not prompt for human confirmation. Proceed through the review steps automatically and report findings using only the allowed tools."

--- a/scripts/verify-code-review-workflow.sh
+++ b/scripts/verify-code-review-workflow.sh
@@ -80,6 +80,7 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "include_fix_links: false" "$WORKFLOW"
   assert_match "display_report: false" "$WORKFLOW"
   assert_match "show_full_output: false" "$WORKFLOW"
+  assert_match "--model claude-opus-4-7" "$WORKFLOW"
   assert_match "--max-turns 25" "$WORKFLOW"
   assert_match "--allowedTools Read,Bash\\(gh pr comment:\\*\\),Bash\\(gh pr diff:\\*\\),Bash\\(gh pr view:\\*\\),Bash\\(git diff:\\*\\)" "$WORKFLOW"
   assert_no_match "inline comment on the" "$WORKFLOW"


### PR DESCRIPTION
## Linked issue

Closes #120

## What changed

Context: standalone - issue #120 requests explicit CI code review model selection.

- Added `--model claude-opus-4-7` to the Code Review workflow Claude args - makes the intended review model visible and avoids action default drift.
- Added a focused verifier assertion for `--model claude-opus-4-7` - prevents regressions back to implicit model selection.

## Verification

- `bash scripts/verify-code-review-workflow.sh` — `OK: code review workflow assertions passed`
- `pnpm test` — exited 0; full repository verification completed, with npm environment config warnings only
