### PR TITLE
feat: #138 add develop-issue workflow skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "description": "Patina Project workflow skills, including install-skills and deprecated Superteam compatibility skills."
+      "description": "Patina Project workflow skills, including develop-issue, install-skills, and deprecated Superteam compatibility skills."
     }
   ]
 }

--- a/.agents/skills/develop-issue
+++ b/.agents/skills/develop-issue
@@ -1,0 +1,1 @@
+../../skills/develop-issue

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, finish-pr, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
+      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, develop-issue, finish-pr, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,6 +4,7 @@
     "./skills/scaffold-repository",
     "./skills/using-github",
     "./skills/new-branch",
+    "./skills/develop-issue",
     "./skills/finish-pr",
     "./skills/review-action",
     "./skills/office-hours",

--- a/.claude/skills/develop-issue
+++ b/.claude/skills/develop-issue
@@ -1,0 +1,1 @@
+../../skills/develop-issue

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,6 +5,7 @@
     "./skills/scaffold-repository",
     "./skills/using-github",
     "./skills/new-branch",
+    "./skills/develop-issue",
     "./skills/finish-pr",
     "./skills/review-action",
     "./skills/office-hours",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ structure check; `writing-skills` is the workflow-contract quality gate.
 - Validate paths with `find` or `rg`
 - Run `bash scripts/verify-dogfood.sh` to confirm all eleven in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-esm-tooling.sh` after changing repo tooling configs or the package module type
+- Run `bash scripts/verify-develop-issue-workflow.sh` after changing `skills/develop-issue/**`
 - Run `bash scripts/verify-finish-pr-workflow.sh` after changing `skills/finish-pr/**`
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
 - Run `bash scripts/verify-superteam-contract.sh` after changing `skills/superteam/**`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/superteam-non-interactive/`: deprecated CI-safe Superteam compatibility skill
 - `skills/using-github/`: using-github skill
 - `skills/new-branch/`: issue branch preparation skill
+- `skills/develop-issue/`: issue development orchestration skill
 - `skills/finish-pr/`: PR finishing skill
 - `skills/review-action/`: local AI review-action emulator skill
 - `skills/office-hours/`: office-hours skill
@@ -17,7 +18,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `.agents/skills/<name>/`: symlinks into `../../skills/<name>/` (dogfood overlay)
 - `.claude/skills/<name>/`: symlinks into `../../skills/<name>/` (Claude Code overlay)
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all ten skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eleven skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this repository
 - `docs/`: contributor docs such as `docs/file-structure.md` and
   `docs/release-flow.md`
@@ -49,7 +50,7 @@ This is a single-context repository; domain docs are optional and created lazily
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `pnpm test`: run the full local verification suite
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the ten skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the eleven skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -81,7 +82,7 @@ structure check; `writing-skills` is the workflow-contract quality gate.
 
 - Run `pnpm test` to run the full suite, or use the targeted commands below while iterating.
 - Validate paths with `find` or `rg`
-- Run `bash scripts/verify-dogfood.sh` to confirm all ten in-repo skills pass the flat-layout check
+- Run `bash scripts/verify-dogfood.sh` to confirm all eleven in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-esm-tooling.sh` after changing repo tooling configs or the package module type
 - Run `bash scripts/verify-finish-pr-workflow.sh` after changing `skills/finish-pr/**`
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
@@ -143,8 +144,9 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns ten skills at flat paths: `skills/scaffold-repository/`,
-`skills/using-github/`, `skills/new-branch/`, `skills/finish-pr/`,
+This repo owns eleven skills at flat paths: `skills/scaffold-repository/`,
+`skills/using-github/`, `skills/new-branch/`, `skills/develop-issue/`,
+`skills/finish-pr/`,
 `skills/review-action/`, `skills/office-hours/`, `skills/plan-ceo-review/`,
 `skills/install-skills/`, plus deprecated compatibility skills at
 `skills/superteam/` and `skills/superteam-non-interactive/`.
@@ -156,7 +158,7 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The ten in-repo skills share the single root `patinaproject-skills` release
+The eleven in-repo skills share the single root `patinaproject-skills` release
 and tag; they are not separate release-please packages. Deprecated Superteam
 skills remain in the release while they are kept for compatibility. Third-party
 skills such as `find-skills` are installed separately from their source repo's

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Skills used by the Patina Project team
 
-Ten installable agent skills for repository scaffolding, project-local skill
+Eleven installable agent skills for repository scaffolding, project-local skill
 installation, GitHub workflows, issue branch setup, PR finishing, local AI
-review-action emulation, product design, strategic plan review, and
+review-action emulation, issue development orchestration, product design,
+strategic plan review, and
 historical Superteam compatibility —
 available across Claude Code, Codex, and
 any agent runtime that reads `AGENTS.md`.
@@ -100,6 +101,17 @@ creating a PR.
 See [./skills/new-branch/](./skills/new-branch/)
 for the skill contract.
 
+### develop-issue
+
+End-to-end issue work needs a single entrypoint without weakening the focused
+skills that already own branch setup, test-driven implementation, diagnosis,
+local review, and PR finishing. `develop-issue` takes exactly one same-repo
+issue reference, coordinates `new-branch`, `tdd`, `diagnose`, `review-action`,
+and `finish-pr`, and stops for human-owned ambiguity instead of inventing scope.
+
+See [./skills/develop-issue/](./skills/develop-issue/)
+for the skill contract.
+
 ### finish-pr
 
 Finishing branch work is more than opening a pull request. `finish-pr` verifies
@@ -166,6 +178,7 @@ for the full README and skill contract.
 | [superteam-non-interactive](./skills/superteam-non-interactive/) | Deprecated CI-safe Superteam orchestration |
 | [using-github](./skills/using-github/) | Patina Project GitHub workflow conventions |
 | [new-branch](./skills/new-branch/) | Prepare local issue branches from the default branch |
+| [develop-issue](./skills/develop-issue/) | Develop one issue through local review and PR readiness |
 | [finish-pr](./skills/finish-pr/) | Finish completed branch work through ready-to-merge PRs |
 | [review-action](./skills/review-action/) | Emulate supported AI code-review actions locally |
 | [office-hours](./skills/office-hours/) | YC-style design partner; runs forcing questions |
@@ -199,7 +212,7 @@ npx skills@latest add ./skills/review-action --list
 bash scripts/verify-scaffold-cleanup.sh
 ```
 
-### Check c — dogfood verification, all ten skills
+### Check c — dogfood verification, all eleven skills
 
 ```sh
 bash scripts/verify-dogfood.sh
@@ -215,6 +228,7 @@ skills/
   superteam-non-interactive/
   using-github/
   new-branch/
+  develop-issue/
   finish-pr/
   review-action/
   office-hours/

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,7 +1,7 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and related install
-documentation. Ten skills live under `skills/<name>/` in a flat layout.
+documentation. Eleven skills live under `skills/<name>/` in a flat layout.
 
 ## Top level
 
@@ -10,15 +10,16 @@ documentation. Ten skills live under `skills/<name>/` in a flat layout.
 - `skills/superteam-non-interactive/`: deprecated CI-safe Superteam compatibility skill
 - `skills/using-github/`: using-github skill
 - `skills/new-branch/`: issue branch preparation skill
+- `skills/develop-issue/`: issue development orchestration skill
 - `skills/finish-pr/`: PR finishing skill
 - `skills/review-action/`: local AI code-review action emulator skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
 - `skills/install-skills/`: project-local skills CLI installation skill
-- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (ten in-repo)
-- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (ten in-repo)
+- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (eleven in-repo)
+- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (eleven in-repo)
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all ten skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eleven skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this
   repository
 - `skills-lock.json`: vercel-labs CLI install lockfile (auto-generated; commit it)
@@ -30,7 +31,7 @@ documentation. Ten skills live under `skills/<name>/` in a flat layout.
 
 ## Flat skill layout
 
-Ten skills are owned by this repository:
+Eleven skills are owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
@@ -39,6 +40,7 @@ Ten skills are owned by this repository:
 | `superteam-non-interactive` | `skills/superteam-non-interactive/` | Deprecated CI-safe historical orchestration |
 | `using-github` | `skills/using-github/` | GitHub workflow skill |
 | `new-branch` | `skills/new-branch/` | Issue branch preparation |
+| `develop-issue` | `skills/develop-issue/` | Issue development orchestration |
 | `finish-pr` | `skills/finish-pr/` | Ready-for-merge PR finishing |
 | `review-action` | `skills/review-action/` | Local AI code-review action emulation |
 | `office-hours` | `skills/office-hours/` | YC-style office hours for product ideation |
@@ -59,7 +61,7 @@ install-block reframes.
 
 ## Dogfood overlay layout
 
-The ten in-repo skills are also accessible through two overlay directories via one-hop
+The eleven in-repo skills are also accessible through two overlay directories via one-hop
 committed symlinks:
 
 | Overlay path | Symlink target | Mode |
@@ -70,7 +72,7 @@ committed symlinks:
 These symlinks allow the agent runtime to discover the in-repo skills alongside any
 third-party skills installed by the vercel-labs CLI.
 
-Third-party CLI-installed skills (including `find-skills`) are untracked; only the ten
+Third-party CLI-installed skills (including `find-skills`) are untracked; only the eleven
 in-repo overlay symlinks are committed.
 
 ## Symlink hygiene

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,11 +3,11 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Ten in-repo skills ship as
+Skills live flat at `skills/<name>/` in this repo. Eleven in-repo skills ship as
 `patinaproject-skills`: active skills `scaffold-repository`, `using-github`,
-`new-branch`, `finish-pr`, `review-action`, `office-hours`,
+`new-branch`, `develop-issue`, `finish-pr`, `review-action`, `office-hours`,
 `plan-ceo-review`, `install-skills`, plus deprecated compatibility skills `superteam` and
-`superteam-non-interactive`. All ten are
+`superteam-non-interactive`. All eleven are
 versioned together as a single marketplace surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
@@ -74,7 +74,7 @@ The vercel-labs CLI consumer pins a specific tag via `#<git-ref>`:
 npx skills@latest add patinaproject/skills#v1.0.0 --skill scaffold-repository
 ```
 
-The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all ten
+The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all eleven
 skills live under `skills/<name>/SKILL.md` in the same repo, one tag pins the full set.
 `skills-lock.json`'s `computedHash` records per-skill content provenance for reproducible
 re-installs within a given tag.
@@ -84,7 +84,7 @@ re-installs within a given tag.
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
 - In-repo skills (`scaffold-repository`, `using-github`, `new-branch`,
-  `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`,
+  `develop-issue`, `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`,
   `install-skills`, plus
   deprecated `superteam` and `superteam-non-interactive`) are not separate release-please packages;
   they share the single root `patinaproject-skills` release and tag.

--- a/scripts/install-third-party-skills.sh
+++ b/scripts/install-third-party-skills.sh
@@ -6,7 +6,7 @@
 # `pnpm skills:restore`). Idempotent — re-runs are a no-op when the skills
 # are already present.
 #
-# Why this script exists: the ten in-repo `patinaproject-skills` are tracked
+# Why this script exists: the eleven in-repo `patinaproject-skills` are tracked
 # in `skills/<name>/`; third-party skills from external skill catalogs are tracked
 # only as pinned entries in `skills-lock.json` to avoid bloating
 # `npx skills add patinaproject/skills` consumer installs with skills from
@@ -30,7 +30,7 @@ fi
 
 # `npx skills experimental_install` reads skills-lock.json and restores all
 # entries. The root lockfile records only third-party skills; in-repo skills
-# (the ten `patinaproject-skills`) are not in it.
+# (the eleven `patinaproject-skills`) are not in it.
 echo "install-third-party-skills: restoring vendored skills from skills-lock.json..."
 npx --yes skills@latest experimental_install --yes
 echo "install-third-party-skills: done"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,10 +13,16 @@ bash scripts/verify-workflow-cleanup.sh
 # CLI compatibility canaries: representative network-backed samples that prove
 # local skill paths are accepted by the current marketplace install protocol.
 run_cli_canary() {
+  local output
   if command -v timeout >/dev/null 2>&1; then
-    timeout 60 env npm_config_ignore_scripts=true npx skills@latest add "$1" --list
+    output="$(COLUMNS=240 timeout 60 env npm_config_ignore_scripts=true npx skills@latest add "$1" --list)"
   else
-    npm_config_ignore_scripts=true npx skills@latest add "$1" --list
+    output="$(COLUMNS=240 npm_config_ignore_scripts=true npx skills@latest add "$1" --list)"
+  fi
+  printf '%s\n' "$output"
+  if [ "${2:-}" != "" ] && ! printf '%s\n' "$output" | grep -Fq "$2"; then
+    echo "FAIL: CLI canary for '$1' did not display expected text: $2" >&2
+    return 1
   fi
 }
 
@@ -24,6 +30,7 @@ run_cli_canary ./skills/scaffold-repository
 run_cli_canary ./skills/install-skills
 run_cli_canary ./skills/office-hours
 run_cli_canary ./skills/review-action
+run_cli_canary ./skills/develop-issue '/develop-issue #123'
 
 run_cli_install_canary() {
   local repo_root tmpdir status

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,7 +30,7 @@ run_cli_canary() {
     output="$(COLUMNS=240 npm_config_ignore_scripts=true npx skills@latest add "$1" --list)"
   fi
   printf '%s\n' "$output"
-  if [ "${2:-}" != "" ] && ! printf '%s\n' "$output" | grep -Fq "$2"; then
+  if ! printf '%s\n' "$output" | grep -Fq "$2"; then
     echo "FAIL: CLI canary for '$1' did not display expected text: $2" >&2
     return 1
   fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 bash scripts/verify-dogfood.sh
+bash scripts/verify-develop-issue-workflow.sh
 bash scripts/verify-esm-tooling.sh
 bash scripts/verify-finish-pr-workflow.sh
 bash scripts/verify-marketplace.sh
@@ -14,6 +15,15 @@ bash scripts/verify-workflow-cleanup.sh
 # local skill paths are accepted by the current marketplace install protocol.
 run_cli_canary() {
   local output
+  if [ "${2:-}" = "" ]; then
+    if command -v timeout >/dev/null 2>&1; then
+      COLUMNS=240 timeout 60 env npm_config_ignore_scripts=true npx skills@latest add "$1" --list
+    else
+      COLUMNS=240 npm_config_ignore_scripts=true npx skills@latest add "$1" --list
+    fi
+    return
+  fi
+
   if command -v timeout >/dev/null 2>&1; then
     output="$(COLUMNS=240 timeout 60 env npm_config_ignore_scripts=true npx skills@latest add "$1" --list)"
   else

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,9 +25,9 @@ run_cli_canary() {
   fi
 
   if command -v timeout >/dev/null 2>&1; then
-    output="$(COLUMNS=240 timeout 60 env npm_config_ignore_scripts=true npx skills@latest add "$1" --list)"
+    output="$(COLUMNS=240 timeout 60 env npm_config_ignore_scripts=true npx skills@latest add "$1" --list 2>&1)"
   else
-    output="$(COLUMNS=240 npm_config_ignore_scripts=true npx skills@latest add "$1" --list)"
+    output="$(COLUMNS=240 npm_config_ignore_scripts=true npx skills@latest add "$1" --list 2>&1)"
   fi
   printf '%s\n' "$output"
   if ! printf '%s\n' "$output" | grep -Fq "$2"; then

--- a/scripts/verify-develop-issue-workflow.sh
+++ b/scripts/verify-develop-issue-workflow.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SKILL="skills/develop-issue/SKILL.md"
+FAIL_COUNT=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_file() {
+  local file="$1"
+  test -f "$file" || fail "missing expected file: $file"
+}
+
+assert_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! rg -n --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "missing expected pattern in $file: $pattern"
+  fi
+}
+
+assert_no_match() {
+  local pattern="$1"
+  local file="$2"
+  if rg -n --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "unexpected pattern in $file: $pattern"
+  fi
+}
+
+assert_order() {
+  local first_pattern="$1"
+  local second_pattern="$2"
+  local file="$3"
+  local first_line second_line
+  first_line="$(rg -n --pcre2 -e "$first_pattern" "$file" | head -n 1 | cut -d: -f1 || true)"
+  second_line="$(rg -n --pcre2 -e "$second_pattern" "$file" | head -n 1 | cut -d: -f1 || true)"
+  if [ -z "$first_line" ] || [ -z "$second_line" ] || [ "$first_line" -ge "$second_line" ]; then
+    fail "expected pattern '$first_pattern' before '$second_pattern' in $file"
+  fi
+}
+
+assert_file "$SKILL"
+
+if [ -f "$SKILL" ]; then
+  assert_match '^name:[[:space:]]*develop-issue$' "$SKILL"
+  assert_match '/develop-issue #123' "$SKILL"
+
+  for child in new-branch tdd diagnose review-action finish-pr; do
+    assert_match "\`$child\`" "$SKILL"
+  done
+
+  assert_match 'Reject missing issue references' "$SKILL"
+  assert_match 'Reject multiple issue references' "$SKILL"
+  assert_match 'Reject cross-repository issue URLs' "$SKILL"
+  assert_match 'same-repository GitHub issue' "$SKILL"
+  assert_match 'halt before implementation' "$SKILL"
+  assert_match 'Read `AGENTS\.md` and `CLAUDE\.md` if present' "$SKILL"
+  assert_match 'Delegate branch setup to `new-branch`' "$SKILL"
+  assert_match 'Implement one behavior at a time through `tdd`' "$SKILL"
+  assert_match 'Route to `diagnose` when root cause is unclear' "$SKILL"
+  assert_match 'Run `review-action` as the local review gate' "$SKILL"
+  assert_match 'Delegate final publishing and PR readiness to `finish-pr`' "$SKILL"
+  assert_match 'Never merge the pull request' "$SKILL"
+
+  assert_order 'Delegate branch setup to `new-branch`' 'Implement one behavior at a time through `tdd`' "$SKILL"
+  assert_order 'Run `review-action` as the local review gate' 'Delegate final publishing and PR readiness to `finish-pr`' "$SKILL"
+
+  for outcome in ready-for-agent ready-for-human wontfix; do
+    assert_match "\`$outcome\`" "$SKILL"
+  done
+  assert_match 'There is no `needs-info` state' "$SKILL"
+  assert_no_match 'receiving-code-review' "$SKILL"
+fi
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "" >&2
+  echo "FAIL: $FAIL_COUNT develop-issue workflow assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "OK: develop-issue workflow assertions passed"

--- a/scripts/verify-dogfood.sh
+++ b/scripts/verify-dogfood.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# verify-dogfood.sh — Asserts that all ten in-repo skills are discoverable
+# verify-dogfood.sh — Asserts that all eleven in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
-# Exit 0: all ten skills pass all assertions.
+# Exit 0: all eleven skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -19,6 +19,7 @@ SKILLS=(
   superteam-non-interactive
   using-github
   new-branch
+  develop-issue
   finish-pr
   review-action
   office-hours
@@ -123,5 +124,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all ten in-repo skills discoverable via flat layout"
+echo "OK: all eleven in-repo skills discoverable via flat layout"
 exit 0

--- a/scripts/verify-marketplace.sh
+++ b/scripts/verify-marketplace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/finish-pr","./skills/review-action","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
+expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/review-action","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
 
 # Validate the Claude Code marketplace catalog.
 test -f .claude-plugin/marketplace.json

--- a/skills/develop-issue/SKILL.md
+++ b/skills/develop-issue/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: develop-issue
+description: "Orchestrate same-repository GitHub issue work from branch setup through local review and PR readiness. Use when the user invokes `/develop-issue #123`, `/develop-issue https://github.com/<owner>/<repo>/issues/123`, or asks to develop exactly one issue end to end."
+---
+
+# Develop Issue
+
+## Quick Start
+
+Invoke with exactly one same-repository GitHub issue reference:
+
+```text
+/develop-issue #123
+```
+
+This skill coordinates existing workflow skills. It does not replace their
+contracts, loosen their guardrails, or merge pull requests.
+
+## Required Child Skills
+
+Before branch setup or implementation, confirm these installed skills are
+available in the agent environment:
+
+- `new-branch`
+- `tdd`
+- `diagnose`
+- `review-action`
+- `finish-pr`
+
+If any are missing, halt before implementation. Report the missing skill names
+and install guidance:
+
+```sh
+npm_config_ignore_scripts=true npx skills@latest add patinaproject/skills --skill new-branch --skill review-action --skill finish-pr -y
+npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@tdd -y
+npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@diagnose -y
+```
+
+## Input Contract
+
+1. Accept one bare issue number, `#<number>`, or same-repository GitHub issue
+   URL.
+2. Reject missing issue references.
+3. Reject multiple issue references.
+4. Reject cross-repository issue URLs.
+5. Resolve the issue through the current working directory's default `gh`
+   repository.
+6. Treat the issue as prior approval for implementation only when acceptance
+   criteria, scope, repository rules, and design decisions are actionable.
+
+Pause for a human when the issue lacks actionable acceptance criteria, conflicts
+with repository rules, requires a design decision, depends on external access,
+or otherwise needs judgment not recorded in the issue.
+
+## Workflow
+
+1. Read `AGENTS.md` and `CLAUDE.md` if present, plus any docs they import.
+2. Validate the single same-repository issue reference and required child skills.
+3. Delegate branch setup to `new-branch`; inherit every halt.
+4. Implement one behavior at a time through `tdd`.
+5. Route to `diagnose` when root cause is unclear, reproduction is missing,
+   behavior is flaky, or performance has regressed.
+6. Run repository-documented verification before local review.
+7. Run `review-action` as the local review gate; inherit its read-only boundary
+   and unsupported-workflow halts.
+8. Triage every local review finding with the router below.
+9. Repeat implementation, verification, and `review-action` until no actionable
+   local findings remain or a human-owned blocker appears.
+10. Delegate final publishing and PR readiness to `finish-pr`; inherit every
+    halt. Never merge the pull request.
+
+## Review Finding Router
+
+Classify findings into exactly one of these outcomes:
+
+| Outcome | Use When | Next Action |
+|---|---|---|
+| `ready-for-agent` | The expected behavior is clear or evidence can be gathered locally | Route clear behavior changes to `tdd`; route unclear root cause, missing reproduction, flaky behavior, or performance regression to `diagnose` |
+| `ready-for-human` | The finding needs judgment, external access, manual testing, design input, missing information, or changed scope | Stop the loop and report the blocker with evidence checked |
+| `wontfix` | The finding is stale, incorrect, outside the issue, or conflicts with repository rules | Explain politely in the report; add code comments only when intentional code would otherwise look non-obvious |
+
+There is no `needs-info` state in v1. Insufficient information maps to
+`ready-for-human`.
+
+## Final Report
+
+When the workflow stops, report:
+
+- Issue reference and URL
+- Branch name
+- Child skills invoked, with halt reason if any
+- Verification commands and results
+- Latest `review-action` result
+- Human-owned blockers, if any
+- `wontfix` explanations, if any
+- PR URL and readiness status, when `finish-pr` runs

--- a/skills/develop-issue/SKILL.md
+++ b/skills/develop-issue/SKILL.md
@@ -11,6 +11,7 @@ Invoke with exactly one same-repository GitHub issue reference:
 
 ```text
 /develop-issue #123
+/develop-issue https://github.com/<owner>/<repo>/issues/123
 ```
 
 This skill coordinates existing workflow skills. It does not replace their

--- a/skills/develop-issue/SKILL.md
+++ b/skills/develop-issue/SKILL.md
@@ -36,6 +36,10 @@ npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@tdd -y
 npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@diagnose -y
 ```
 
+The `tdd` and `diagnose` install hints intentionally track their source
+catalog's default branch. Consumers who need a frozen install can add
+`#<git-ref>` to either source.
+
 ## Input Contract
 
 1. Accept one bare issue number, `#<number>`, or same-repository GitHub issue


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #138

## What changed

Context: standalone - issue #138 defines the new explicit issue-development workflow skill.

- Added `develop-issue` as the eleventh in-repo marketplace skill - gives agents a single issue-based entrypoint that delegates to branch setup, TDD, diagnosis, local review, and PR finishing without replacing those child contracts.
- Updated Claude and Codex marketplace/plugin manifests plus dogfood overlays - makes `develop-issue` discoverable across supported hosts.
- Updated catalog docs and verifiers from ten to eleven skills - keeps install docs, release docs, dogfood checks, marketplace checks, and CLI canaries aligned with the shipped catalog.

## Verification

- `bash scripts/verify-dogfood.sh` — passed; all eleven in-repo skills resolve from canonical paths and overlays.
- `bash scripts/verify-marketplace.sh` — passed; Claude and Codex skill arrays match and include `develop-issue`.
- `git diff --check` — passed.
- `pnpm test` — passed, including the new `/develop-issue #123` CLI description canary.
- Local `review-action` emulation via `claude --print` against `origin/main` — passed on rerun with no actionable findings.
- `pnpm lint:md` — failed on pre-existing `CHANGELOG.md` MD012 blank-line errors at lines 5, 12, and 19; this branch does not modify `CHANGELOG.md`.
