### PR TITLE
feat: #156 prioritize PR feedback before checks

### DIFF
--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+SKILL="skills/finish-pr/SKILL.md"
 WORKFLOW="skills/finish-pr/workflows/ready-for-merge.md"
 TRIAGE="skills/finish-pr/workflows/triage.md"
 FAIL_COUNT=0
@@ -40,8 +41,14 @@ assert_order() {
   fi
 }
 
+assert_file "$SKILL"
 assert_file "$WORKFLOW"
 assert_file "$TRIAGE"
+
+if [ -f "$SKILL" ]; then
+  assert_match "currently available PR feedback" "$SKILL"
+  assert_match "eligible conversation resolution" "$SKILL"
+fi
 
 if [ -f "$WORKFLOW" ]; then
   assert_match "Final unresolved review-thread gate" "$WORKFLOW"
@@ -56,15 +63,24 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "restart the readiness loop on the new head" "$WORKFLOW"
   assert_match "product judgment, secrets, permissions" "$WORKFLOW"
   assert_match "destructive git operations, unrelated scope" "$WORKFLOW"
-  assert_order "mergeability gate" "gh pr checks --watch" "$WORKFLOW"
-  assert_order "gh pr checks --watch" "Final unresolved review-thread gate" "$WORKFLOW"
+  assert_order "mergeability gate" "Fetch the full PR feedback surface" "$WORKFLOW"
+  assert_order "Fetch the full PR feedback surface" "Triage every currently available feedback item" "$WORKFLOW"
+  assert_order "Triage every currently available feedback item" "gh pr checks --watch" "$WORKFLOW"
+  assert_order "gh pr checks --watch" "Re-query the full PR feedback surface" "$WORKFLOW"
+  assert_order "Re-query the full PR feedback surface" "Final unresolved review-thread gate" "$WORKFLOW"
   assert_order "Final unresolved review-thread gate" "gh pr ready" "$WORKFLOW"
   assert_match "resolveReviewThread" "$WORKFLOW"
   assert_match "isResolved" "$WORKFLOW"
+  assert_match "newly available, changed, unresolved" "$WORKFLOW"
+  assert_match "evidence-pending feedback" "$WORKFLOW"
+  assert_match "body hash or update time" "$WORKFLOW"
+  assert_match "deferred-until-checks dispositions" "$WORKFLOW"
   assert_match "(?i)(?:unresolved.*blocker|blocker.*unresolved)" "$WORKFLOW"
   assert_match "top-level" "$WORKFLOW"
   assert_match "per-finding disposition" "$WORKFLOW"
   assert_match "unaddressed findings" "$WORKFLOW"
+  assert_match "fix-now.*pending checks" "$WORKFLOW"
+  assert_match "explain.*stale.*defer.*before checks" "$WORKFLOW"
 fi
 
 if [ -f "$TRIAGE" ]; then
@@ -79,6 +95,12 @@ if [ -f "$TRIAGE" ]; then
   assert_match "Do not rebase or force-push by default" "$TRIAGE"
   assert_match "Do not use browser conflict" "$TRIAGE"
   assert_match "merge the pull request itself" "$TRIAGE"
+  assert_match "Handle currently available feedback before watching checks" "$TRIAGE"
+  assert_match "fix-now.*pending" "$TRIAGE"
+  assert_match "explain.*stale.*defer.*before checks" "$TRIAGE"
+  assert_match "isResolved: true" "$TRIAGE"
+  assert_match "Re-query the full feedback surface after checks finish" "$TRIAGE"
+  assert_match "Wait for all checks only after currently available feedback has been handled" "$TRIAGE"
 fi
 
 if [ "$FAIL_COUNT" -gt 0 ]; then

--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -48,6 +48,7 @@ assert_file "$TRIAGE"
 if [ -f "$SKILL" ]; then
   assert_match "currently available PR feedback" "$SKILL"
   assert_match "eligible conversation resolution" "$SKILL"
+  assert_match "re-query PR feedback after checks" "$SKILL"
 fi
 
 if [ -f "$WORKFLOW" ]; then
@@ -75,6 +76,7 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "evidence-pending feedback" "$WORKFLOW"
   assert_match "body hash or update time" "$WORKFLOW"
   assert_match "deferred-until-checks dispositions" "$WORKFLOW"
+  assert_match "Prior eligible resolutions stand" "$WORKFLOW"
   assert_match "(?i)(?:unresolved.*blocker|blocker.*unresolved)" "$WORKFLOW"
   assert_match "top-level" "$WORKFLOW"
   assert_match "per-finding disposition" "$WORKFLOW"

