### PR TITLE
docs: #158 let develop-issue invoke review-code without extra confirmation

### DIFF
--- a/scripts/tests/develop-issue-workflow.test.sh
+++ b/scripts/tests/develop-issue-workflow.test.sh
@@ -85,6 +85,7 @@ if [ -f "$SKILL" ]; then
   assert_match 'committed branch diff[[:space:]]+from the default-branch merge base' "$SKILL"
   assert_match 'staged changes, unstaged changes, or[[:space:]]+untracked files' "$SKILL"
   assert_match 'When reviewable changes exist, invoke `review-code`' "$SKILL"
+  assert_match 'without asking for[[:space:]]+another user confirmation' "$SKILL"
   assert_match 'When no reviewable changes exist, skip `review-code`' "$SKILL"
   assert_match '`review-code` owns fresh reviewer dispatch' "$SKILL"
   assert_match 'isolation[[:space:]]+requirements, read-only boundary, cleanup, and halt reporting' "$SKILL"

--- a/skills/develop-issue/SKILL.md
+++ b/skills/develop-issue/SKILL.md
@@ -109,6 +109,13 @@ or otherwise needs judgment not recorded in the issue.
 9. When reviewable changes exist, invoke `review-code` and inherit its full
    contract. `review-code` owns fresh reviewer dispatch, isolation
    requirements, read-only boundary, cleanup, and halt reporting.
+   Explicit use of `develop-issue` is sufficient approval for this required
+   local review gate: dispatch the fresh read-only reviewer without asking for
+   another user confirmation. Preserve the `review-code` boundary exactly:
+   no same-thread fallback and no file edits, staging, commits, pushes, PR
+   comments, review-thread mutation, or other worktree mutation. Halt if fresh
+   reviewer dispatch is unavailable or if `review-code` reports a halt
+   condition.
    When no reviewable changes exist, skip `review-code` and report that no
    local changes required review.
 10. Triage every local review finding with the router below.


### PR DESCRIPTION
## Linked issue

Closes #158

## What changed

Context: standalone - issue #158 updates the develop-issue local review gate contract

- Updated `develop-issue` review-gate instructions - makes explicit that the required fresh read-only `review-code` reviewer may be dispatched without a second user confirmation while preserving no-mutation and halt boundaries.
- Added a develop-issue workflow regression assertion - keeps the no-extra-confirmation wording from being removed accidentally.

## Verification

- `bash scripts/tests/develop-issue-workflow.test.sh` — passed.
- `bash scripts/tests/review-code-skill.test.sh` — passed.
- `pnpm test` — passed; npm printed existing unknown env config warnings during installer canaries.
- `review-code` local gate — passed via fresh Explorer dispatch with no findings.
