### PR TITLE
docs: #145 record review disposition states

### DIFF
--- a/scripts/tests/develop-issue-workflow.test.sh
+++ b/scripts/tests/develop-issue-workflow.test.sh
@@ -99,7 +99,7 @@ if [ -f "$SKILL" ]; then
   assert_match 'valid work outside the issue' "$SKILL"
   assert_match 'future reviewers would otherwise re-raise' "$SKILL"
   assert_match 'There is no `needs-info` state' "$SKILL"
-  assert_match 'clean or every local finding has a[[:space:]]+disposition' "$SKILL"
+  assert_match 'clean or every local finding has a[[:space:]]+recorded `ready-for-agent`, `ready-for-human`, or `wontfix` disposition' "$SKILL"
   assert_no_match 'receiving-code-review' "$SKILL"
   assert_no_match 'requesting-code-review' "$SKILL"
   assert_no_match 'Superpowers' "$SKILL"

--- a/skills/develop-issue/SKILL.md
+++ b/skills/develop-issue/SKILL.md
@@ -118,7 +118,8 @@ or otherwise needs judgment not recorded in the issue.
    local findings remain or a human-owned blocker appears.
 11. Delegate final publishing and PR readiness to `finish-pr` only after local
     verification and `review-code` are clean or every local finding has a
-    disposition; inherit every halt. Never merge the pull request.
+    recorded `ready-for-agent`, `ready-for-human`, or `wontfix` disposition;
+    inherit every halt. Never merge the pull request.
 
 ## Review Finding Router
 


### PR DESCRIPTION
## Linked issue

Closes #145

## What changed

Context: follow-up to #147 - hosted review asked for the `finish-pr` handoff gate to name the local review disposition states verbatim.

- Tightened `develop-issue` workflow step 11 - the handoff to `finish-pr` now requires either clean local review or a recorded `ready-for-agent`, `ready-for-human`, or `wontfix` disposition.
- Updated the develop-issue workflow verifier - future edits preserve the explicit disposition-state wording.

## Verification

- `bash scripts/tests/develop-issue-workflow.test.sh` — passed
- `pnpm test` — passed
