### PR TITLE
feat: #133 add execute workflow skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "description": "Patina Project workflow skills, including install-skills and deprecated Superteam compatibility skills."
+      "description": "Patina Project workflow skills, including execute, install-skills, and deprecated Superteam compatibility skills."
     }
   ]
 }

--- a/.agents/skills/execute
+++ b/.agents/skills/execute
@@ -1,0 +1,1 @@
+../../skills/execute

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, finish-pr, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
+      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, execute, finish-pr, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
     "./skills/new-branch",
     "./skills/finish-pr",
     "./skills/review-action",
+    "./skills/execute",
     "./skills/office-hours",
     "./skills/plan-ceo-review",
     "./skills/install-skills",

--- a/.claude/skills/execute
+++ b/.claude/skills/execute
@@ -1,0 +1,1 @@
+../../skills/execute

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,6 +7,7 @@
     "./skills/new-branch",
     "./skills/finish-pr",
     "./skills/review-action",
+    "./skills/execute",
     "./skills/office-hours",
     "./skills/plan-ceo-review",
     "./skills/install-skills",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,14 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/new-branch/`: issue branch preparation skill
 - `skills/finish-pr/`: PR finishing skill
 - `skills/review-action/`: local AI review-action emulator skill
+- `skills/execute/`: issue-to-PR workflow orchestration skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
 - `skills/install-skills/`: project-local skills CLI installation skill
 - `.agents/skills/<name>/`: symlinks into `../../skills/<name>/` (dogfood overlay)
 - `.claude/skills/<name>/`: symlinks into `../../skills/<name>/` (Claude Code overlay)
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all ten skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eleven skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this repository
 - `docs/`: contributor docs such as `docs/file-structure.md` and
   `docs/release-flow.md`
@@ -49,7 +50,7 @@ This is a single-context repository; domain docs are optional and created lazily
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `pnpm test`: run the full local verification suite
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the ten skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the eleven skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -81,7 +82,7 @@ structure check; `writing-skills` is the workflow-contract quality gate.
 
 - Run `pnpm test` to run the full suite, or use the targeted commands below while iterating.
 - Validate paths with `find` or `rg`
-- Run `bash scripts/verify-dogfood.sh` to confirm all ten in-repo skills pass the flat-layout check
+- Run `bash scripts/verify-dogfood.sh` to confirm all eleven in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-esm-tooling.sh` after changing repo tooling configs or the package module type
 - Run `bash scripts/verify-finish-pr-workflow.sh` after changing `skills/finish-pr/**`
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
@@ -143,10 +144,10 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns ten skills at flat paths: `skills/scaffold-repository/`,
+This repo owns eleven skills at flat paths: `skills/scaffold-repository/`,
 `skills/using-github/`, `skills/new-branch/`, `skills/finish-pr/`,
-`skills/review-action/`, `skills/office-hours/`, `skills/plan-ceo-review/`,
-`skills/install-skills/`, plus deprecated compatibility skills at
+`skills/review-action/`, `skills/execute/`, `skills/office-hours/`,
+`skills/plan-ceo-review/`, `skills/install-skills/`, plus deprecated compatibility skills at
 `skills/superteam/` and `skills/superteam-non-interactive/`.
 `find-skills` is a third-party skill from `vercel-labs/skills` and is not
 a marketplace entry in this repo.
@@ -156,7 +157,7 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The ten in-repo skills share the single root `patinaproject-skills` release
+The eleven in-repo skills share the single root `patinaproject-skills` release
 and tag; they are not separate release-please packages. Deprecated Superteam
 skills remain in the release while they are kept for compatibility. Third-party
 skills such as `find-skills` are installed separately from their source repo's

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Skills used by the Patina Project team
 
-Ten installable agent skills for repository scaffolding, project-local skill
+Eleven installable agent skills for repository scaffolding, project-local skill
 installation, GitHub workflows, issue branch setup, PR finishing, local AI
-review-action emulation, product design, strategic plan review, and
+review-action emulation, issue-to-PR execution, product design, strategic plan review, and
 historical Superteam compatibility —
 available across Claude Code, Codex, and
 any agent runtime that reads `AGENTS.md`.
