### PR TITLE
feat: #143 add isolated review-code skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "description": "Patina Project workflow skills, including develop-issue, install-skills, and deprecated Superteam compatibility skills."
+      "description": "Patina Project workflow skills, including develop-issue, review-code, install-skills, and deprecated Superteam compatibility skills."
     }
   ]
 }

--- a/.agents/skills/review-code
+++ b/.agents/skills/review-code
@@ -1,0 +1,1 @@
+../../skills/review-code

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, develop-issue, finish-pr, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
+      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, develop-issue, finish-pr, review-code, review-action, office-hours, plan-ceo-review, install-skills, plus deprecated Superteam compatibility skills",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
     "./skills/new-branch",
     "./skills/develop-issue",
     "./skills/finish-pr",
+    "./skills/review-code",
     "./skills/review-action",
     "./skills/office-hours",
     "./skills/plan-ceo-review",

--- a/.claude/skills/review-code
+++ b/.claude/skills/review-code
@@ -1,0 +1,1 @@
+../../skills/review-code

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,6 +7,7 @@
     "./skills/new-branch",
     "./skills/develop-issue",
     "./skills/finish-pr",
+    "./skills/review-code",
     "./skills/review-action",
     "./skills/office-hours",
     "./skills/plan-ceo-review",

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -49,7 +49,7 @@ jobs:
           reviewable=false
           while IFS= read -r file; do
             case "$file" in
-              ""|CHANGELOG.md|pnpm-lock.yaml|package-lock.json|yarn.lock|bun.lockb|docs/superpowers/*)
+              ""|CHANGELOG.md|pnpm-lock.yaml|package-lock.json|yarn.lock|bun.lockb)
                 ;;
               *.lock|*.lockb|*.snap|*.png|*.jpg|*.jpeg|*.gif|*.webp|*.svg)
                 ;;

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -24,7 +24,6 @@ jobs:
             **/*.md
             #node_modules
             #CHANGELOG.md
-            #docs/superpowers/**
             #skills/**
             #.agents/skills/**
             #.claude/skills/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-docs/superpowers/plans/.artifacts/
 
 # Third-party skills (installed via `npx skills add` on demand) are not
 # committed to the repo. The pnpm `postinstall` script restores them from

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ docs/superpowers/plans/.artifacts/
 
 # Third-party skills (installed via `npx skills add` on demand) are not
 # committed to the repo. The pnpm `postinstall` script restores them from