--- a/skills/finish-pr/SKILL.md
+++ b/skills/finish-pr/SKILL.md
@@ -31,7 +31,7 @@ human input is required. It never merges the PR.
 7. Create or update a ready-for-review PR using the repository template.
 8. Enter the readiness loop: detect merge conflicts, triage currently
    available PR feedback, resolve eligible conversations, watch all checks,
-   triage every problematic check or newly posted feedback item, fix
+   triage every problematic check, re-query PR feedback after checks, fix
    branch-local issues, push, and repeat.
 9. Mark draft PRs ready when the loop reaches the ready state.
 10. Report ready-to-merge status without merging.

--- a/skills/finish-pr/SKILL.md
+++ b/skills/finish-pr/SKILL.md
@@ -15,8 +15,9 @@ Example: on branch `42-let-agents-use-github-more-ergonomically`, infer issue
 the ready-for-review PR.
 
 This skill verifies, commits, pushes, creates or reuses a ready-for-review pull
-request, then loops through mergeability, checks, and PR feedback until the PR
-is ready-to-merge or human input is required. It never merges the PR.
+request, then loops through mergeability, currently available PR feedback,
+eligible conversation resolution, and checks until the PR is ready-to-merge or
+human input is required. It never merges the PR.
 
 ## Workflow
 
@@ -28,9 +29,10 @@ is ready-to-merge or human input is required. It never merges the PR.
 5. Commit using the repository's required commit format.
 6. Push the branch when there is work to publish.
 7. Create or update a ready-for-review PR using the repository template.
-8. Enter the readiness loop: detect merge conflicts, watch all checks, triage
-   every problematic check and PR feedback item, fix branch-local issues, push,
-   and repeat.
+8. Enter the readiness loop: detect merge conflicts, triage currently
+   available PR feedback, resolve eligible conversations, watch all checks,
+   triage every problematic check or newly posted feedback item, fix
+   branch-local issues, push, and repeat.
 9. Mark draft PRs ready when the loop reaches the ready state.
 10. Report ready-to-merge status without merging.
 

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -175,9 +175,10 @@ directory's default `gh` repository.
     inventory. Triage and handle any newly available, changed, unresolved, or
     evidence-pending feedback before the final gate, including
     deferred-until-checks dispositions whose evidence depended on check
-    results. Apply the same disposition rules from steps 10 and 11, including
-    immediate loop restart for `fix-now` feedback and GraphQL verification for
-    resolved inline threads.
+    results. Prior eligible resolutions stand unless the re-query shows changed
+    or newly unresolved thread state. Apply the same disposition rules from
+    steps 10 and 11, including immediate loop restart for `fix-now` feedback
+    and GraphQL verification for resolved inline threads.
 
 15. Final unresolved review-thread gate: immediately before declaring the PR
     ready, re-query paginated GraphQL review threads for the latest PR head.

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -152,15 +152,15 @@ directory's default `gh` repository.
 
 12. Watch all checks to terminal state:
 
-   ```sh
-   gh pr checks --watch
-   ```
+    ```sh
+    gh pr checks --watch
+    ```
 
-   Do not use `--fail-fast` by default. Do not filter to required checks only;
-   optional checks can produce review comments or useful blocking evidence.
-   Do not add arbitrary settle sleeps, pass-count caps, or wall-clock caps. If
-   the check set shows no state change after a reasonable observation window,
-   stop for operator feedback instead of waiting indefinitely.
+    Do not use `--fail-fast` by default. Do not filter to required checks only;
+    optional checks can produce review comments or useful blocking evidence.
+    Do not add arbitrary settle sleeps, pass-count caps, or wall-clock caps. If
+    the check set shows no state change after a reasonable observation window,
+    stop for operator feedback instead of waiting indefinitely.
 
 13. Triage every non-pass, canceled, or otherwise problematic check with
     [triage.md](triage.md). Fix `fix-now` outcomes in branch-local follow-up

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -113,7 +113,44 @@ directory's default `gh` repository.
 
    Report the aborted merge state and the reason human input is required.
 