@@ -121,6 +121,18 @@ local CLI, and prints a terminal-only report.
 See [./skills/review-action/](./skills/review-action/)
 for the skill contract.
 
+### execute
+
+Routine issue work crosses several focused workflows: branch setup,
+test-driven implementation, local AI review, review remediation, and PR
+finishing. `execute` is the generic orchestrator for that lifecycle. It
+delegates branch setup to `new-branch`, local review to `review-action`, and
+publication readiness to `finish-pr`, while using TDD for implementation and
+review fixes.
+
+See [./skills/execute/](./skills/execute/)
+for the skill contract.
+
 ### office-hours
 
 New product ideas benefit from honest forcing questions before any code is
@@ -168,6 +180,7 @@ for the full README and skill contract.
 | [new-branch](./skills/new-branch/) | Prepare local issue branches from the default branch |
 | [finish-pr](./skills/finish-pr/) | Finish completed branch work through ready-to-merge PRs |
 | [review-action](./skills/review-action/) | Emulate supported AI code-review actions locally |
+| [execute](./skills/execute/) | Orchestrate issue work from branch setup to PR readiness |
 | [office-hours](./skills/office-hours/) | YC-style design partner; runs forcing questions |
 | [plan-ceo-review](./skills/plan-ceo-review/) | Founder-mode review for existing plans |
 | [install-skills](./skills/install-skills/) | Project-local skills CLI installation workflow |
@@ -191,6 +204,7 @@ npx skills@latest add ./skills/scaffold-repository --list
 npx skills@latest add ./skills/install-skills --list
 npx skills@latest add ./skills/office-hours --list
 npx skills@latest add ./skills/review-action --list
+npx skills@latest add ./skills/execute --list
 ```
 
 ### Check b — scaffold-repository cleanup contract
@@ -199,7 +213,7 @@ npx skills@latest add ./skills/review-action --list
 bash scripts/verify-scaffold-cleanup.sh
 ```
 
