### PR TITLE
feat: #162 refresh dependencies after branch updates

### DIFF
--- a/scripts/tests/update-branch-workflow.test.sh
+++ b/scripts/tests/update-branch-workflow.test.sh
@@ -69,6 +69,13 @@ if [ -f "$SKILL" ]; then
   assert_match 'documented verification' "$SKILL"
   assert_match 'auto-commit|auto-committing' "$SKILL"
   assert_match 'conflict resolution|resolving conflicts|resolved conflicts' "$SKILL"
+  assert_match 'dependency-related files changing during[[:space:]]+the merge|dependency inputs changed during the merge' "$SKILL"
+  assert_match 'manifests, lockfiles,[[:space:]]+workspace manifests, or toolchain version files' "$SKILL"
+  assert_match 'documented[[:space:]]+install/bootstrap command' "$SKILL"
+  assert_match 'before verification' "$SKILL"
+  assert_match 'no install/bootstrap command is[[:space:]]+documented' "$SKILL"
+  assert_match 'do not reinstall dependencies unconditionally|does not reinstall dependencies unconditionally' "$SKILL"
+  assert_match 'Do not silently commit lockfile or generated dependency changes' "$SKILL"
 fi
 
 node --input-type=module <<'NODE'

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -89,7 +89,7 @@
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
-      "computedHash": "c77b86b4332919499608f9af1880074e1fec65a59b95c70c27a9f39cd137865e"
+      "computedHash": "ef32aea0a8fab9b365ff9e08a95f8d353e20ca21ea46ec2e73587c86dd341351"
     },
     "migrate-to-codex": {
       "source": "openai/skills",

--- a/skills/update-branch/SKILL.md
+++ b/skills/update-branch/SKILL.md
@@ -18,6 +18,9 @@ No argument means resolve the base from `origin/HEAD`. An optional base
 argument selects another branch or remote-tracking ref. Dirty work normally
 stops the update; a clearly cohesive, branch-local, non-silent auto-commit with
 explicit operator confirmation is the only exception.
+Dependency refresh is conditional on dependency-related files changing during
+the merge; do not reinstall dependencies unconditionally on every branch
+update.
 
 This skill is local-first. Use pure `git`; do not use `gh pr update-branch`,
 GitHub's remote update button, or any GitHub update API. Never push
@@ -73,11 +76,24 @@ automatically.
    in scope, and mechanically verifiable. Stop for product judgment, unrelated
    scope, permissions, secrets, generated-file uncertainty, or unverifiable
    semantics.
-8. Run documented verification after auto-committing dirty work or completing
-   conflict resolution. Prefer commands in `AGENTS.md`, README files, package
-   scripts, or other repository guidance. If no local verification applies,
-   say so explicitly.
-9. Report the result without pushing.
+8. After a successful merge or conflict resolution, inspect whether dependency
+   inputs changed during the merge. Treat package manifests, lockfiles,
+   workspace manifests, or toolchain version files as dependency inputs.
+   - When dependency inputs changed, run the repository's documented
+     install/bootstrap command before verification. Prefer commands in
+     `AGENTS.md`, README files, package scripts, or other repository guidance.
+   - If dependency inputs changed and no install/bootstrap command is
+     documented, stop and report that dependencies may need refresh before
+     verification can run.
+   - Do not silently commit lockfile or generated dependency changes. Include
+     them only when they are a direct result of the documented install command,
+     are in scope for the branch update, and follow the same explicit
+     confirmation and commit-message rules as other auto-committed dirty work.
+9. Run documented verification after auto-committing dirty work, completing
+   dependency refresh, or completing conflict resolution. Prefer commands in
+   `AGENTS.md`, README files, package scripts, or other repository guidance. If
+   no local verification applies, say so explicitly.
+10. Report the result without pushing.
 
 ## Conflict Rules
 
@@ -95,6 +111,8 @@ Always include:
 - Base ref fetched and merged.
 - Whether a dirty-work auto-commit was created.
 - Whether a merge commit was created or the branch was already up to date.
+- Whether dependency refresh was skipped, run, or blocked because no documented
+  install/bootstrap command was available.
 - Conflicts resolved or the human-owned blocker that stopped the workflow.
 - Documented verification commands and results, when run.
 - A clear note that the branch remains local-only.


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #162

## What changed

Context: standalone - implements the update-branch dependency-refresh contract from issue #162

- Added conditional dependency-refresh guidance to update-branch - agents now inspect dependency inputs after successful merges and run documented install/bootstrap commands before verification only when needed.
- Added stop/report guidance when no install/bootstrap command is documented - prevents verification from running against stale dependencies without an explicit blocker.
- Added focused workflow assertions - covers conditional refresh, no unconditional reinstall, and non-silent lockfile/generated dependency handling.
- Preserved the approved skills lock hash update - keeps the pre-existing local lockfile change as an explicit commit instead of silent churn.

## Verification

- `bash scripts/tests/update-branch-workflow.test.sh` — passed
- `pnpm test` — passed; npm printed unknown-env-config warnings during canary install checks, but the suite completed successfully
- `git diff --check origin/main...HEAD` — passed with no whitespace errors
- Isolated local review — no update-branch implementation findings; lockfile hash change was reviewed and intentionally kept after explicit operator approval