-# `skills-lock.json` so editors get them after `pnpm install`. Only the nine
+# `skills-lock.json` so editors get them after `pnpm install`. Only the twelve
 # in-repo `patinaproject-skills` overlay symlinks are tracked.
 .agents/skills/*
 !.agents/skills/scaffold-repository
@@ -11,17 +11,23 @@ docs/superpowers/plans/.artifacts/
 !.agents/skills/superteam-non-interactive
 !.agents/skills/using-github
 !.agents/skills/new-branch
+!.agents/skills/develop-issue
 !.agents/skills/finish-pr
+!.agents/skills/review-code
 !.agents/skills/review-action
 !.agents/skills/office-hours
 !.agents/skills/plan-ceo-review
+!.agents/skills/install-skills
 .claude/skills/*
 !.claude/skills/scaffold-repository
 !.claude/skills/superteam
 !.claude/skills/superteam-non-interactive
 !.claude/skills/using-github
 !.claude/skills/new-branch
+!.claude/skills/develop-issue
 !.claude/skills/finish-pr
+!.claude/skills/review-code
 !.claude/skills/review-action
 !.claude/skills/office-hours
 !.claude/skills/plan-ceo-review
+!.claude/skills/install-skills

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,13 +1,12 @@
 // Lint-staged configuration
-// Filters out vendored skill files, canonical skill overlay files (from
-// external sources), and superpowers artifacts from markdownlint so each
-// source can use its own markdownlint config without conflicting with ours.
+// Filters out vendored skill files and canonical skill overlay files (from
+// external sources) so each source can use its own markdownlint config without
+// conflicting with ours.
 export default {
   "*.md": (files) => {
     const filtered = files.filter(
       (f) =>
         !f.includes("/skills/") &&
-        !f.includes("/docs/superpowers/") &&
         !f.includes("/.agents/skills/") &&
         !f.includes("/.claude/skills/")
     );

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -2,8 +2,6 @@ node_modules/
 pnpm-lock.yaml
 dist/
 build/
-docs/superpowers/plans/
-docs/superpowers/specs/
 skills/
 .agents/skills/
 .claude/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/new-branch/`: issue branch preparation skill
 - `skills/develop-issue/`: issue development orchestration skill
 - `skills/finish-pr/`: PR finishing skill
+- `skills/review-code/`: isolated local branch-diff review skill
 - `skills/review-action/`: local AI review-action emulator skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
@@ -18,7 +19,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `.agents/skills/<name>/`: symlinks into `../../skills/<name>/` (dogfood overlay)
 - `.claude/skills/<name>/`: symlinks into `../../skills/<name>/` (Claude Code overlay)
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eleven skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all twelve skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this repository
 - `docs/`: contributor docs such as `docs/file-structure.md` and
   `docs/release-flow.md`
@@ -50,7 +51,7 @@ This is a single-context repository; domain docs are optional and created lazily
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `pnpm test`: run the full local verification suite
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the eleven skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the twelve skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -82,11 +83,12 @@ structure check; `writing-skills` is the workflow-contract quality gate.
 
 - Run `pnpm test` to run the full suite, or use the targeted commands below while iterating.
 - Validate paths with `find` or `rg`
-- Run `bash scripts/verify-dogfood.sh` to confirm all eleven in-repo skills pass the flat-layout check
+- Run `bash scripts/verify-dogfood.sh` to confirm all twelve in-repo skills pass the flat-layout check
 - Run `bash scripts/verify-esm-tooling.sh` after changing repo tooling configs or the package module type
 - Run `bash scripts/verify-develop-issue-workflow.sh` after changing `skills/develop-issue/**`
 - Run `bash scripts/verify-finish-pr-workflow.sh` after changing `skills/finish-pr/**`
 - Run `bash scripts/verify-marketplace.sh` to confirm the `.claude-plugin/` catalog is valid
+- Run `bash scripts/verify-review-code-skill.sh` after changing `skills/review-code/**`
 - Run `bash scripts/verify-review-action-skill.sh` after changing `skills/review-action/**`
 - Run `bash scripts/verify-superteam-contract.sh` after changing `skills/superteam/**`
 - Run `bash scripts/verify-code-review-workflow.sh` after changing `.github/workflows/code-review.yml`
@@ -146,9 +148,9 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns eleven skills at flat paths: `skills/scaffold-repository/`,
+This repo owns twelve skills at flat paths: `skills/scaffold-repository/`,
 `skills/using-github/`, `skills/new-branch/`, `skills/develop-issue/`,
-`skills/finish-pr/`,
+`skills/finish-pr/`, `skills/review-code/`,
 `skills/review-action/`, `skills/office-hours/`, `skills/plan-ceo-review/`,
 `skills/install-skills/`, plus deprecated compatibility skills at
 `skills/superteam/` and `skills/superteam-non-interactive/`.
@@ -160,7 +162,7 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The eleven in-repo skills share the single root `patinaproject-skills` release
+The twelve in-repo skills share the single root `patinaproject-skills` release
 and tag; they are not separate release-please packages. Deprecated Superteam
 skills remain in the release while they are kept for compatibility. Third-party
 skills such as `find-skills` are installed separately from their source repo's

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Skills used by the Patina Project team
 
-Eleven installable agent skills for repository scaffolding, project-local skill
+Twelve installable agent skills for repository scaffolding, project-local skill
 installation, GitHub workflows, issue branch setup, PR finishing, local AI
-review-action emulation, issue development orchestration, product design,
-strategic plan review, and
+isolated code review, hosted-review emulation, issue development
+orchestration, product design, strategic plan review, and
 historical Superteam compatibility —
 available across Claude Code, Codex, and
 any agent runtime that reads `AGENTS.md`.
@@ -106,10 +106,21 @@ for the skill contract.
 End-to-end issue work needs a single entrypoint without weakening the focused
 skills that already own branch setup, test-driven implementation, diagnosis,
 local review, and PR finishing. `develop-issue` takes exactly one same-repo
-issue reference, coordinates `new-branch`, `tdd`, `diagnose`, `review-action`,
+issue reference, coordinates `new-branch`, `tdd`, `diagnose`, `review-code`,
 and `finish-pr`, and stops for human-owned ambiguity instead of inventing scope.
 
 See [./skills/develop-issue/](./skills/develop-issue/)
+for the skill contract.
+
+### review-code
+
+Local issue work needs a fresh review pass before publishing. `review-code`
+computes the default-branch merge-base, includes committed, staged, unstaged,
+and untracked changes, then dispatches a fresh read-only reviewer to report
+findings without editing files or mutating GitHub state. It halts when isolated
+review dispatch is unavailable.
+
+See [./skills/review-code/](./skills/review-code/)
 for the skill contract.
 
 ### finish-pr
@@ -180,6 +191,7 @@ for the full README and skill contract.
 | [new-branch](./skills/new-branch/) | Prepare local issue branches from the default branch |
 | [develop-issue](./skills/develop-issue/) | Develop one issue through local review and PR readiness |
 | [finish-pr](./skills/finish-pr/) | Finish completed branch work through ready-to-merge PRs |
+| [review-code](./skills/review-code/) | Run isolated local branch-diff review |
 | [review-action](./skills/review-action/) | Emulate supported AI code-review actions locally |
 | [office-hours](./skills/office-hours/) | YC-style design partner; runs forcing questions |
 | [plan-ceo-review](./skills/plan-ceo-review/) | Founder-mode review for existing plans |
@@ -203,6 +215,7 @@ pnpm test
 npx skills@latest add ./skills/scaffold-repository --list
 npx skills@latest add ./skills/install-skills --list
 npx skills@latest add ./skills/office-hours --list
+npx skills@latest add ./skills/review-code --list
 npx skills@latest add ./skills/review-action --list
 ```
 
@@ -212,7 +225,7 @@ npx skills@latest add ./skills/review-action --list
 bash scripts/verify-scaffold-cleanup.sh
 ```
 
-### Check c — dogfood verification, all eleven skills
+### Check c — dogfood verification, all twelve skills
 
 ```sh
 bash scripts/verify-dogfood.sh
@@ -230,6 +243,7 @@ skills/
   new-branch/
   develop-issue/
   finish-pr/
+  review-code/
   review-action/
   office-hours/
   plan-ceo-review/

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,7 +1,7 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and related install
-documentation. Eleven skills live under `skills/<name>/` in a flat layout.
+documentation. Twelve skills live under `skills/<name>/` in a flat layout.
 
 ## Top level
 
@@ -12,14 +12,15 @@ documentation. Eleven skills live under `skills/<name>/` in a flat layout.
 - `skills/new-branch/`: issue branch preparation skill
 - `skills/develop-issue/`: issue development orchestration skill
 - `skills/finish-pr/`: PR finishing skill
+- `skills/review-code/`: isolated local branch-diff review skill
 - `skills/review-action/`: local AI code-review action emulator skill
 - `skills/office-hours/`: office-hours skill
 - `skills/plan-ceo-review/`: plan-ceo-review skill
 - `skills/install-skills/`: project-local skills CLI installation skill
-- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (eleven in-repo)
-- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (eleven in-repo)
+- `.agents/skills/<name>/`: committed symlinks into `../../skills/<name>/` (twelve in-repo)
+- `.claude/skills/<name>/`: committed symlinks into `../../skills/<name>/` (twelve in-repo)
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eleven skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing all twelve skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this
   repository
 - `skills-lock.json`: vercel-labs CLI install lockfile (auto-generated; commit it)
@@ -31,7 +32,7 @@ documentation. Eleven skills live under `skills/<name>/` in a flat layout.
 
 ## Flat skill layout
 
-Eleven skills are owned by this repository:
+Twelve skills are owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
@@ -42,6 +43,7 @@ Eleven skills are owned by this repository:
 | `new-branch` | `skills/new-branch/` | Issue branch preparation |
 | `develop-issue` | `skills/develop-issue/` | Issue development orchestration |
 | `finish-pr` | `skills/finish-pr/` | Ready-for-merge PR finishing |
+| `review-code` | `skills/review-code/` | Isolated local branch-diff review |
 | `review-action` | `skills/review-action/` | Local AI code-review action emulation |
 | `office-hours` | `skills/office-hours/` | YC-style office hours for product ideation |
 | `plan-ceo-review` | `skills/plan-ceo-review/` | Founder-mode review for existing plans |
@@ -61,7 +63,7 @@ install-block reframes.
 
 ## Dogfood overlay layout
 
-The eleven in-repo skills are also accessible through two overlay directories via one-hop
+The twelve in-repo skills are also accessible through two overlay directories via one-hop
 committed symlinks:
 
 | Overlay path | Symlink target | Mode |
@@ -72,7 +74,7 @@ committed symlinks:
 These symlinks allow the agent runtime to discover the in-repo skills alongside any
 third-party skills installed by the vercel-labs CLI.
 
-Third-party CLI-installed skills (including `find-skills`) are untracked; only the eleven
+Third-party CLI-installed skills (including `find-skills`) are untracked; only the twelve
 in-repo overlay symlinks are committed.
 
 ## Symlink hygiene

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,11 +3,11 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Eleven in-repo skills ship as
+Skills live flat at `skills/<name>/` in this repo. Twelve in-repo skills ship as
 `patinaproject-skills`: active skills `scaffold-repository`, `using-github`,
-`new-branch`, `develop-issue`, `finish-pr`, `review-action`, `office-hours`,
-`plan-ceo-review`, `install-skills`, plus deprecated compatibility skills `superteam` and
-`superteam-non-interactive`. All eleven are
+`new-branch`, `develop-issue`, `finish-pr`, `review-code`, `review-action`,
+`office-hours`, `plan-ceo-review`, `install-skills`, plus deprecated compatibility skills
+`superteam` and `superteam-non-interactive`. All twelve are
 versioned together as a single marketplace surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
@@ -74,7 +74,7 @@ The vercel-labs CLI consumer pins a specific tag via `#<git-ref>`:
 npx skills@latest add patinaproject/skills#v1.0.0 --skill scaffold-repository
 ```
 
-The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all eleven
+The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all twelve
 skills live under `skills/<name>/SKILL.md` in the same repo, one tag pins the full set.
 `skills-lock.json`'s `computedHash` records per-skill content provenance for reproducible
 re-installs within a given tag.
@@ -84,8 +84,8 @@ re-installs within a given tag.
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
 - In-repo skills (`scaffold-repository`, `using-github`, `new-branch`,
-  `develop-issue`, `finish-pr`, `review-action`, `office-hours`, `plan-ceo-review`,
-  `install-skills`, plus
+  `develop-issue`, `finish-pr`, `review-code`, `review-action`, `office-hours`,
+  `plan-ceo-review`, `install-skills`, plus
   deprecated `superteam` and `superteam-non-interactive`) are not separate release-please packages;
   they share the single root `patinaproject-skills` release and tag.
   Third-party skills such as `find-skills` are installed separately from their

--- a/scripts/install-third-party-skills.sh
+++ b/scripts/install-third-party-skills.sh
@@ -6,7 +6,7 @@
 # `pnpm skills:restore`). Idempotent — re-runs are a no-op when the skills
 # are already present.
 #
-# Why this script exists: the eleven in-repo `patinaproject-skills` are tracked
+# Why this script exists: the twelve in-repo `patinaproject-skills` are tracked
 # in `skills/<name>/`; third-party skills from external skill catalogs are tracked
 # only as pinned entries in `skills-lock.json` to avoid bloating
 # `npx skills add patinaproject/skills` consumer installs with skills from
@@ -30,7 +30,7 @@ fi
 
 # `npx skills experimental_install` reads skills-lock.json and restores all
 # entries. The root lockfile records only third-party skills; in-repo skills
-# (the eleven `patinaproject-skills`) are not in it.
+# (the twelve `patinaproject-skills`) are not in it.
 echo "install-third-party-skills: restoring vendored skills from skills-lock.json..."
 npx --yes skills@latest experimental_install --yes
 echo "install-third-party-skills: done"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,7 @@ bash scripts/verify-develop-issue-workflow.sh
 bash scripts/verify-esm-tooling.sh
 bash scripts/verify-finish-pr-workflow.sh
 bash scripts/verify-marketplace.sh
+bash scripts/verify-review-code-skill.sh
 bash scripts/verify-review-action-skill.sh
 bash scripts/verify-scaffold-cleanup.sh
 bash scripts/verify-superteam-contract.sh
@@ -40,6 +41,7 @@ run_cli_canary() {
 run_cli_canary ./skills/scaffold-repository
 run_cli_canary ./skills/install-skills
 run_cli_canary ./skills/office-hours
+run_cli_canary ./skills/review-code
 run_cli_canary ./skills/review-action
 run_cli_canary ./skills/develop-issue '/develop-issue #123'
 

--- a/scripts/verify-develop-issue-workflow.sh
+++ b/scripts/verify-develop-issue-workflow.sh
@@ -51,9 +51,10 @@ if [ -f "$SKILL" ]; then
   assert_match '^name:[[:space:]]*develop-issue$' "$SKILL"
   assert_match '/develop-issue #123' "$SKILL"
 
-  for child in new-branch tdd diagnose review-action finish-pr; do
+  for child in new-branch tdd diagnose review-code finish-pr; do
     assert_match "\`$child\`" "$SKILL"
   done
+  assert_match '\`review-action\` remains available separately' "$SKILL"
 
   assert_match 'Reject missing issue references' "$SKILL"
   assert_match 'Reject multiple issue references' "$SKILL"
@@ -64,12 +65,12 @@ if [ -f "$SKILL" ]; then
   assert_match 'Delegate branch setup to `new-branch`' "$SKILL"
   assert_match 'Implement one behavior at a time through `tdd`' "$SKILL"
   assert_match 'Route to `diagnose` when root cause is unclear' "$SKILL"
-  assert_match 'Run `review-action` as the local review gate' "$SKILL"
+  assert_match 'Run `review-code` as the local review gate' "$SKILL"
   assert_match 'Delegate final publishing and PR readiness to `finish-pr`' "$SKILL"
   assert_match 'Never merge the pull request' "$SKILL"
 
   assert_order 'Delegate branch setup to `new-branch`' 'Implement one behavior at a time through `tdd`' "$SKILL"
-  assert_order 'Run `review-action` as the local review gate' 'Delegate final publishing and PR readiness to `finish-pr`' "$SKILL"
+  assert_order 'Run `review-code` as the local review gate' 'Delegate final publishing and PR readiness to `finish-pr`' "$SKILL"
 
   for outcome in ready-for-agent ready-for-human wontfix; do
     assert_match "\`$outcome\`" "$SKILL"

--- a/scripts/verify-dogfood.sh
+++ b/scripts/verify-dogfood.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# verify-dogfood.sh — Asserts that all eleven in-repo skills are discoverable
+# verify-dogfood.sh — Asserts that all twelve in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
-# Exit 0: all eleven skills pass all assertions.
+# Exit 0: all twelve skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -21,6 +21,7 @@ SKILLS=(
   new-branch
   develop-issue
   finish-pr
+  review-code
   review-action
   office-hours
   plan-ceo-review
@@ -124,5 +125,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all eleven in-repo skills discoverable via flat layout"
+echo "OK: all twelve in-repo skills discoverable via flat layout"
 exit 0

--- a/scripts/verify-marketplace.sh
+++ b/scripts/verify-marketplace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/review-action","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
+expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/review-code","./skills/review-action","./skills/office-hours","./skills/plan-ceo-review","./skills/install-skills","./skills/superteam","./skills/superteam-non-interactive"]'
 
 # Validate the Claude Code marketplace catalog.
 test -f .claude-plugin/marketplace.json

--- a/scripts/verify-review-code-skill.sh
+++ b/scripts/verify-review-code-skill.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SKILL="skills/review-code/SKILL.md"
+FAIL_COUNT=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! rg -n --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "missing expected pattern in $file: $pattern"
+  fi
+}
+
+assert_no_match() {
+  local pattern="$1"
+  local file="$2"
+  if rg -n --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "unexpected pattern in $file: $pattern"
+  fi
+}
+
+test -f "$SKILL" || fail "missing expected file: $SKILL"
+
+if [ -f "$SKILL" ]; then
+  assert_match '^name:[[:space:]]*review-code$' "$SKILL"
+  assert_match 'fresh-context reviewer' "$SKILL"
+  assert_match 'read-only Explorer or reviewer background agent' "$SKILL"
+  assert_match 'If fresh reviewer dispatch is unavailable, halt' "$SKILL"
+  assert_match 'Do not fall back to same-thread review' "$SKILL"
+  assert_match 'read-only and findings-only' "$SKILL"
+  assert_match 'Do not edit files, stage changes, commit, push, create pull requests, post GitHub comments, or mutate review threads' "$SKILL"
+  assert_match 'merge-base' "$SKILL"
+  assert_match 'defaultBranchRef --jq \.defaultBranchRef\.name' "$SKILL"
+  assert_match 'Normalize the fallback by stripping the leading' "$SKILL"
+  assert_match 'git remote set-head origin --auto' "$SKILL"
+  assert_match 'Do not update refs during' "$SKILL"
+  assert_match 'git rev-parse --verify origin/<default-branch>' "$SKILL"
+  assert_match 'gh repo view --json nameWithOwner --jq' "$SKILL"
+  assert_match '\.nameWithOwner' "$SKILL"
+  assert_match 'gh api repos' "$SKILL"
+  assert_match '--jq \.commit\.sha' "$SKILL"
+  assert_match 'freshness is unverified' "$SKILL"
+  assert_match 'Freshness unverified: gh unavailable; reviewed current' "$SKILL"
+  assert_no_match 'git fetch' "$SKILL"
+  assert_match 'staged, unstaged, and untracked' "$SKILL"
+  assert_match 'Load repository instructions' "$SKILL"
+  assert_match 'generated files, lockfiles, vendored files, and dogfood overlay paths' "$SKILL"
+  assert_match 'Group findings by severity' "$SKILL"
+  assert_match 'file and line reference' "$SKILL"
+  assert_match 'rationale' "$SKILL"
+  assert_match 'suggested fix' "$SKILL"
+  assert_match '## Distinction From Hosted Review' "$SKILL"
+  assert_match '`review-action`' "$SKILL"
+  assert_match '`code-review\.yml`' "$SKILL"
+  assert_no_match 'repository-local helper script' "$SKILL"
+fi
+
+node --input-type=module <<'NODE'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+assert.equal(
+  Object.hasOwn(packageJson.scripts, "review-code"),
+  false,
+  "review-code must remain a portable skill, not a package helper script",
+);
+NODE
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "" >&2
+  echo "FAIL: $FAIL_COUNT review-code skill assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "OK: review-code skill assertions passed"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -43,12 +43,6 @@
       "skillPath": "plugins/plugin-dev/skills/skill-development/SKILL.md",
       "computedHash": "8d262f08f33825947ea20204ebf5101e36056c98090251bd973a552ec8ef0c0c"
     },
-    "brainstorming": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/brainstorming/SKILL.md",
-      "computedHash": "8df9b47092524833138b58682d03f2e153a242e550d1693657afdbee0cc9cdb0"
-    },
     "caveman": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -67,29 +61,11 @@
       "skillPath": "skills/engineering/diagnose/SKILL.md",
       "computedHash": "15939a26f86edec2d4862042b8564e5a062cb81d04e047a0cea6305c8830b5f5"
     },
-    "dispatching-parallel-agents": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/dispatching-parallel-agents/SKILL.md",
-      "computedHash": "e21044ae7496fc285f1df9ff3fb518a3a20bea6f5216c1f59f4987e12c769a0a"
-    },
-    "executing-plans": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/executing-plans/SKILL.md",
-      "computedHash": "b41c919caf1bb07fbacb0e29899ac513f9eb11cd4dd695975ad352c2c03cc4d7"
-    },
     "find-skills": {
       "source": "vercel-labs/skills",
       "sourceType": "github",
       "skillPath": "skills/find-skills/SKILL.md",
       "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
-    },
-    "finishing-a-development-branch": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/finishing-a-development-branch/SKILL.md",
-      "computedHash": "932d23af11a3eb2b758f5b1d9aec7b6d28ddd26658328414f87f34dff7179d19"
     },
     "grill-me": {
       "source": "mattpocock/skills",
@@ -133,18 +109,6 @@
       "skillPath": "skills/engineering/prototype/SKILL.md",
       "computedHash": "e4d0c8f8cb3fc096ee99405a15491da466545cf4a3694bee5a0c9db2fa621a43"
     },
-    "receiving-code-review": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/receiving-code-review/SKILL.md",
-      "computedHash": "2760c85d4f4117b0006e7ba755f4bbd61f8f4c185f347999763c97f507274e30"
-    },
-    "requesting-code-review": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/requesting-code-review/SKILL.md",
-      "computedHash": "874f3786b05007a8b4a60452a4cd89b9917c645d34b6b1e40ea05037d12f0e67"
-    },
     "setup-matt-pocock-skills": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -163,29 +127,11 @@
       "skillPath": "skills/.system/skill-installer/SKILL.md",
       "computedHash": "44e8f0fda4a4aff2b98ae8587ceb812c15e7e5dba230f16295017c2f416f6d05"
     },
-    "subagent-driven-development": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/subagent-driven-development/SKILL.md",
-      "computedHash": "b38be2f3a092d758127f6d47e77c2493885aebf38aae359e4c786df2c343b837"
-    },
-    "systematic-debugging": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/systematic-debugging/SKILL.md",
-      "computedHash": "7246fdd3a795fc3daff0af72044ca99bf836e4e6a46844742858786fdfb86488"
-    },
     "tdd": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/tdd/SKILL.md",
       "computedHash": "15a7b5e36383ebadb2dec5e586679e55e9663d292da418926b8da6fc0ef27d84"
-    },
-    "test-driven-development": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/test-driven-development/SKILL.md",
-      "computedHash": "126f1ebf6ccd414f42544f6e83d8cc5adb089e1108eaffb7c400701e37eecd9f"
     },
     "to-issues": {
       "source": "mattpocock/skills",
@@ -205,41 +151,11 @@
       "skillPath": "skills/engineering/triage/SKILL.md",
       "computedHash": "2b6efb6da12d92551772fcc04acf331f4e0e6f7bd9d4cb23ce0b301e0b128feb"
     },
-    "using-git-worktrees": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/using-git-worktrees/SKILL.md",
-      "computedHash": "bd10bc57c23040630b17c877a9bc7b4be40c35161a2e2f110d770d78e3b0a4ff"
-    },
-    "using-superpowers": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/using-superpowers/SKILL.md",
-      "computedHash": "de10fd3ff46d797acc92b9df6b3ea456a5cd1d095b73c90bc921e83cce4c5bb9"
-    },
-    "verification-before-completion": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/verification-before-completion/SKILL.md",
-      "computedHash": "9b446f0c7fe1cfb560b1d34439523b1a76d5f177290007b2c053a1c749a4a8ba"
-    },
     "write-a-skill": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/productivity/write-a-skill/SKILL.md",
       "computedHash": "b44d8aab2ead83c716e01af4c9a24ccc4575ce70ad58ec4f1749fb88c9cc82ba"
-    },
-    "writing-plans": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/writing-plans/SKILL.md",
-      "computedHash": "2b986445454a025ca2c3839f8a2024747e8cce0517948437232cd113d2719060"
-    },
-    "writing-skills": {
-      "source": "obra/superpowers",
-      "sourceType": "github",
-      "skillPath": "skills/writing-skills/SKILL.md",
-      "computedHash": "c0a92e629e39ea91b1f54da67a6aa92723008a8ef5b500c6de078f55485937c7"
     },
     "zoom-out": {
       "source": "mattpocock/skills",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -101,13 +101,13 @@
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
-      "computedHash": "1adf321072f53cce3dcaf5357d91b8230d4aa647bb8a51756745337a6ee567b8"
+      "computedHash": "a5c65e76275008b469962f7bee8b34866f1c9b0709f4886e71c8e731735640e4"
     },
     "handoff": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/productivity/handoff/SKILL.md",
-      "computedHash": "0c1bc23392f3c80f07a11a21ed019bee9c9afaa7bad18f240deafbc8711f5369"
+      "computedHash": "1a78d774f8a59db5daa6e65e20a6596872fa8cde769f9a6e3a09b678dd5ae8cc"
     },
     "improve-codebase-architecture": {
       "source": "mattpocock/skills",

--- a/skills/develop-issue/SKILL.md
+++ b/skills/develop-issue/SKILL.md
@@ -25,14 +25,14 @@ available in the agent environment:
 - `new-branch`
 - `tdd`
 - `diagnose`
-- `review-action`
+- `review-code`
 - `finish-pr`
 
 If any are missing, halt before implementation. Report the missing skill names
 and install guidance:
 
 ```sh
-npm_config_ignore_scripts=true npx skills@latest add patinaproject/skills --skill new-branch --skill review-action --skill finish-pr -y
+npm_config_ignore_scripts=true npx skills@latest add patinaproject/skills --skill new-branch --skill review-code --skill finish-pr -y
 npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@tdd -y
 npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@diagnose -y
 ```
@@ -66,10 +66,12 @@ or otherwise needs judgment not recorded in the issue.
 5. Route to `diagnose` when root cause is unclear, reproduction is missing,
    behavior is flaky, or performance has regressed.
 6. Run repository-documented verification before local review.
-7. Run `review-action` as the local review gate; inherit its read-only boundary
-   and unsupported-workflow halts.
+7. Run `review-code` as the local review gate; inherit its read-only boundary,
+   fresh-reviewer isolation requirement, and halt conditions.
+   `review-action` remains available separately for users who explicitly want
+   hosted workflow emulation.
 8. Triage every local review finding with the router below.
-9. Repeat implementation, verification, and `review-action` until no actionable
+9. Repeat implementation, verification, and `review-code` until no actionable
    local findings remain or a human-owned blocker appears.
 10. Delegate final publishing and PR readiness to `finish-pr`; inherit every
     halt. Never merge the pull request.
@@ -95,7 +97,7 @@ When the workflow stops, report:
 - Branch name
 - Child skills invoked, with halt reason if any
 - Verification commands and results
-- Latest `review-action` result
+- Latest `review-code` result
 - Human-owned blockers, if any
 - `wontfix` explanations, if any
 - PR URL and readiness status, when `finish-pr` runs

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: review-code
+description: Run a read-only, fresh-context branch-diff code review and report findings. Use when running /review-code, before finishing issue work, or when a local review gate should inspect committed, staged, unstaged, and untracked changes without mutating code or GitHub state.
+---
+
+# Review Code
+
+This skill is portable. It works from instructions alone and should be usable in
+any repository with Git history and repository guidance.
+
+## Safety Boundary
+
+Local code review is read-only and findings-only.
+
+- Do not edit files, stage changes, commit, push, create pull requests, post GitHub comments, or mutate review threads.
+- Do not run formatters, generators, fixers, installers, or other commands that
+  write to the worktree.
+- Do not read, require, print, or infer secrets.
+- Do not fall back to same-thread review. If fresh reviewer dispatch is unavailable, halt.
+
+## Scope
+
+1. Resolve the repository default branch with `gh repo view --json
+   defaultBranchRef --jq .defaultBranchRef.name` or `git rev-parse
+   --abbrev-ref origin/HEAD`. Normalize the fallback by stripping the leading
+   `origin/` so the branch name is `main`, not `origin/main`. If neither
+   source can identify a default branch, halt with instructions to set
+   `origin/HEAD` outside this skill, for example with
+   `git remote set-head origin --auto`.
+2. Use the current `origin/<default-branch>` ref. Do not update refs during
+   review. Verify the local ref exists with
+   `git rev-parse --verify origin/<default-branch>`. When `gh` is available,
+   resolve `{owner}/{repo}` with `gh repo view --json nameWithOwner --jq
+   .nameWithOwner`, then compare the local SHA to the remote default-branch SHA
+   from `gh api repos/{owner}/{repo}/branches/{branch} --jq .commit.sha`; halt
+   and report both SHAs when they differ. When remote freshness cannot be
+   checked, continue only after recording that freshness is unverified in the
+   report.
+3. Compute the review base with `git merge-base origin/<default-branch> HEAD`
+   after normalization.
+4. Review the default-branch merge-base to the current branch, plus staged,
+   unstaged, and untracked local changes. Include deleted files.
+5. Load repository instructions before review: `AGENTS.md`, `CLAUDE.md` if
+   present, and docs they explicitly import.
+6. Treat generated files, lockfiles, vendored files, and dogfood overlay paths
+   as low-signal unless repository instructions or the diff make them relevant.
+
+## Fresh Reviewer Dispatch
+
+The primary agent may compute scope and collect context, but the actual review
+must run as a fresh-context reviewer in a fresh reviewer agent or equivalent
+isolated dispatch surface with no inherited implementation conversation.
+Prefer a host-provided read-only Explorer or reviewer background agent when one
+is available, because branch-diff review is a codebase question with a bounded
+scope.
+
+Pass only:
+
+- Repository path
+- Default branch, merge-base, head, and dirty/untracked scope
+- Changed file list and relevant diff commands
+- Repository instructions
+- This read-only review contract
+
+If the host runtime cannot create a fresh reviewer or equivalent isolated
+review surface, halt and report that isolation is unavailable. Do not ask the
+current implementation conversation to perform the review.
+
+## Reviewer Contract
+
+The reviewer should inspect the scoped diff for merge-relevant risk:
+
+- correctness, security, data loss, requirements fit, error handling, test
+  quality, edge cases, production readiness, clarity, and maintainability
+- missing or misleading tests for changed behavior
+- inconsistencies with repository instructions or issue acceptance criteria
+
+Group findings by severity: blocking, non-blocking, and low-severity. Each
+finding must include a file and line reference, rationale, and suggested fix.
+Keep praise-heavy commentary out of the report. If there are no findings, say
+so and mention residual risk or test gaps.
+
+## Distinction From Hosted Review
+
+`review-code` is a local isolated reviewer for branch-diff findings. It does
+not emulate `code-review.yml`, does not require a PR number, and does not post
+comments.
+
+Use `review-action` when the user explicitly wants to emulate a supported
+hosted AI code-review workflow locally. Hosted workflows own their own prompt,
+permissions, and PR-commenting contract.
+
+## Report
+
+- Base, head, and default branch used
+- Local default-branch ref freshness check, or why freshness is unverified
+  (for example: `Freshness unverified: gh unavailable; reviewed current
+  origin/main only`)
+- Changed files, including staged, unstaged, and untracked files
+- Fresh reviewer dispatch mechanism, or halt reason
+- Findings grouped by severity
+- Low-signal paths skipped or reviewed with rationale


### PR DESCRIPTION
## Linked issue

Closes #143

## What changed

Context: standalone - add the local isolated review gate requested by issue #143

- Added the `review-code` skill - gives agents a portable, read-only fresh-reviewer branch-diff gate that includes dirty and untracked local changes
- Updated `develop-issue` to require and invoke `review-code` - makes isolated local review the default issue-development gate while keeping `review-action` explicit
- Registered the new skill across Claude/Codex manifests, dogfood overlays, docs, and verifiers - keeps the marketplace catalog and local tests aligned at twelve in-repo skills
- Updated `.gitignore` overlay allowlist entries - includes the new `review-code` symlinks and fixes pre-existing missing allow entries for `develop-issue` and `install-skills` overlays

## Verification

- `bash scripts/verify-review-code-skill.sh` — passed
- `bash scripts/verify-develop-issue-workflow.sh` — passed
- `bash scripts/verify-dogfood.sh` — passed
- `bash scripts/verify-marketplace.sh` — passed
- `pnpm test` — passed
- `pnpm lint:md` — not clean before this change; fails on existing `CHANGELOG.md` MD012 blank-line issues
- Fresh `review-code` pass — no findings after fixes