-### Check c — dogfood verification, all ten skills
+### Check c — dogfood verification, all eleven skills
 
 ```sh
 bash scripts/verify-dogfood.sh
@@ -217,6 +231,7 @@ skills/
   new-branch/
   finish-pr/
   review-action/
+  execute/
   office-hours/
   plan-ceo-review/
 .agents/skills/<name>/               Symlinks to ../../skills/<name>/

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,7 +1,7 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and related install
-documentation. Ten skills live under `skills/<name>/` in a flat layout.
+documentation. Eleven skills live under `skills/<name>/` in a flat layout.
 
 ## Top level
 
@@ -12,13 +12,14 @@ documentation. Ten skills live under `skills/<name>/` in a flat layout.
 - `skills/new-branch/`: issue branch preparation skill
 - `skills/finish-pr/`: PR finishing skill
 - `skills/review-action/`: local AI code-review action emulator skill
+- `skills/execute/`: issue-to-PR workflow orchestration skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
 - `skills/install-skills/`: project-local skills CLI installation skill
-- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (ten in-repo)
-- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (ten in-repo)
+- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (eleven in-repo)
+- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (eleven in-repo)
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all ten skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eleven skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this
   repository
 - `skills-lock.json`: vercel-labs CLI install lockfile (auto-generated; commit it)
@@ -30,7 +31,7 @@ documentation. Ten skills live under `skills/<name>/` in a flat layout.
 
 ## Flat skill layout
 
-Ten skills are owned by this repository:
+Eleven skills are owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
@@ -41,6 +42,7 @@ Ten skills are owned by this repository:
 | `new-branch` | `skills/new-branch/` | Issue branch preparation |
 | `finish-pr` | `skills/finish-pr/` | Ready-for-merge PR finishing |
 | `review-action` | `skills/review-action/` | Local AI code-review action emulation |
+| `execute` | `skills/execute/` | Issue-to-PR workflow orchestration |
 | `office-hours` | `skills/office-hours/` | YC-style office hours for product ideation |
 | `plan-ceo-review` | `skills/plan-ceo-review/` | Founder-mode review for existing plans |
 | `install-skills` | `skills/install-skills/` | Project-local skills CLI installation workflow |
@@ -59,7 +61,7 @@ install-block reframes.
 
 ## Dogfood overlay layout
 
-The ten in-repo skills are also accessible through two overlay directories via one-hop
+The eleven in-repo skills are also accessible through two overlay directories via one-hop
 committed symlinks:
 
 | Overlay path | Symlink target | Mode |
@@ -70,7 +72,7 @@ committed symlinks:
 These symlinks allow the agent runtime to discover the in-repo skills alongside any
 third-party skills installed by the vercel-labs CLI.
 
-Third-party CLI-installed skills (including `find-skills`) are untracked; only the ten
+Third-party CLI-installed skills (including `find-skills`) are untracked; only the eleven
 in-repo overlay symlinks are committed.
 
 ## Symlink hygiene

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,11 +3,11 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Ten in-repo skills ship as
+Skills live flat at `skills/<name>/` in this repo. Eleven in-repo skills ship as
 `patinaproject-skills`: active skills `scaffold-repository`, `using-github`,
-`new-branch`, `finish-pr`, `review-action`, `office-hours`,
+`new-branch`, `finish-pr`, `review-action`, `execute`, `office-hours`,
 `plan-ceo-review`, `install-skills`, plus deprecated compatibility skills `superteam` and
-`superteam-non-interactive`. All ten are
+`superteam-non-interactive`. All eleven are
 versioned together as a single marketplace surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
@@ -74,7 +74,7 @@ The vercel-labs CLI consumer pins a specific tag via `#<git-ref>`:
 npx skills@latest add patinaproject/skills#v1.0.0 --skill scaffold-repository
 ```
 
-The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all ten
+The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all eleven
 skills live under `skills/<name>/SKILL.md` in the same repo, one tag pins the full set.
 `skills-lock.json`'s `computedHash` records per-skill content provenance for reproducible
 re-installs within a given tag.
@@ -84,7 +84,7 @@ re-installs within a given tag.
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
 - In-repo skills (`scaffold-repository`, `using-github`, `new-branch`,
-  `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`,
+  `finish-pr`, `review-action`, `execute`, `office-hours`, `plan-ceo-review`,
   `install-skills`, plus
   deprecated `superteam` and `superteam-non-interactive`) are not separate release-please packages;
   they share the single root `patinaproject-skills` release and tag.

--- a/scripts/install-third-party-skills.sh
+++ b/scripts/install-third-party-skills.sh
@@ -6,7 +6,7 @@
 # `pnpm skills:restore`). Idempotent — re-runs are a no-op when the skills
 # are already present.
 #
-# Why this script exists: the ten in-repo `patinaproject-skills` are tracked
+# Why this script exists: the eleven in-repo `patinaproject-skills` are tracked
 # in `skills/<name>/`; third-party skills from external skill catalogs are tracked
 # only as pinned entries in `skills-lock.json` to avoid bloating
 # `npx skills add patinaproject/skills` consumer installs with skills from
@@ -30,7 +30,7 @@ fi
 
 # `npx skills experimental_install` reads skills-lock.json and restores all
 # entries. The root lockfile records only third-party skills; in-repo skills
-# (the ten `patinaproject-skills`) are not in it.
+# (the eleven `patinaproject-skills`) are not in it.
 echo "install-third-party-skills: restoring vendored skills from skills-lock.json..."
 npx --yes skills@latest experimental_install --yes
 echo "install-third-party-skills: done"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,6 +24,7 @@ run_cli_canary ./skills/scaffold-repository
 run_cli_canary ./skills/install-skills
 run_cli_canary ./skills/office-hours
 run_cli_canary ./skills/review-action
+run_cli_canary ./skills/execute
 
 run_cli_install_canary() {
   local repo_root tmpdir status

--- a/scripts/verify-dogfood.sh
+++ b/scripts/verify-dogfood.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# verify-dogfood.sh — Asserts that all ten in-repo skills are discoverable
+# verify-dogfood.sh — Asserts that all eleven in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
-# Exit 0: all ten skills pass all assertions.
+# Exit 0: all eleven skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -21,6 +21,7 @@ SKILLS=(
   new-branch
   finish-pr
   review-action
+  execute
   office-hours
   plan-ceo-review
 )
@@ -123,5 +124,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all ten in-repo skills discoverable via flat layout"
+echo "OK: all eleven in-repo skills discoverable via flat layout"
 exit 0

--- a/scripts/verify-marketplace.sh
+++ b/scripts/verify-marketplace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/finish-pr","./skills/review-action","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
+expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/finish-pr","./skills/review-action","./skills/execute","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
 
 # Validate the Claude Code marketplace catalog.
 test -f .claude-plugin/marketplace.json

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: execute
+description: Orchestrate issue-linked development from branch setup through local review and PR readiness. Use when asked to run /execute, complete an issue end to end, or drive the standard issue-to-PR workflow.
+---
+
+# Execute
+
+## Quick Start
+
+Given an issue reference or implementation request, run the standard local
+development lifecycle:
+
+1. Prepare the issue branch with `new-branch`.
+2. Implement through TDD.
+3. Run repository-documented verification.
+4. Run `review-action` locally.
+5. Fix valid local review findings through TDD and rerun review until clean.
+6. Hand the clean branch to `finish-pr`.
+
+Example: `/execute #42` prepares the branch for issue `#42`, implements the
+issue, reviews the local diff, fixes valid findings, and finishes the ready PR.
+
+## Workflow
+
+1. Read repository guidance, the issue, and any linked acceptance criteria.
+2. Invoke `new-branch` for the issue reference and inherit all of its halt
+   conditions.
+3. Choose the next smallest behavior required by the issue.
+4. Use the `tdd` skill when available. If it is unavailable, use the fallback
+   loop below.
+5. Run focused tests after each red-green-refactor cycle.
+6. Run the repository's documented verification commands before local review.
+7. Invoke `review-action` and inherit its read-only safety boundary and
+   unsupported-workflow halt conditions.
+8. Triage every review finding as a technical claim:
+   - Fix valid branch-local findings one at a time through TDD.
+   - Push back in the report on findings that are wrong, stale, already
+     covered, or out of scope.
+   - Halt for unclear, unverifiable, permission-sensitive, secret-sensitive,
+     external-state-dependent, or product-scope findings.
+9. After each valid fix, rerun focused tests, documented verification as
+   needed, and `review-action`.
+10. Continue until local review is clean or a human-needed blocker appears.
+11. Invoke `finish-pr` only after the local review loop is clean, inheriting
+    all of its guardrails and stop conditions.
+
+## Fallback TDD
+
+Use this only when the `tdd` skill is not installed.
+
+1. Write one failing test for one behavior.
+2. Run the focused test and confirm it fails for the expected reason.
+3. Make the smallest implementation change that can pass the test.
+4. Rerun the focused test and confirm it passes.
+5. Refactor only while tests stay green.
+6. Repeat for the next behavior.
+
+Do not write production code before observing a failing test unless the user
+explicitly exempts the task from TDD.
+
+## Halt Conditions
+
+Halt and report the current state when:
+
+- Any child skill halts.
+- The worktree has unrelated or ambiguous local changes.
+- The issue, acceptance criteria, or branch target is ambiguous.
+- A test or verification failure is not branch-local.
+- Review settings are unsupported by `review-action`.
+- A review finding needs human judgment, secrets, permissions, external state,
+  or product-scope decisions.
+- `finish-pr` reports merge, check, feedback, or publishing blockers.
+
+## Report
+
+The final report should include the issue, branch, verification commands,
+review-action result, review findings fixed or pushed back on, and the PR URL
+or halt reason.


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #133

## What changed

Context: standalone - add the issue-to-PR orchestration skill requested by the issue PRD

- Added the `execute` skill contract - gives agents one generic entrypoint for branch setup, TDD implementation, local review, review remediation, and PR finishing while preserving child-skill guardrails
- Added `execute` to Claude and Codex marketplace manifests plus dogfood overlays - makes the new skill discoverable across supported hosts
- Updated verifiers, CLI canaries, and catalog documentation - catches catalog drift and documents the eleven-skill marketplace surface

## Verification

- `pnpm test` — passed, including dogfood verification, marketplace verification, workflow checks, and the new `./skills/execute --list` CLI canary
- `git diff --check` — passed
- `pnpm lint:md` — failed on pre-existing `CHANGELOG.md` blank lines at lines 5 and 12; CI markdown lint excludes `CHANGELOG.md`