-9. Watch all checks to terminal state:
+9. Fetch the full PR feedback surface before watching checks:
+
+   - Unresolved inline review threads through paginated GraphQL.
+   - Top-level PR comments, including bot summaries with `Findings`,
+     severity counts, or line-keyed observations.
+   - Review bodies and latest review state.
+   - Review decision, when available.
+
+   Prefer inline threads when duplicate feedback exists. Maintain an in-memory
+   handled inventory for this run with comment or review identifiers, URLs,
+   authors, body hash or update time when available, classification, and
+   evidence status. Do not persist handled state in files.
+
+10. Triage every currently available feedback item with
+    [triage.md](triage.md). A `fix-now` finding interrupts pending checks:
+    patch, verify, commit, push, and restart the readiness loop on the new head
+    before waiting on check runs that the fix will make stale. For `explain`,
+    `stale`, and `defer`, reply or report with concrete evidence; handle
+    `explain`, `stale`, and `defer` before checks unless the evidence itself
+    depends on check results. Stop only when feedback returns `needs-human`.
+
+    When a top-level review comment contains findings, handle each finding
+    separately with a per-finding disposition: fixed in a named commit,
+    explained with evidence, stale, deferred as out of scope, or blocked for
+    human judgment. Severity labels such as `Minor` do not make findings
+    optional; unaddressed findings are blockers until they have a disposition
+    recorded in the PR or final report.
+
+11. Resolve eligible inline threads once the disposition is valid. Explanation,
+    stale, and deferral dispositions are eligible after an evidence-bearing
+    reply is present on the latest head. Code-fix dispositions are eligible
+    after the fix is present on the latest head and local verification passes.
+    Use GraphQL `resolveReviewThread`, then verify GraphQL `isResolved` after
+    resolving. If permissions do not allow resolution, leave an
+    evidence-bearing reply and report the unresolved state. Do not treat
+    replies as resolution.
+
+12. Watch all checks to terminal state:
 
    ```sh
    gh pr checks --watch
@@ -121,49 +158,28 @@ directory's default `gh` repository.
 
    Do not use `--fail-fast` by default. Do not filter to required checks only;
    optional checks can produce review comments or useful blocking evidence.
-   Check completion is the synchronization point for GitHub Action-authored
-   feedback. Do not add arbitrary settle sleeps, pass-count caps, or wall-clock
-   caps. If the check set shows no state change after a reasonable observation
-   window, stop for operator feedback instead of waiting indefinitely.
+   Do not add arbitrary settle sleeps, pass-count caps, or wall-clock caps. If
+   the check set shows no state change after a reasonable observation window,
+   stop for operator feedback instead of waiting indefinitely.
 
-10. Triage every non-pass, canceled, or otherwise problematic check with
+13. Triage every non-pass, canceled, or otherwise problematic check with
     [triage.md](triage.md). Fix `fix-now` outcomes in branch-local follow-up
     commits, verify locally, push, and restart the loop on the new head. Continue
     for `explain`, `stale`, and `defer` outcomes only with concrete evidence.
     Stop only when a check returns `needs-human`.
 
-11. Fetch the full PR feedback surface after checks finish:
+14. Re-query the full PR feedback surface after checks finish because GitHub
+    Actions or review automation may have posted new comments or updated
+    existing comments while checks were running. Compare comment and review
+    identifiers plus body hash or update time from the in-memory handled
+    inventory. Triage and handle any newly available, changed, unresolved, or
+    evidence-pending feedback before the final gate, including
+    deferred-until-checks dispositions whose evidence depended on check
+    results. Apply the same disposition rules from steps 10 and 11, including
+    immediate loop restart for `fix-now` feedback and GraphQL verification for
+    resolved inline threads.
 
-    - Unresolved inline review threads through paginated GraphQL.
-    - Top-level PR comments, including bot summaries with `Findings`,
-      severity counts, or line-keyed observations.
-    - Review bodies and latest review state.
-    - Review decision, when available.
-
-    Prefer inline threads when duplicate feedback exists. Triage each item with
-    [triage.md](triage.md). Maintain an in-memory handled inventory for this
-    run with comment or review identifiers, URLs, authors, body hash or update
-    time when available, classification, and evidence status. Do not persist
-    handled state in files.
-
-12. Handle feedback. Fix `fix-now` outcomes in branch-local follow-up commits,
-    verify locally, push, and restart the loop on the new head. For `explain`,
-    `stale`, and `defer`, reply or report with concrete evidence and continue.
-    Stop only when feedback returns `needs-human`. When a top-level review
-    comment contains findings, handle each finding separately with a
-    per-finding disposition: fixed in a named commit, explained with evidence,
-    stale, deferred as out of scope, or blocked for human judgment. Severity
-    labels such as `Minor` do not make findings optional; unaddressed findings
-    are blockers until they have a disposition recorded in the PR or final
-    report.
-
-13. Resolve eligible inline threads only after the relevant fix or explanation
-    is present on the latest head and checks pass. Use GraphQL
-    `resolveReviewThread`, then verify GraphQL `isResolved` after resolving. If
-    permissions do not allow resolution, leave an evidence-bearing reply and
-    report the unresolved state. Do not treat replies as resolution.
-
-14. Final unresolved review-thread gate: immediately before declaring the PR
+15. Final unresolved review-thread gate: immediately before declaring the PR
     ready, re-query paginated GraphQL review threads for the latest PR head.
     Distinguish unresolved actionable feedback from outdated or stale feedback
     that is already fixed on the latest head. For stale fixed threads, resolve
@@ -175,7 +191,7 @@ directory's default `gh` repository.
     fixes or newly pushed commits. Unresolved threads are blockers until they
     are resolved, fixed, or evidence-classified as stale or non-blocking.
 
-15. When the loop reaches the ready state, mark a draft PR ready for review:
+16. When the loop reaches the ready state, mark a draft PR ready for review:
 
     ```sh
     gh pr ready
