### PR TITLE
fix: #165 set up scaffold skill installation

### DIFF
--- a/scripts/tests/marketplace.test.sh
+++ b/scripts/tests/marketplace.test.sh
@@ -74,6 +74,23 @@ if [ "$claude_skills" != "$expected_marketplace_skills" ]; then
   exit 1
 fi
 
+unexpected_lock_entries="$(
+  jq -r '
+    .skills
+    | to_entries[]
+    | select(
+        (.value.source != "mattpocock/skills")
+        and (.key != "find-skills" or .value.source != "vercel-labs/skills")
+      )
+    | "\(.key): \(.value.source)"
+  ' skills-lock.json
+)"
+if [ -n "$unexpected_lock_entries" ]; then
+  echo "FAIL: skills-lock.json may only keep mattpocock/skills entries plus find-skills" >&2
+  printf '%s\n' "$unexpected_lock_entries" >&2
+  exit 1
+fi
+
 # Assert the two version fields stay in lockstep. Each host stores the
 # marketplace version in a different file per its own schema:
 #   Claude: .claude-plugin/marketplace.json metadata.version

--- a/scripts/tests/scaffold-cleanup.test.sh
+++ b/scripts/tests/scaffold-cleanup.test.sh
@@ -73,9 +73,9 @@ assert_absent_path "scripts/verify-scaffold-agent-plugin-readme.js"
 assert_absent_path ".github/ISSUE_TEMPLATE/bug_report.md"
 assert_absent_path ".github/ISSUE_TEMPLATE/feature_request.md"
 
-# This protects the live patinaproject/skills reference repo. It intentionally
-# includes marketplace-internal verification files that are not emitted into
-# generic scaffolded consumer repositories.
+# This protects the live patinaproject/skills reference repo. Some files below
+# are marketplace-internal verification files, while the skill installation
+# lifecycle files are now part of the generic scaffold baseline.
 for live_reference_path in \
   .claude/settings.json \
   .codex/environments/environment.toml \
@@ -167,6 +167,18 @@ assert_no_match "#cursor|#windsurf|#github-copilot|#continuedev" \
 
 assert_no_match "scripts/(test|verify-code-review-workflow|verify-develop-issue-workflow|verify-dogfood|verify-esm-tooling|verify-finish-pr-workflow|verify-marketplace|verify-review-code-skill|verify-scaffold-cleanup|verify-workflow-cleanup)\\.sh" \
   skills/scaffold-repository/SKILL.md skills/scaffold-repository/audit-checklist.md
+
+assert_match "scripts/install-third-party-skills\\.sh" \
+  skills/scaffold-repository/SKILL.md skills/scaffold-repository/audit-checklist.md
+
+assert_match "skills-lock\\.json" \
+  skills/scaffold-repository/SKILL.md skills/scaffold-repository/audit-checklist.md
+
+assert_match "postinstall: \"bash scripts/install-third-party-skills\\.sh\"" \
+  skills/scaffold-repository/SKILL.md
+
+assert_match "skills:restore: \"bash scripts/install-third-party-skills\\.sh\"" \
+  skills/scaffold-repository/SKILL.md
 
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "" >&2

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,60 +1,6 @@
 {
   "version": 1,
   "skills": {
-    "Agent Development": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/agent-development/SKILL.md",
-      "computedHash": "4931c2867890bfef5881225adb691c3d719fe9ad556e3d5fae15f83e0668fa60"
-    },
-    "Command Development": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/command-development/SKILL.md",
-      "computedHash": "bca581f0a2789f75d9501499b9f4dc354eb40b213ccd23d13f5b87299db1f84a"
-    },
-    "Hook Development": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/hook-development/SKILL.md",
-      "computedHash": "a1721df65785b6c0439d4326cdee0cb2b6aa98de09fc98463afc3e040fe00ce9"
-    },
-    "MCP Integration": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/mcp-integration/SKILL.md",
-      "computedHash": "99cfef49810cb80a39762a79dbb6a80d486ea56cfa1a81ed10cae0a5a296b496"
-    },
-    "Plugin Settings": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/plugin-settings/SKILL.md",
-      "computedHash": "b4be0bf62782da83e962aa759e7d5efb1d5934b81554f1d15801fdf5e01b18a4"
-    },
-    "Plugin Structure": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/plugin-structure/SKILL.md",
-      "computedHash": "c4e9b3ea36efad4ab599465aaac71f81dc3320a183920678fe1587181c446b07"
-    },
-    "Skill Development": {
-      "source": "anthropics/claude-code",
-      "sourceType": "github",
-      "skillPath": "plugins/plugin-dev/skills/skill-development/SKILL.md",
-      "computedHash": "8d262f08f33825947ea20204ebf5101e36056c98090251bd973a552ec8ef0c0c"
-    },
-    "caveman": {
-      "source": "mattpocock/skills",
-      "sourceType": "github",
-      "skillPath": "skills/productivity/caveman/SKILL.md",
-      "computedHash": "934433479903febc585bf6deb5f0cebc63137e3f86b7babe0aab1ecb94d6d7a4"
-    },
-    "cli-creator": {
-      "source": "openai/skills",
-      "sourceType": "github",
-      "skillPath": "skills/.curated/cli-creator/SKILL.md",
-      "computedHash": "bd8f6db9268abf0483e17215ae6a39852a8780429c54b65658780c6f94bb4f61"
-    },
     "diagnose": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -91,18 +37,6 @@
       "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
       "computedHash": "ef32aea0a8fab9b365ff9e08a95f8d353e20ca21ea46ec2e73587c86dd341351"
     },
