### PR TITLE
ci: #120 set code review effort to medium

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -211,6 +211,7 @@ jobs:
               URLs, private paths, or private context.
           claude_args: |
             --model claude-opus-4-7
+            --effort medium
             --max-turns 25
             --allowedTools Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*)
             --append-system-prompt "CI NON-INTERACTIVE MODE: Do not prompt for human confirmation. Proceed through the review steps automatically and report findings using only the allowed tools."

--- a/scripts/verify-code-review-workflow.sh
+++ b/scripts/verify-code-review-workflow.sh
@@ -81,6 +81,7 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "display_report: false" "$WORKFLOW"
   assert_match "show_full_output: false" "$WORKFLOW"
   assert_match "--model claude-opus-4-7" "$WORKFLOW"
+  assert_match "--effort medium" "$WORKFLOW"
   assert_match "--max-turns 25" "$WORKFLOW"
   assert_match "--allowedTools Read,Bash\\(gh pr comment:\\*\\),Bash\\(gh pr diff:\\*\\),Bash\\(gh pr view:\\*\\),Bash\\(git diff:\\*\\)" "$WORKFLOW"
   assert_no_match "inline comment on the" "$WORKFLOW"


### PR DESCRIPTION
## Linked issue

Closes #120

## What changed

Context: follow-up to #121 - explicitly configure the Claude Code effort level after selecting Opus 4.7.

- Added `--effort medium` to the Code Review workflow Claude args - configures the requested medium reasoning effort for automated review.
- Added a focused verifier assertion for `--effort medium` - prevents the workflow from silently returning to the model default effort level.

## Verification

- `bash scripts/verify-code-review-workflow.sh` — `OK: code review workflow assertions passed`
- `pnpm test` — exited 0; full repository verification completed, with npm environment config warnings only