@@ -183,7 +199,7 @@ directory's default `gh` repository.
 
     Keep the no-merge guardrail: stop when merge is the next action.
 
-16. Final report includes:
+17. Final report includes:
 
     - PR URL.
     - Latest head SHA.

--- a/skills/finish-pr/workflows/triage.md
+++ b/skills/finish-pr/workflows/triage.md
@@ -29,23 +29,32 @@ executing the state action.
 - Paginate GraphQL review threads; REST review comments alone are not enough.
 - Replies do not equal resolution. Check `isResolved`.
 - Verify line context against the latest head before replying or resolving.
+- Handle currently available feedback before watching checks. A `fix-now`
+  feedback item restarts the readiness loop on the new head even when checks are
+  pending; treat `fix-now` as pending-check-interrupting feedback.
+- Reply to or record `explain`, `stale`, and `defer` dispositions before checks
+  when the evidence does not depend on check results.
 - Route requirement, acceptance-criteria, scope, or user-visible behavior
   changes through the repository's planning owner before implementation.
 - Reply concisely to every handled human comment.
-- Resolve inline threads only after the fix or explanation is present on latest
-  head and checks pass.
+- Resolve inline threads only after the fix, explanation, stale evidence, or
+  deferral evidence is present on latest head.
+- Verify `isResolved: true` after calling `resolveReviewThread`; unresolved
+  threads remain blockers unless permission-blocked and explicitly reported.
 - Track handled top-level comments and review bodies in memory during the run so
   loop passes do not post duplicate replies.
 
 ## Check Failure Rules
 
-- Wait for all checks with `gh pr checks --watch`; do not use fail-fast by
-  default.
+- Wait for all checks only after currently available feedback has been handled.
+- Use `gh pr checks --watch`; do not use fail-fast by default.
 - Triage every non-pass, canceled, or otherwise problematic check result.
 - Inspect logs before classifying.
 - Fix branch-local failures in normal follow-up commits.
 - Stop for missing secrets, permission failures, external outages, or flaky
   infrastructure that cannot be proven branch-local.
+- Re-query the full feedback surface after checks finish so CI-authored review
+  comments are triaged before final readiness reporting.
 
 ## Merge Conflict Rules
 


### PR DESCRIPTION
## Linked issue

Closes #156

## What changed

Context: standalone - finish-pr readiness loop currently waits on checks before actioning available PR feedback.

- Updated finish-pr readiness guidance to fetch and triage currently available feedback before check watching - feedback fixes, explanations, stale dispositions, and deferrals should not wait behind checks they may invalidate.
- Added explicit eligible conversation resolution guidance with GraphQL `resolveReviewThread` and `isResolved` verification - replies alone should not leave merge-blocking conversations unresolved.
- Reworked post-check feedback synchronization to re-query changed, unresolved, and evidence-pending feedback before final readiness - CI-authored or updated comments are handled before the final gate.
- Expanded finish-pr workflow regression assertions - future edits must preserve mergeability, feedback, checks, re-query, final-gate, and ready ordering.

## Verification

- `bash scripts/tests/finish-pr-workflow.test.sh` — passed
- `pnpm test` — passed
- local `review-code` gate — passed on second review with no findings