-    "migrate-to-codex": {
-      "source": "openai/skills",
-      "sourceType": "github",
-      "skillPath": "skills/.curated/migrate-to-codex/SKILL.md",
-      "computedHash": "23d69489c36cf1fb7f960949e2c5ec64bf154ddb490e3f94ae0d2f9e3ecc3ec3"
-    },
-    "plugin-creator": {
-      "source": "openai/skills",
-      "sourceType": "github",
-      "skillPath": "skills/.system/plugin-creator/SKILL.md",
-      "computedHash": "f6cd2ab74e30276067cb68aa2f41d56a762b41fe9dfb9dd914f2dbc27d0010f9"
-    },
     "prototype": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -114,18 +48,6 @@
       "sourceType": "github",
       "skillPath": "skills/engineering/setup-matt-pocock-skills/SKILL.md",
       "computedHash": "0164a8b1ef998abca426056c6ed8a7716a9d4692fc6daa5378f68381a6dafd24"
-    },
-    "skill-creator": {
-      "source": "openai/skills",
-      "sourceType": "github",
-      "skillPath": "skills/.system/skill-creator/SKILL.md",
-      "computedHash": "c1f04920b03c2a412e1d0b90680dc10b6de64793db7daae7e4bf64535b9fdf75"
-    },
-    "skill-installer": {
-      "source": "openai/skills",
-      "sourceType": "github",
-      "skillPath": "skills/.system/skill-installer/SKILL.md",
-      "computedHash": "44e8f0fda4a4aff2b98ae8587ceb812c15e7e5dba230f16295017c2f416f6d05"
     },
     "tdd": {
       "source": "mattpocock/skills",

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -65,10 +65,17 @@ Behavior:
 - Group recommendations into ordered batches that can be applied independently. Each batch below must cover its listed files. `patinaproject/skills` is a normal realignment target – the skill must not self-exclude when run against it.
   1. Plugin manifests: `.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, `release-please-config.json`, `.release-please-manifest.json`.
   2. Commit / PR conventions: `commitlint.config.js`, `.husky/*`, `.github/pull_request_template.md`; stale GitHub issue templates should be offered for deletion.
-  3. PNPM tooling: `package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`.
+  3. PNPM tooling and skills installation: `package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`, `skills-lock.json`, `scripts/install-third-party-skills.sh`, `.gitignore`.
   4. Agent + repo docs: `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/release-flow.md`.
   5. Marketplace catalogs: `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`.
   6. Workflows: `.github/workflows/actions.yml`, `.github/workflows/markdown.yml`, `.github/workflows/pull-request.yml`, and agent-plugin release workflow when applicable.
+- Include skills installation in every scaffold and realignment. Emit or
+  realign `skills-lock.json`, `scripts/install-third-party-skills.sh`,
+  `.gitignore`, and the `package.json` `postinstall` / `skills:restore` scripts
+  so project-local skills restore after `pnpm install`. After accepted changes
+  to those files, run `pnpm skills:restore` when the lockfile records one or
+  more skills, then verify `npx --yes skills@latest list --json` includes the
+  restored project-local skills.
 
 ## Prompts
 
@@ -126,15 +133,17 @@ docs/release-flow.md
 docs/wiki-index.md
 package.json
 pnpm-lock.yaml
+scripts/install-third-party-skills.sh
+skills-lock.json
 ```
 
 Marketplace-internal verification and dogfood files in the live reference repo,
-including the repository test harness, verify scripts, third-party skill restore
-script, lockfile, generated agent overlays, code-review workflow, verify
-workflow, and marketplace release workflow, are reference implementation
-tooling. Do not emit them into a generic scaffolded consumer repo unless that
-repo explicitly opts into the same marketplace maintenance role. Consumer
-workflows must be adapted to the files they actually receive.
+including the repository test harness, verify scripts, generated agent overlays,
+code-review workflow, verify workflow, and marketplace release workflow, are
+reference implementation tooling. Do not emit them into a generic scaffolded
+consumer repo unless that repo explicitly opts into the same marketplace
+maintenance role. Consumer workflows must be adapted to the files they actually
+receive.
 
 ## Agent plugin surfaces
 
@@ -181,13 +190,17 @@ retired workflow dependencies.
   prefix. Body structure is owned by the skill creating the issue; do not emit
   GitHub issue templates as a baseline convention.
 - **Markdown**: `markdownlint-cli2` with `.markdownlint.jsonc` + `.markdownlintignore`. `lint-staged` runs it from `pre-commit`. The lint script uses a glob that excludes `node_modules/`.
-- **PNPM**: `"type": "module"`, `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, and `lint:md` script.
+- **PNPM**: `"type": "module"`, `"packageManager": "pnpm@10.33.2"` pin, `engines.node >=24`, `prepare: "husky"`, `postinstall: "bash scripts/install-third-party-skills.sh"`, `skills:restore: "bash scripts/install-third-party-skills.sh"`, and `lint:md` script.
 - **Commitizen config**: `commitizen.config.json` stays JSON because `cz-customizable` loads it through CommonJS `require()`; do not convert it to ESM JavaScript.
-- **Shared skill lifecycle**: this repository uses `skills-lock.json` plus
-  `scripts/install-third-party-skills.sh` to restore project-local third-party
-  skills for dogfooding. Scaffolded consumer repositories should copy the live
-  lifecycle pattern directly from the maintained baseline instead of relying on
-  hidden generated files.
+- **Shared skill lifecycle**: scaffolded repositories include
+  `skills-lock.json` plus `scripts/install-third-party-skills.sh` so
+  project-local skills restore after `pnpm install`. The script is idempotent:
+  an empty or absent lockfile is a no-op, while a populated lockfile restores
+  every locked skill through `npx --yes skills@latest experimental_install
+  --yes`. Realignment must add missing `postinstall` and `skills:restore`
+  package scripts, run `pnpm skills:restore` after accepted lifecycle changes
+  when skills are locked, and verify the restored overlay with
+  `npx --yes skills@latest list --json`.
 - **Line endings**: `.gitattributes` with `* text=auto eol=lf`.
 - **PR title hygiene**: `.github/workflows/pull-request.yml` validates that every PR title is ASCII-only, follows conventional commits (no scopes), starts with a `#<issue>` ref, keeps breaking-change markers consistent (`!` in title ⇔ `BREAKING CHANGE:` footer), and that the body contains a GitHub closing keyword.
 - **Markdown CI**: `.github/workflows/markdown.yml` runs `DavidAnson/markdownlint-cli2-action` on every PR as a backstop to the husky `pre-commit` hook (which can be bypassed with `--no-verify`).

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -26,8 +26,10 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `commitizen.config.json` | yes | present; remains JSON because `cz-customizable` loads it through CommonJS `require()` |
 | `.husky/commit-msg` | yes | present; runs `pnpm exec commitlint --edit "$1"` |
 | `.husky/pre-commit` | yes | present; runs `pnpm exec lint-staged` |
-| `package.json` | yes | present; has `author.name`; `author.email`; `author.url`; `type: module`; `packageManager: pnpm@10.x`; `engines.node >= 24`; scripts include `lint:md`; repo-specific `test` scripts are recommended only when the target owns meaningful verifiers |
+| `package.json` | yes | present; has `author.name`; `author.email`; `author.url`; `type: module`; `packageManager: pnpm@10.x`; `engines.node >= 24`; scripts include `lint:md`, `postinstall: bash scripts/install-third-party-skills.sh`, and `skills:restore: bash scripts/install-third-party-skills.sh`; repo-specific `test` scripts are recommended only when the target owns meaningful verifiers |
 | `pnpm-lock.yaml` | yes | present |
+| `skills-lock.json` | yes | present; valid JSON; records project-local skills restored by the skills CLI, or an empty `skills` object when no shared skills are locked yet |
+| `scripts/install-third-party-skills.sh` | yes | present; executable; exits successfully when `skills-lock.json` is absent or empty; otherwise runs `npx --yes skills@latest experimental_install --yes` from the repo root |
 | `CHANGELOG.md` | yes | present; compatible with release-please (no hand-edits to released sections) |
 | `docs/release-flow.md` | yes | present; documents the release-please flow |
 
@@ -91,6 +93,20 @@ When detected, the following surfaces should all be present. Missing platforms a
 
 Author URLs in `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` must point to the resolved `https://github.com/<author-handle>`, not the repository owner URL. Repository-level URLs such as `homepage`, `repository`, and Codex interface URLs stay on `https://github.com/<owner>/<repo>`.
 
+### Shared skill lifecycle
+
+This check applies to every scaffolded or realigned repository so project-local
+skills restore after `pnpm install`.
+
+| File / command | Required | Check |
+|---|---|---|
+| `skills-lock.json` | yes | present; records every vendored skill that should be restored into the project overlay, or an empty `skills` object if none are installed yet |
+| `scripts/install-third-party-skills.sh` | yes | present; runs `npx --yes skills@latest experimental_install --yes` from the repo root |
+| `package.json` | yes | includes `postinstall: bash scripts/install-third-party-skills.sh` and `skills:restore: bash scripts/install-third-party-skills.sh` |
+| `.gitignore` | yes | ignores generated `.agents/skills/*` and `.claude/skills/*` payloads while keeping committed in-repo skill symlinks unignored |
+| `pnpm skills:restore` | yes | run after accepting lifecycle drift when one or more skills are locked; installs all locked vendored skills into the local project overlay |
+| `npx --yes skills@latest list --json` | yes | verify restored locked vendored skills are present alongside any in-repo overlay symlinks |
+
 ## Area 6 – Deprecated workflow cleanup
 
 Detection: look for retired workflow scaffolding in active repo guidance.
@@ -146,7 +162,7 @@ Group recommendations into ordered batches and offer them in this sequence (matc
 
 1. Plugin manifests (`.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, `release-please-config.json`, `.release-please-manifest.json`)
 2. Commit / PR conventions (`commitlint.config.js`, `.husky/*`, `.github/pull_request_template.md`, stale GitHub issue templates)
-3. PNPM tooling (`package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`)
+3. PNPM tooling and skills installation (`package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`, `skills-lock.json`, `scripts/install-third-party-skills.sh`, `.gitignore`)
 4. Agent + repo docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/release-flow.md`)
 5. Marketplace catalogs (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`)
 6. Workflows (`actions.yml`, `markdown.yml`, `pull-request.yml`, and agent-plugin `release-please.yml` when applicable)


### PR DESCRIPTION
## Linked issue

Closes #165

## What changed

Context: standalone - scaffold-repository missed setting up project-local skill restoration in consumer repos

- Make skills installation part of the scaffold-repository core baseline - so scaffolded and realigned repos receive `skills-lock.json`, `scripts/install-third-party-skills.sh`, `.gitignore` overlay ignores, and `postinstall` / `skills:restore` package scripts.
- Expand the scaffold audit checklist and cleanup assertions - so future realignment work keeps the skills lifecycle required instead of marketplace-only.
- Prune the vendored skill lockfile to Matt Pocock skills plus `find-skills`, with `caveman` removed - so repo-local restored skills match the intended allowlist.

## Verification

- `pnpm test` — passed.
- `pnpm lint:md` — failed on existing `CHANGELOG.md:5` MD012 in a released changelog section; left untouched per repo guidance not to hand-edit released changelog sections.
- `git diff --check` — passed.
