### PR TITLE
feat: #122 add install-skills workflow

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "description": "Patina Project workflow skills, including deprecated Superteam compatibility skills."
+      "description": "Patina Project workflow skills, including install-skills and deprecated Superteam compatibility skills."
     }
   ]
 }

--- a/.agents/skills/install-skills
+++ b/.agents/skills/install-skills
@@ -1,0 +1,1 @@
+../../skills/install-skills

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, finish-pr, review-action, office-hours, plan-ceo-review, plus deprecated Superteam compatibility skills",
+      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, finish-pr, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,13 +2,14 @@
   "name": "patinaproject-skills",
   "skills": [
     "./skills/scaffold-repository",
-    "./skills/superteam",
-    "./skills/superteam-non-interactive",
     "./skills/using-github",
     "./skills/new-branch",
     "./skills/finish-pr",
     "./skills/review-action",
     "./skills/office-hours",
-    "./skills/plan-ceo-review"
+    "./skills/plan-ceo-review",
+    "./skills/install-skills",
+    "./skills/superteam",
+    "./skills/superteam-non-interactive"
   ]
 }

--- a/.claude/skills/install-skills
+++ b/.claude/skills/install-skills
@@ -1,0 +1,1 @@
+../../skills/install-skills

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,13 +3,14 @@
   "version": "1.9.0",
   "skills": [
     "./skills/scaffold-repository",
-    "./skills/superteam",
-    "./skills/superteam-non-interactive",
     "./skills/using-github",
     "./skills/new-branch",
     "./skills/finish-pr",
     "./skills/review-action",
     "./skills/office-hours",
-    "./skills/plan-ceo-review"
+    "./skills/plan-ceo-review",
+    "./skills/install-skills",
+    "./skills/superteam",
+    "./skills/superteam-non-interactive"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,11 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/review-action/`: local AI review-action emulator skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
+- `skills/install-skills/`: project-local skills CLI installation skill
 - `.agents/skills/<name>/`: symlinks into `../../skills/<name>/` (dogfood overlay)
 - `.claude/skills/<name>/`: symlinks into `../../skills/<name>/` (Claude Code overlay)
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all nine skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all ten skill paths
 - `docs/`: contributor docs such as `docs/file-structure.md` and
   `docs/release-flow.md`
 - If `CLAUDE.md` exists, it should point contributors back to `AGENTS.md`
@@ -48,7 +49,7 @@ This is a single-context repository; domain docs are optional and created lazily
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `pnpm test`: run the full local verification suite
 - `pnpm apply:scaffold-repository:check`: assert scaffolding is in sync (exit 0)
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the nine skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the ten skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -80,7 +81,7 @@ structure check; `writing-skills` is the workflow-contract quality gate.
 
 - Run `pnpm test` to run the full suite, or use the targeted commands below while iterating.
 - Validate paths with `find` or `rg`
-- Run `bash scripts/verify-dogfood.sh` to confirm all nine in-repo skills pass the flat-layout check
+- Run `bash scripts/verify-dogfood.sh` to confirm all ten in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-finish-pr-workflow.sh` after changing `skills/finish-pr/**`
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
 - Run `bash scripts/verify-superteam-contract.sh` after changing `skills/superteam/**`
@@ -143,11 +144,11 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns nine skills at flat paths: `skills/scaffold-repository/`,
+This repo owns ten skills at flat paths: `skills/scaffold-repository/`,
 `skills/using-github/`, `skills/new-branch/`, `skills/finish-pr/`,
 `skills/review-action/`, `skills/office-hours/`, `skills/plan-ceo-review/`,
-plus deprecated compatibility skills at `skills/superteam/` and
-`skills/superteam-non-interactive/`.
+`skills/install-skills/`, plus deprecated compatibility skills at
+`skills/superteam/` and `skills/superteam-non-interactive/`.
 `find-skills` is a third-party skill from `vercel-labs/skills` and is not
 a marketplace entry in this repo.
 
@@ -156,7 +157,7 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The nine in-repo skills share the single root `patinaproject-skills` release
+The ten in-repo skills share the single root `patinaproject-skills` release
 and tag; they are not separate release-please packages. Deprecated Superteam
 skills remain in the release while they are kept for compatibility. Third-party
 skills such as `find-skills` are installed separately from their source repo's

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Skills used by the Patina Project team
 
-Nine installable agent skills for repository scaffolding, GitHub workflows,
-issue branch setup, PR finishing, local AI review-action emulation, product
-design, strategic plan review, and historical Superteam compatibility —
+Ten installable agent skills for repository scaffolding, project-local skill
+installation, GitHub workflows, issue branch setup, PR finishing, local AI
+review-action emulation, product design, strategic plan review, and
+historical Superteam compatibility —
 available across Claude Code, Codex, and
 any agent runtime that reads `AGENTS.md`.
 
@@ -76,6 +77,17 @@ routes publishing and checks to `finish-pr`.
 
 See [./skills/using-github/](./skills/using-github/)
 for the full README and skill contract.
+
+### install-skills
+
+Shared workflow skills should be added to a repository without mutating an
+operator's global agent environment. `install-skills` gives agents a canonical
+`npx skills@latest` workflow: read local guidance, inspect `skills-lock.json`,
+list ambiguous sources, install selected skills project-locally for all
+supported agent targets, and verify the resulting lockfile and overlay changes.
+
+See [./skills/install-skills/](./skills/install-skills/)
+for the skill contract.
 
 ### new-branch
 
@@ -158,6 +170,7 @@ for the full README and skill contract.
 | [review-action](./skills/review-action/) | Emulate supported AI code-review actions locally |
 | [office-hours](./skills/office-hours/) | YC-style design partner; runs forcing questions |
 | [plan-ceo-review](./skills/plan-ceo-review/) | Founder-mode review for existing plans |
+| [install-skills](./skills/install-skills/) | Project-local skills CLI installation workflow |
 | [scaffold-repository](./skills/scaffold-repository/) | Scaffold a new repository to the Patina Project baseline |
 
 ## Local iteration
@@ -175,6 +188,7 @@ pnpm test
 
 ```sh
 npx skills@latest add ./skills/scaffold-repository --list
+npx skills@latest add ./skills/install-skills --list
 npx skills@latest add ./skills/office-hours --list
 npx skills@latest add ./skills/review-action --list
 ```
@@ -185,7 +199,7 @@ npx skills@latest add ./skills/review-action --list
 node scripts/apply-scaffold-repository.js skills/scaffold-repository --check
 ```
 
-### Check c — dogfood verification, all nine skills
+### Check c — dogfood verification, all ten skills
 
 ```sh
 bash scripts/verify-dogfood.sh
@@ -196,6 +210,7 @@ bash scripts/verify-dogfood.sh
 ```text
 skills/
   scaffold-repository/
+  install-skills/
   superteam/
   superteam-non-interactive/
   using-github/

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,7 +1,7 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and related install
-documentation. Nine skills live under `skills/<name>/` in a flat layout.
+documentation. Ten skills live under `skills/<name>/` in a flat layout.
 
 ## Top level
 
@@ -14,10 +14,11 @@ documentation. Nine skills live under `skills/<name>/` in a flat layout.
 - `skills/review-action/`: local AI code-review action emulator skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
-- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (nine in-repo)
-- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (nine in-repo)
+- `skills/install-skills/`: project-local skills CLI installation skill
+- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (ten in-repo)
+- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (ten in-repo)
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all nine skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all ten skill paths
 - `skills-lock.json`: vercel-labs CLI install lockfile (auto-generated; commit it)
 - `docs/`: contributor-facing docs for skill maintenance
 - `package.json`, `commitizen.config.js`, `commitlint.config.js`: repo tooling
@@ -27,7 +28,7 @@ documentation. Nine skills live under `skills/<name>/` in a flat layout.
 
 ## Flat skill layout
 
-Nine skills are owned by this repository:
+Ten skills are owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
@@ -40,6 +41,7 @@ Nine skills are owned by this repository:
 | `review-action` | `skills/review-action/` | Local AI code-review action emulation |
 | `office-hours` | `skills/office-hours/` | YC-style office hours for product ideation |
 | `plan-ceo-review` | `skills/plan-ceo-review/` | Founder-mode review for existing plans |
+| `install-skills` | `skills/install-skills/` | Project-local skills CLI installation workflow |
 
 `find-skills` is a third-party vendored skill from `vercel-labs/skills`. It is installed
 via the vercel-labs CLI and is not owned by this repository. Install with:
@@ -55,7 +57,7 @@ install-block reframes.
 
 ## Dogfood overlay layout
 
-The nine in-repo skills are also accessible through two overlay directories via one-hop
+The ten in-repo skills are also accessible through two overlay directories via one-hop
 committed symlinks:
 
 | Overlay path | Symlink target | Mode |
@@ -66,7 +68,7 @@ committed symlinks:
 These symlinks allow the agent runtime to discover the in-repo skills alongside any
 third-party skills installed by the vercel-labs CLI.
 
-Third-party CLI-installed skills (including `find-skills`) are untracked; only the nine
+Third-party CLI-installed skills (including `find-skills`) are untracked; only the ten
 in-repo overlay symlinks are committed.
 
 ## Symlink hygiene

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,10 +3,11 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Nine in-repo skills ship as
+Skills live flat at `skills/<name>/` in this repo. Ten in-repo skills ship as
 `patinaproject-skills`: active skills `scaffold-repository`, `using-github`,
-`new-branch`, `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`,
-plus deprecated compatibility skills `superteam` and `superteam-non-interactive`. All nine are
+`new-branch`, `finish-pr`, `review-action`, `office-hours`,
+`plan-ceo-review`, `install-skills`, plus deprecated compatibility skills `superteam` and
+`superteam-non-interactive`. All ten are
 versioned together as a single marketplace surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
@@ -78,7 +79,7 @@ The vercel-labs CLI consumer pins a specific tag via `#<git-ref>`:
 npx skills@latest add patinaproject/skills#v1.0.0 --skill scaffold-repository
 ```
 
-The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all nine
+The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all ten
 skills live under `skills/<name>/SKILL.md` in the same repo, one tag pins the full set.
 `skills-lock.json`'s `computedHash` records per-skill content provenance for reproducible
 re-installs within a given tag.
@@ -112,7 +113,8 @@ items are not applied by the self-apply script:
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
 - In-repo skills (`scaffold-repository`, `using-github`, `new-branch`,
-  `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`, plus
+  `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`,
+  `install-skills`, plus
   deprecated `superteam` and `superteam-non-interactive`) are not separate release-please packages;
   they share the single root `patinaproject-skills` release and tag.
   Third-party skills such as `find-skills` are installed separately from their

--- a/scripts/apply-scaffold-repository.js
+++ b/scripts/apply-scaffold-repository.js
@@ -113,6 +113,11 @@ const STATIC_FILES = [
 // The SKILL.md lists it as part of the baseline, but for self-apply the
 // in-repo version is intentionally extended and must not be reverted.
 
+// skills-lock.json is a static file in core templates, but this repo's root
+// lockfile records third-party dogfood skills. The scaffold template lockfile
+// records active Patina skills for downstream repos, so self-apply must not
+// overwrite the root third-party catalog with the scaffold default catalog.
+
 // .husky/pre-commit in the template calls `pnpm check:versions`, which runs
 // scripts/check-plugin-versions.mjs. That script checks that plugin manifest
 // versions match package.json. This skills repo is a monorepo root with no

--- a/scripts/install-third-party-skills.sh
+++ b/scripts/install-third-party-skills.sh
@@ -6,7 +6,7 @@
 # `pnpm skills:restore`). Idempotent — re-runs are a no-op when the skills
 # are already present.
 #
-# Why this script exists: the nine in-repo `patinaproject-skills` are tracked
+# Why this script exists: the ten in-repo `patinaproject-skills` are tracked
 # in `skills/<name>/`; third-party skills from external skill catalogs are tracked
 # only as pinned entries in `skills-lock.json` to avoid bloating
 # `npx skills add patinaproject/skills` consumer installs with skills from
@@ -29,8 +29,8 @@ if [ ! -f skills-lock.json ]; then
 fi
 
 # `npx skills experimental_install` reads skills-lock.json and restores all
-# entries. The lockfile records only third-party skills; in-repo skills
-# (the nine `patinaproject-skills`) are not in it.
+# entries. The root lockfile records only third-party skills; in-repo skills
+# (the ten `patinaproject-skills`) are not in it.
 echo "install-third-party-skills: restoring vendored skills from skills-lock.json..."
 npx --yes skills@latest experimental_install --yes
 echo "install-third-party-skills: done"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,5 +21,93 @@ run_cli_canary() {
 }
 
 run_cli_canary ./skills/scaffold-repository
+run_cli_canary ./skills/install-skills
 run_cli_canary ./skills/office-hours
 run_cli_canary ./skills/review-action
+
+run_cli_install_canary() {
+  local repo_root tmpdir status
+  repo_root="$(pwd)"
+  tmpdir="$(mktemp -d)"
+  set +e
+  (
+    set -e
+    cd "$tmpdir"
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 60 env npm_config_ignore_scripts=true npx --yes skills@latest add "$repo_root" --skill scaffold-repository install-skills --agent '*' --yes
+    else
+      npm_config_ignore_scripts=true npx --yes skills@latest add "$repo_root" --skill scaffold-repository install-skills --agent '*' --yes
+    fi
+    test -f .agents/skills/scaffold-repository/SKILL.md
+    test -f .agents/skills/install-skills/SKILL.md
+  )
+  status=$?
+  set -e
+  rm -rf "$tmpdir"
+  return "$status"
+}
+
+run_cli_all_skill_canary() {
+  local repo_root tmpdir status
+  repo_root="$(pwd)"
+  tmpdir="$(mktemp -d)"
+  set +e
+  (
+    set -e
+    cd "$tmpdir"
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 60 env npm_config_ignore_scripts=true npx --yes skills@latest add "$repo_root/skills/install-skills" --skill '*' --agent '*' --yes
+    else
+      npm_config_ignore_scripts=true npx --yes skills@latest add "$repo_root/skills/install-skills" --skill '*' --agent '*' --yes
+    fi
+    test -f .agents/skills/install-skills/SKILL.md
+  )
+  status=$?
+  set -e
+  rm -rf "$tmpdir"
+  return "$status"
+}
+
+run_lockfile_restore_canary() {
+  local repo_root tmpdir status
+  repo_root="$(pwd)"
+  tmpdir="$(mktemp -d)"
+  set +e
+  node -e '
+const fs = require("node:fs");
+const source = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+for (const entry of Object.values(source.skills)) {
+  entry.source = process.argv[3];
+  entry.sourceType = "local";
+}
+fs.writeFileSync(process.argv[2], `${JSON.stringify(source, null, 2)}\n`);
+' \
+    "$repo_root/skills/scaffold-repository/templates/core/skills-lock.json" \
+    "$tmpdir/skills-lock.json" \
+    "$repo_root" &&
+  (
+    set -e
+    cd "$tmpdir"
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 60 env npm_config_ignore_scripts=true npx --yes skills@latest experimental_install --yes
+    else
+      npm_config_ignore_scripts=true npx --yes skills@latest experimental_install --yes
+    fi
+    test -f .agents/skills/finish-pr/SKILL.md
+    test -f .agents/skills/install-skills/SKILL.md
+    test -f .agents/skills/new-branch/SKILL.md
+    test -f .agents/skills/office-hours/SKILL.md
+    test -f .agents/skills/plan-ceo-review/SKILL.md
+    test -f .agents/skills/review-action/SKILL.md
+    test -f .agents/skills/scaffold-repository/SKILL.md
+    test -f .agents/skills/using-github/SKILL.md
+  )
+  status=$?
+  set -e
+  rm -rf "$tmpdir"
+  return "$status"
+}
+
+run_cli_install_canary
+run_cli_all_skill_canary
+run_lockfile_restore_canary

--- a/scripts/verify-dogfood.sh
+++ b/scripts/verify-dogfood.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# verify-dogfood.sh — Asserts that all nine in-repo skills are discoverable
+# verify-dogfood.sh — Asserts that all ten in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
-# Exit 0: all nine skills pass all assertions.
+# Exit 0: all ten skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -14,6 +14,7 @@ cd "$REPO_ROOT"
 
 SKILLS=(
   scaffold-repository
+  install-skills
   superteam
   superteam-non-interactive
   using-github
@@ -122,5 +123,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all nine in-repo skills discoverable via flat layout"
+echo "OK: all ten in-repo skills discoverable via flat layout"
 exit 0

--- a/scripts/verify-marketplace.sh
+++ b/scripts/verify-marketplace.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/finish-pr","./skills/review-action","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
+expected_scaffold_default_skills='["finish-pr","install-skills","new-branch","office-hours","plan-ceo-review","review-action","scaffold-repository","using-github"]'
+
 # Validate the Claude Code marketplace catalog.
 test -f .claude-plugin/marketplace.json
 test -f .claude-plugin/plugin.json
@@ -54,6 +57,37 @@ if [ "$claude_skills" != "$codex_skills" ]; then
   echo "FAIL: Claude and Codex plugin.json skills[] arrays diverged" >&2
   echo "  Claude: $claude_skills" >&2
   echo "  Codex:  $codex_skills" >&2
+  exit 1
+fi
+if [ "$claude_skills" != "$expected_marketplace_skills" ]; then
+  echo "FAIL: marketplace skills[] did not match expected shipped catalog" >&2
+  echo "  Expected: $expected_marketplace_skills" >&2
+  echo "  Actual:   $claude_skills" >&2
+  exit 1
+fi
+
+scaffold_default_skills=$(jq -c '.skills | keys | sort' skills/scaffold-repository/templates/core/skills-lock.json)
+if [ "$scaffold_default_skills" != "$expected_scaffold_default_skills" ]; then
+  echo "FAIL: scaffold default skills-lock.json did not match expected active catalog" >&2
+  echo "  Expected: $expected_scaffold_default_skills" >&2
+  echo "  Actual:   $scaffold_default_skills" >&2
+  exit 1
+fi
+if jq -e '.skills | has("superteam") or has("superteam-non-interactive")' \
+  skills/scaffold-repository/templates/core/skills-lock.json >/dev/null; then
+  echo "FAIL: scaffold defaults must exclude deprecated Superteam compatibility skills" >&2
+  exit 1
+fi
+if ! jq -e '
+  .skills
+  | to_entries
+  | all(
+      .value.source == "patinaproject/skills"
+      and .value.sourceType == "github"
+      and .value.skillPath == ("skills/" + .key + "/SKILL.md")
+    )
+' skills/scaffold-repository/templates/core/skills-lock.json >/dev/null; then
+  echo "FAIL: scaffold default lockfile entries must point at patinaproject/skills skill paths" >&2
   exit 1
 fi
 

--- a/scripts/verify-scaffold-agent-plugin-readme.js
+++ b/scripts/verify-scaffold-agent-plugin-readme.js
@@ -33,6 +33,10 @@ const coreInstallSkillsTemplatePath = path.join(
   repoRoot,
   "skills/scaffold-repository/templates/core/scripts/install-skills.mjs",
 );
+const coreSkillsLockTemplatePath = path.join(
+  repoRoot,
+  "skills/scaffold-repository/templates/core/skills-lock.json",
+);
 const coreUpdateSkillsTemplatePath = path.join(
   repoRoot,
   "skills/scaffold-repository/templates/core/scripts/update-skills.mjs",
@@ -102,6 +106,7 @@ const corePackageTemplate = fs.readFileSync(corePackageTemplatePath, "utf8");
 const coreAgentsTemplate = fs.readFileSync(coreAgentsTemplatePath, "utf8");
 const coreGitignoreTemplate = fs.readFileSync(coreGitignoreTemplatePath, "utf8");
 const coreInstallSkillsTemplate = fs.readFileSync(coreInstallSkillsTemplatePath, "utf8");
+const coreSkillsLockTemplate = fs.readFileSync(coreSkillsLockTemplatePath, "utf8");
 const coreUpdateSkillsTemplate = fs.readFileSync(coreUpdateSkillsTemplatePath, "utf8");
 const skillContract = fs.readFileSync(skillContractPath, "utf8");
 const auditChecklist = fs.readFileSync(auditChecklistPath, "utf8");
@@ -156,6 +161,39 @@ assertIncludes(coreGitignoreTemplate, "skills-lock.json.bak", "Generated skill r
 assertIncludes(coreInstallSkillsTemplate, "No skills-lock.json found", "Install no-lockfile no-op");
 assertIncludes(coreInstallSkillsTemplate, "experimental_install", "Install read-only lockfile command");
 assertIncludes(coreInstallSkillsTemplate, "--list", "Install list mode");
+const scaffoldDefaultSkills = Object.keys(JSON.parse(coreSkillsLockTemplate).skills ?? {}).sort();
+const expectedScaffoldDefaultSkills = [
+  "finish-pr",
+  "install-skills",
+  "new-branch",
+  "office-hours",
+  "plan-ceo-review",
+  "review-action",
+  "scaffold-repository",
+  "using-github",
+];
+if (JSON.stringify(scaffoldDefaultSkills) !== JSON.stringify(expectedScaffoldDefaultSkills)) {
+  fail(
+    `Scaffold default skills: expected ${expectedScaffoldDefaultSkills.join(", ")}, got ${scaffoldDefaultSkills.join(", ")}`,
+  );
+}
+for (const deprecatedSkill of ["superteam", "superteam-non-interactive"]) {
+  if (scaffoldDefaultSkills.includes(deprecatedSkill)) {
+    fail(`Scaffold default skills: deprecated ${deprecatedSkill} must not be included`);
+  }
+}
+const scaffoldDefaultCatalog = JSON.parse(coreSkillsLockTemplate);
+for (const [skill, entry] of Object.entries(scaffoldDefaultCatalog.skills ?? {})) {
+  if (entry.source !== "patinaproject/skills") {
+    fail(`Scaffold default ${skill}: expected source patinaproject/skills`);
+  }
+  if (entry.sourceType !== "github") {
+    fail(`Scaffold default ${skill}: expected sourceType github`);
+  }
+  if (entry.skillPath !== `skills/${skill}/SKILL.md`) {
+    fail(`Scaffold default ${skill}: expected skillPath skills/${skill}/SKILL.md`);
+  }
+}
 assertIncludes(coreUpdateSkillsTemplate, '"npx"', "Update marketplace refresh command");
 assertIncludes(
   coreUpdateSkillsTemplate,

--- a/skills/install-skills/SKILL.md
+++ b/skills/install-skills/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: install-skills
+description: Install one or more agent skills into the current repository with the skills CLI. Use when adding, refreshing, or restoring project-local skills, when a user names a skill source, or when a repository needs shared skills installed without mutating global agent state.
+---
+
+# install-skills
+
+Install skills project-locally so the repository, not the operator's global
+environment, owns the shared workflow catalog.
+
+## Preflight
+
+1. Read repository guidance first: `AGENTS.md`, `CLAUDE.md` if present, and
+   any docs governing agent skills or shared tooling.
+2. Inspect the current catalog if present:
+
+   ```bash
+   test -f skills-lock.json && npm_config_ignore_scripts=true npx --yes skills@latest list --json
+   ```
+
+   If the repository exposes a wrapper such as `pnpm skills:list`, use that
+   instead of the raw CLI list command.
+
+3. Resolve the requested source and skill names. If the source contents or
+   requested skill names are ambiguous, list before installing:
+
+   ```bash
+   npm_config_ignore_scripts=true npx --yes skills@latest add <source> --list
+   ```
+
+## Install
+
+Run installs from the repository root. Do not use `--global`.
+
+Canonical single-source install:
+
+```bash
+npm_config_ignore_scripts=true npx --yes skills@latest add <source> --skill <skill-name> --agent '*' --yes
+```
+
+For multiple skills from the same source, repeat `--skill` values as separate
+arguments after one flag:
+
+```bash
+npm_config_ignore_scripts=true npx --yes skills@latest add <source> --skill <skill-a> <skill-b> --agent '*' --yes
+```
+
+For all skills from a source, prefer an explicit all-agent install:
+
+```bash
+npm_config_ignore_scripts=true npx --yes skills@latest add <source> --skill '*' --agent '*' --yes
+```
+
+Use a pinned source when reproducibility matters:
+
+```bash
+npm_config_ignore_scripts=true npx --yes skills@latest add owner/repo#<git-ref> --skill <skill-name> --agent '*' --yes
+```
+
+## Patina Sources
+
+For Patina Project marketplace skills, use `patinaproject/skills` as the source
+and install only the requested skills unless the user explicitly asks for all.
+
+Active Patina scaffold defaults are:
+
+- `scaffold-repository`
+- `using-github`
+- `new-branch`
+- `finish-pr`
+- `review-action`
+- `office-hours`
+- `plan-ceo-review`
+- `install-skills`
+
+Deprecated Superteam compatibility skills remain installable, but do not add
+them to a scaffold default catalog unless the user explicitly asks for legacy
+compatibility.
+
+## Verify
+
+After installing, prove what changed:
+
+```bash
+npm_config_ignore_scripts=true npx --yes skills@latest list --json
+git status --short
+```
+
+If the repository exposes wrapper scripts, also run:
+
+```bash
+pnpm skills:list
+```
+
+Report the installed skills, the source used, and the changed lockfile or agent
+overlay paths. Stop before committing unless the user asked you to finish the
+branch.

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -101,6 +101,7 @@ scripts/check-plugin-versions.mjs
 scripts/install-skills.mjs
 scripts/sync-plugin-versions.mjs
 scripts/update-skills.mjs
+skills-lock.json
 ```
 
 ## Agent plugin surfaces
@@ -159,7 +160,7 @@ deprecated Superteam or Superpowers workflows.
 - **Issue titles**: plain-language, no commit-style prefix.
 - **Markdown**: `markdownlint-cli2` with `.markdownlint.jsonc` + `.markdownlintignore`. `lint-staged` runs it from `pre-commit`. The lint script uses a glob that excludes `node_modules/`.
 - **PNPM**: `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, and `lint:md` script.
-- **Shared skill lifecycle**: scaffolded consumer repositories expose `pnpm skills:install`, `pnpm skills:update`, and `pnpm skills:list`. Fresh repos do not emit `skills-lock.json`; install and list no-op clearly until a repo commits a shared skill catalog. Update refreshes Patina-owned skills already present in the lockfile through `npx skills@latest add patinaproject/skills --skill <name>`, pins missing immutable GitHub refs, verifies the resulting lockfile installs, and restores the previous lockfile on failure. The wrappers set `npm_config_ignore_scripts=true` for CLI calls. While the vercel-labs CLI restore command is still named `experimental_install`, consumers should rerun `scaffold-repository` after that subcommand graduates or is renamed.
+- **Shared skill lifecycle**: scaffolded consumer repositories expose `pnpm skills:install`, `pnpm skills:update`, and `pnpm skills:list`. Fresh repos emit a committed `skills-lock.json` containing the active Patina workflow skills: `scaffold-repository`, `using-github`, `new-branch`, `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`, and `install-skills`. Deprecated Superteam compatibility skills remain marketplace-installable but are excluded from scaffold defaults. The template lockfile intentionally starts with unpinned `patinaproject/skills` sources so the not-yet-released scaffold template can restore the active set after it ships; the first `pnpm skills:update` pins Patina sources to a full immutable GitHub SHA. Install restores the committed catalog without refreshing it. Update refreshes Patina-owned skills already present in the lockfile through `npx skills@latest add patinaproject/skills --skill <name>`, pins missing immutable GitHub refs, verifies the resulting lockfile installs, and restores the previous lockfile on failure. The wrappers set `npm_config_ignore_scripts=true` for CLI calls. While the vercel-labs CLI restore command is still named `experimental_install`, consumers should rerun `scaffold-repository` after that subcommand graduates or is renamed.
 - **Line endings**: `.gitattributes` with `* text=auto eol=lf`.
 - **PR title hygiene**: `.github/workflows/pull-request.yml` validates that every PR title is ASCII-only, follows conventional commits (no scopes), starts with a `#<issue>` ref, keeps breaking-change markers consistent (`!` in title ⇔ `BREAKING CHANGE:` footer), and that the body contains a GitHub closing keyword.
 - **Markdown CI**: `.github/workflows/markdown.yml` runs `DavidAnson/markdownlint-cli2-action` on every PR as a backstop to the husky `pre-commit` hook (which can be bypassed with `--no-verify`).

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -27,7 +27,8 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `pnpm-lock.yaml` | yes | present |
 | `scripts/check-plugin-versions.mjs` | yes | present; fails with non-zero exit on version drift |
 | `scripts/sync-plugin-versions.mjs` | yes | present; rewrites plugin manifests from `package.json` |
-| `scripts/install-skills.mjs` | yes | present; `pnpm skills:install` treats missing `skills-lock.json` as a no-op, installs from the committed lockfile without refreshing it, sets `npm_config_ignore_scripts=true`, and `pnpm skills:list` lists committed shared skills |
+| `scripts/install-skills.mjs` | yes | present; `pnpm skills:install` installs from the committed lockfile without refreshing it, sets `npm_config_ignore_scripts=true`, and `pnpm skills:list` lists committed shared skills |
+| `skills-lock.json` | yes | present in scaffolded repos; contains the active Patina workflow skill catalog and excludes deprecated Superteam compatibility skills. The install wrapper still no-ops clearly when an older or hand-curated repo has no lockfile |
 | `scripts/update-skills.mjs` | yes | present; `pnpm skills:update` refreshes Patina-owned skills already present in the lockfile with `npx skills@latest add patinaproject/skills --skill <name>`, sets `npm_config_ignore_scripts=true`, pins missing immutable GitHub refs, verifies installability, restores the prior lockfile on failure, and documents that consumers should rerun `scaffold-repository` when `experimental_install` graduates |
 | `CHANGELOG.md` | yes | present; compatible with release-please (no hand-edits to released sections) |
 | `RELEASING.md` | yes | present; documents the release-please flow |

--- a/skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
+++ b/skills/scaffold-repository/templates/agent-plugin/README.md.tmpl
@@ -162,8 +162,8 @@ This repository is the source for the plugin. Local workflow:
 
 ```bash
 pnpm install           # installs dev deps and wires husky
-pnpm skills:install    # installs committed shared skills, if skills-lock.json exists
-pnpm skills:update     # refreshes Patina-owned shared skills already in the lockfile
+pnpm skills:install    # installs committed shared skills; no-ops without skills-lock.json
+pnpm skills:update     # refreshes Patina-owned shared skills and pins Patina refs
 pnpm skills:list       # lists committed shared skills without installing them
 pnpm lint:md           # markdownlint-cli2
 pnpm check:versions    # enforce package.json ↔ plugin manifests lockstep

--- a/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
+++ b/skills/scaffold-repository/templates/core/AGENTS.md.tmpl
@@ -20,7 +20,7 @@ or in normal docs when it is broadly useful beyond one issue.
 
 - `pnpm install`: install local tooling and initialize Husky hooks.
 - `pnpm skills:install`: install committed shared skills from `skills-lock.json`; no-ops when no lockfile exists.
-- `pnpm skills:update`: refresh Patina-owned shared skills already in the lockfile, verify installability, and keep the previous lockfile on failure.
+- `pnpm skills:update`: refresh Patina-owned shared skills already in the lockfile, pin Patina sources to immutable GitHub SHAs, verify installability, and keep the previous lockfile on failure.
 - `pnpm skills:list`: list committed shared skills without changing installed payloads.
 - `pnpm exec commitlint --edit <path>`: validate a commit message file against repo rules.
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`.

--- a/skills/scaffold-repository/templates/core/skills-lock.json
+++ b/skills/scaffold-repository/templates/core/skills-lock.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "skills": {
+    "scaffold-repository": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/scaffold-repository/SKILL.md"
+    },
+    "using-github": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/using-github/SKILL.md"
+    },
+    "new-branch": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/new-branch/SKILL.md"
+    },
+    "finish-pr": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/finish-pr/SKILL.md"
+    },
+    "review-action": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/review-action/SKILL.md"
+    },
+    "office-hours": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/office-hours/SKILL.md"
+    },
+    "plan-ceo-review": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/plan-ceo-review/SKILL.md"
+    },
+    "install-skills": {
+      "source": "patinaproject/skills",
+      "sourceType": "github",
+      "skillPath": "skills/install-skills/SKILL.md"
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #122

## What changed

Context: standalone - issue #122 requested a first-class project-local skill install workflow and scaffold defaults for active Patina skills.

- Added the `install-skills` workflow skill - gives agents a canonical, project-local `skills` CLI process with all-agent targeting, source listing, and verification.
- Updated marketplace manifests and dogfood overlays - distributes `install-skills` through Claude, Codex, and local overlay surfaces while keeping deprecated Superteam skills installable.
- Added the scaffold default `skills-lock.json` and verification coverage - fresh scaffolded repos restore the active Patina workflow set while excluding deprecated compatibility skills.
- Updated contributor and release docs - replaces nine-skill language with the current ten-skill catalog and active/deprecated split.

## Verification

- `pnpm test` — passed.
- `pnpm lint:md` — failed on pre-existing `CHANGELOG.md:5` MD012 multiple blank lines; this branch does not touch `CHANGELOG.md`.
