### PR TITLE
feat: #170 halt blocked issue branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@write-a-s
 - Validate paths with `find` or `rg`
 - Run `bash scripts/tests/dogfood.test.sh` to confirm all eight in-repo skills pass the flat-layout check
 - Run `bash scripts/tests/esm-tooling.test.sh` after changing repo tooling configs or the package module type
+- Run `bash scripts/tests/new-branch-workflow.test.sh` after changing `skills/new-branch/**`
 - Run `bash scripts/tests/develop-issue-workflow.test.sh` after changing `skills/develop-issue/**`
 - Run `bash scripts/tests/finish-pr-workflow.test.sh` after changing `skills/finish-pr/**`
 - Run `bash scripts/tests/marketplace.test.sh` to confirm the `.claude-plugin/` catalog is valid

--- a/scripts/tests/new-branch-workflow.test.sh
+++ b/scripts/tests/new-branch-workflow.test.sh
@@ -57,6 +57,8 @@ if [ -f "$WORKFLOW" ]; then
   assert_match 'pageInfo[[:space:]]*\{[[:space:]]*hasNextPage[[:space:]]+endCursor[[:space:]]*\}' "$WORKFLOW"
   assert_match 'while :; do' "$WORKFLOW"
   assert_match 'after:' "$WORKFLOW"
+  assert_match 'if ! page=' "$WORKFLOW"
+  assert_match "\\.errors" "$WORKFLOW"
   assert_match 'dependency query fails' "$WORKFLOW"
   assert_match 'refuse unless the user gives an explicit[[:space:]]+current-turn override' "$WORKFLOW"
   assert_match 'state:[[:space:]]*OPEN' "$WORKFLOW"

--- a/scripts/tests/new-branch-workflow.test.sh
+++ b/scripts/tests/new-branch-workflow.test.sh
@@ -48,12 +48,15 @@ if [ -f "$SKILL" ]; then
 fi
 
 if [ -f "$WORKFLOW" ]; then
-  assert_match 'gh issue view "\$issue" --json number,title,state' "$WORKFLOW"
+  assert_match 'gh issue view "\$issue" --json number,title,state --jq \.number' "$WORKFLOW"
   assert_match 'issue_number=' "$WORKFLOW"
   assert_match 'gh repo view --json nameWithOwner' "$WORKFLOW"
-  assert_match 'blockedBy\(first:100\)' "$WORKFLOW"
-  assert_match 'If the dependency query fails' "$WORKFLOW"
-  assert_match 'refuse unless the user gives an explicit current-turn override' "$WORKFLOW"
+  assert_match 'blockedBy\(first:100' "$WORKFLOW"
+  assert_match 'pageInfo[[:space:]]*\{[[:space:]]*hasNextPage[[:space:]]+endCursor[[:space:]]*\}' "$WORKFLOW"
+  assert_match 'while :; do' "$WORKFLOW"
+  assert_match 'after:' "$WORKFLOW"
+  assert_match 'dependency query fails' "$WORKFLOW"
+  assert_match 'refuse unless the user gives an explicit[[:space:]]+current-turn override' "$WORKFLOW"
   assert_match 'state:[[:space:]]*OPEN' "$WORKFLOW"
   assert_match 'number, title, state, and URL' "$WORKFLOW"
   assert_match 'Closed blockers do not halt' "$WORKFLOW"

--- a/scripts/tests/new-branch-workflow.test.sh
+++ b/scripts/tests/new-branch-workflow.test.sh
@@ -48,8 +48,10 @@ if [ -f "$SKILL" ]; then
 fi
 
 if [ -f "$WORKFLOW" ]; then
-  assert_match 'gh issue view "\$issue" --json number,title,state --jq \.number' "$WORKFLOW"
+  assert_match 'issue_json=' "$WORKFLOW"
   assert_match 'issue_number=' "$WORKFLOW"
+  assert_match 'issue_title=' "$WORKFLOW"
+  assert_match 'issue_state=' "$WORKFLOW"
   assert_match 'gh repo view --json nameWithOwner' "$WORKFLOW"
   assert_match 'blockedBy\(first:100' "$WORKFLOW"
   assert_match 'pageInfo[[:space:]]*\{[[:space:]]*hasNextPage[[:space:]]+endCursor[[:space:]]*\}' "$WORKFLOW"
@@ -61,8 +63,8 @@ if [ -f "$WORKFLOW" ]; then
   assert_match 'number, title, state, and URL' "$WORKFLOW"
   assert_match 'Closed blockers do not halt' "$WORKFLOW"
   assert_match 'Body-prose fallback relationships.*do not halt' "$WORKFLOW"
-  assert_match 'issues this target is blocking.*do not halt' "$WORKFLOW"
-  assert_match 'parent or sub-issue relationships.*do not halt' "$WORKFLOW"
+  assert_match 'Issues this target is blocking.*do not halt' "$WORKFLOW"
+  assert_match 'Parent or sub-issue relationships.*do not halt' "$WORKFLOW"
   assert_match 'explicit current-turn override' "$WORKFLOW"
   assert_match 'Open native `blockedBy` dependencies exist' "$WORKFLOW"
   assert_match 'The native `blockedBy` dependency query fails' "$WORKFLOW"

--- a/scripts/tests/new-branch-workflow.test.sh
+++ b/scripts/tests/new-branch-workflow.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SKILL="skills/new-branch/SKILL.md"
+WORKFLOW="skills/new-branch/workflows/issue-branch.md"
+FAIL_COUNT=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+assert_file() {
+  local file="$1"
+  test -f "$file" || fail "missing expected file: $file"
+}
+
+assert_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! rg -n -U --pcre2 -e "$pattern" "$file" >/dev/null 2>&1; then
+    fail "missing expected pattern in $file: $pattern"
+  fi
+}
+
+assert_order() {
+  local first_pattern="$1"
+  local second_pattern="$2"
+  local file="$3"
+  local first_line second_line
+  first_line="$(rg -n --pcre2 -e "$first_pattern" "$file" | head -n 1 | cut -d: -f1 || true)"
+  second_line="$(rg -n --pcre2 -e "$second_pattern" "$file" | head -n 1 | cut -d: -f1 || true)"
+  if [ -z "$first_line" ] || [ -z "$second_line" ] || [ "$first_line" -ge "$second_line" ]; then
+    fail "expected pattern '$first_pattern' before '$second_pattern' in $file"
+  fi
+}
+
+assert_file "$SKILL"
+assert_file "$WORKFLOW"
+
+if [ -f "$SKILL" ]; then
+  assert_match '^name:[[:space:]]*new-branch$' "$SKILL"
+  assert_match 'open native GitHub `blockedBy`' "$SKILL"
+  assert_match 'explicitly asks to start blocked work anyway' "$SKILL"
+fi
+
+if [ -f "$WORKFLOW" ]; then
+  assert_match 'gh repo view --json nameWithOwner' "$WORKFLOW"
+  assert_match 'blockedBy\(first:100\)' "$WORKFLOW"
+  assert_match 'state:[[:space:]]*OPEN' "$WORKFLOW"
+  assert_match 'number, title, state, and URL' "$WORKFLOW"
+  assert_match 'Closed blockers do not halt' "$WORKFLOW"
+  assert_match 'Body-prose fallback relationships.*do not halt' "$WORKFLOW"
+  assert_match 'issues this target is blocking.*do not halt' "$WORKFLOW"
+  assert_match 'parent or sub-issue relationships.*do not halt' "$WORKFLOW"
+  assert_match 'explicit current-turn override' "$WORKFLOW"
+  assert_match 'Open native `blockedBy` dependencies exist' "$WORKFLOW"
+
+  assert_order 'Resolve the issue' 'Check native dependency blockers' "$WORKFLOW"
+  assert_order 'Check native dependency blockers' 'Inspect local branch state' "$WORKFLOW"
+  assert_order 'Check native dependency blockers' 'Create or update the local branch' "$WORKFLOW"
+fi
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "" >&2
+  echo "FAIL: $FAIL_COUNT new-branch workflow assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "OK: new-branch workflow assertions passed"

--- a/scripts/tests/new-branch-workflow.test.sh
+++ b/scripts/tests/new-branch-workflow.test.sh
@@ -48,8 +48,12 @@ if [ -f "$SKILL" ]; then
 fi
 
 if [ -f "$WORKFLOW" ]; then
+  assert_match 'gh issue view "\$issue" --json number,title,state' "$WORKFLOW"
+  assert_match 'issue_number=' "$WORKFLOW"
   assert_match 'gh repo view --json nameWithOwner' "$WORKFLOW"
   assert_match 'blockedBy\(first:100\)' "$WORKFLOW"
+  assert_match 'If the dependency query fails' "$WORKFLOW"
+  assert_match 'refuse unless the user gives an explicit current-turn override' "$WORKFLOW"
   assert_match 'state:[[:space:]]*OPEN' "$WORKFLOW"
   assert_match 'number, title, state, and URL' "$WORKFLOW"
   assert_match 'Closed blockers do not halt' "$WORKFLOW"
@@ -58,6 +62,7 @@ if [ -f "$WORKFLOW" ]; then
   assert_match 'parent or sub-issue relationships.*do not halt' "$WORKFLOW"
   assert_match 'explicit current-turn override' "$WORKFLOW"
   assert_match 'Open native `blockedBy` dependencies exist' "$WORKFLOW"
+  assert_match 'The native `blockedBy` dependency query fails' "$WORKFLOW"
 
   assert_order 'Resolve the issue' 'Check native dependency blockers' "$WORKFLOW"
   assert_order 'Check native dependency blockers' 'Inspect local branch state' "$WORKFLOW"

--- a/scripts/tests/suite.test.sh
+++ b/scripts/tests/suite.test.sh
@@ -6,6 +6,7 @@ bash scripts/tests/develop-issue-workflow.test.sh
 bash scripts/tests/esm-tooling.test.sh
 bash scripts/tests/finish-pr-workflow.test.sh
 bash scripts/tests/marketplace.test.sh
+bash scripts/tests/new-branch-workflow.test.sh
 bash scripts/tests/pull-request-workflow.test.sh
 bash scripts/tests/review-code-skill.test.sh
 bash scripts/tests/update-branch-workflow.test.sh

--- a/skills/new-branch/SKILL.md
+++ b/skills/new-branch/SKILL.md
@@ -20,13 +20,15 @@ implementation work.
 
 1. Read the repository guidance first, especially branch and GitHub rules.
 2. Resolve the issue in the current working directory's default `gh` repository.
-3. Compute the branch name as `<issue-number>-<kebab-title>`, matching
+3. Halt when open native GitHub `blockedBy` dependencies exist, unless the user
+   explicitly asks to start blocked work anyway.
+4. Compute the branch name as `<issue-number>-<kebab-title>`, matching
    GitHub's issue branch suggestion.
-4. Refuse to switch branches when the worktree has uncommitted changes.
-5. Fetch the repository default branch from `origin`.
-6. Create the branch from `origin/<default-branch>`, switch to it, or warn
+5. Refuse to switch branches when the worktree has uncommitted changes.
+6. Fetch the repository default branch from `origin`.
+7. Create the branch from `origin/<default-branch>`, switch to it, or warn
    before leaving a different issue branch.
-7. Report the branch and base SHA.
+8. Report the branch and base SHA.
 
 ## Guardrails
 
@@ -34,4 +36,5 @@ implementation work.
 - Never hardcode `main`; resolve the default branch through `gh repo view`.
 - Keep empty issue branches local.
 - Ask before switching away from a different issue branch.
+- Use native GitHub issue relationships as the blocked-work source of truth.
 - Stop on rebase conflicts and surface the manual resolution steps.

--- a/skills/new-branch/workflows/issue-branch.md
+++ b/skills/new-branch/workflows/issue-branch.md
@@ -41,7 +41,7 @@ against the current working directory's default `gh` repository.
        exit 1
      fi
      printf '%s\n' "$page" |
-       jq -r '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")'
+       jq -r '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN") | "#\(.number) \(.title) [\(.state)] \(.url)"'
      has_next="$(printf '%s\n' "$page" | jq -r '.data.repository.issue.blockedBy.pageInfo.hasNextPage')"
      after="$(printf '%s\n' "$page" | jq -r '.data.repository.issue.blockedBy.pageInfo.endCursor')"
      [ "$has_next" = "true" ] || break

--- a/skills/new-branch/workflows/issue-branch.md
+++ b/skills/new-branch/workflows/issue-branch.md
@@ -13,7 +13,10 @@ against the current working directory's default `gh` repository.
 1. Resolve the issue:
 
    ```sh
-   issue_number="$(gh issue view "$issue" --json number,title,state --jq .number)"
+   issue_json="$(gh issue view "$issue" --json number,title,state)"
+   issue_number="$(printf '%s\n' "$issue_json" | jq -r .number)"
+   issue_title="$(printf '%s\n' "$issue_json" | jq -r .title)"
+   issue_state="$(printf '%s\n' "$issue_json" | jq -r .state)"
    ```
 
    Refuse if the issue cannot be resolved. Refuse closed issues unless the user
@@ -50,7 +53,12 @@ against the current working directory's default `gh` repository.
    only when the user gives an explicit current-turn override such as "start
    anyway" or "start blocked work anyway".
 
-   Closed blockers do not halt. Body-prose fallback relationships such as `Blocked by #N` do not halt. Native `blocking` relationships, meaning issues this target is blocking, do not halt. Native parent or sub-issue relationships do not halt.
+   The following relationships do not halt:
+
+   - Closed blockers do not halt.
+   - Body-prose fallback relationships such as `Blocked by #N` do not halt.
+   - Issues this target is blocking do not halt.
+   - Parent or sub-issue relationships do not halt.
 
 3. Compute the branch name:
 

--- a/skills/new-branch/workflows/issue-branch.md
+++ b/skills/new-branch/workflows/issue-branch.md
@@ -13,8 +13,7 @@ against the current working directory's default `gh` repository.
 1. Resolve the issue:
 
    ```sh
-   gh issue view "$issue" --json number,title,state
-   issue_number="$(gh issue view "$issue" --json number --jq .number)"
+   issue_number="$(gh issue view "$issue" --json number,title,state --jq .number)"
    ```
 
    Refuse if the issue cannot be resolved. Refuse closed issues unless the user
@@ -26,13 +25,24 @@ against the current working directory's default `gh` repository.
    repo_full_name="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
    owner="${repo_full_name%%/*}"
    repo="${repo_full_name#*/}"
-   gh api graphql \
-     -F owner="$owner" -F repo="$repo" -F number="$issue_number" \
-     -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100){nodes{number title state url}}}}}' \
-     --jq '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")'
+   after=null
+   while :; do
+     page="$(gh api graphql \
+       -F owner="$owner" -F repo="$repo" -F number="$issue_number" -F after="$after" \
+       -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100, after:$after){nodes{number title state url} pageInfo { hasNextPage endCursor }}}}}')"
+     printf '%s\n' "$page" |
+       jq -r '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")'
+     has_next="$(printf '%s\n' "$page" | jq -r '.data.repository.issue.blockedBy.pageInfo.hasNextPage')"
+     after="$(printf '%s\n' "$page" | jq -r '.data.repository.issue.blockedBy.pageInfo.endCursor')"
+     [ "$has_next" = "true" ] || break
+   done
    ```
 
-   If the dependency query fails, refuse unless the user gives an explicit current-turn override. This includes GraphQL errors, an unavailable `blockedBy` field, or any other result that prevents the workflow from checking native GitHub issue relationships as the source of truth.
+   Fetch every dependency page before deciding that no open blockers exist. If
+   the dependency query fails, refuse unless the user gives an explicit
+   current-turn override. This includes GraphQL errors, an unavailable
+   `blockedBy` field, or any other result that prevents the workflow from
+   checking native GitHub issue relationships as the source of truth.
 
    Treat blockers with `state: OPEN` as active blockers. If any open blockers
    exist, refuse before inspecting or changing local

--- a/skills/new-branch/workflows/issue-branch.md
+++ b/skills/new-branch/workflows/issue-branch.md
@@ -14,6 +14,7 @@ against the current working directory's default `gh` repository.
 
    ```sh
    gh issue view "$issue" --json number,title,state
+   issue_number="$(gh issue view "$issue" --json number --jq .number)"
    ```
 
    Refuse if the issue cannot be resolved. Refuse closed issues unless the user
@@ -30,6 +31,8 @@ against the current working directory's default `gh` repository.
      -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100){nodes{number title state url}}}}}' \
      --jq '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")'
    ```
+
+   If the dependency query fails, refuse unless the user gives an explicit current-turn override. This includes GraphQL errors, an unavailable `blockedBy` field, or any other result that prevents the workflow from checking native GitHub issue relationships as the source of truth.
 
    Treat blockers with `state: OPEN` as active blockers. If any open blockers
    exist, refuse before inspecting or changing local
@@ -89,6 +92,7 @@ against the current working directory's default `gh` repository.
 - Issue cannot be resolved.
 - Issue is closed without explicit allowance.
 - Open native `blockedBy` dependencies exist without explicit override.
+- The native `blockedBy` dependency query fails without explicit override.
 - Worktree has uncommitted changes.
 - Default branch cannot be resolved.
 - User asks for a different repository from the current working directory.

--- a/skills/new-branch/workflows/issue-branch.md
+++ b/skills/new-branch/workflows/issue-branch.md
@@ -30,9 +30,16 @@ against the current working directory's default `gh` repository.
    repo="${repo_full_name#*/}"
    after=null
    while :; do
-     page="$(gh api graphql \
+     if ! page="$(gh api graphql \
        -F owner="$owner" -F repo="$repo" -F number="$issue_number" -F after="$after" \
-       -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100, after:$after){nodes{number title state url} pageInfo { hasNextPage endCursor }}}}}')"
+       -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100, after:$after){nodes{number title state url} pageInfo { hasNextPage endCursor }}}}}')"; then
+       echo "Dependency query failed; refuse unless explicit override." >&2
+       exit 1
+     fi
+     if printf '%s\n' "$page" | jq -e '.errors | length > 0' >/dev/null; then
+       echo "Dependency query returned GraphQL errors; refuse unless explicit override." >&2
+       exit 1
+     fi
      printf '%s\n' "$page" |
        jq -r '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")'
      has_next="$(printf '%s\n' "$page" | jq -r '.data.repository.issue.blockedBy.pageInfo.hasNextPage')"

--- a/skills/new-branch/workflows/issue-branch.md
+++ b/skills/new-branch/workflows/issue-branch.md
@@ -19,7 +19,27 @@ against the current working directory's default `gh` repository.
    Refuse if the issue cannot be resolved. Refuse closed issues unless the user
    explicitly allows closed issue work.
 
-2. Compute the branch name:
+2. Check native dependency blockers:
+
+   ```sh
+   repo_full_name="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+   owner="${repo_full_name%%/*}"
+   repo="${repo_full_name#*/}"
+   gh api graphql \
+     -F owner="$owner" -F repo="$repo" -F number="$issue_number" \
+     -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100){nodes{number title state url}}}}}' \
+     --jq '.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")'
+   ```
+
+   Treat blockers with `state: OPEN` as active blockers. If any open blockers
+   exist, refuse before inspecting or changing local
+   branch state. Report each blocker by number, title, state, and URL. Continue
+   only when the user gives an explicit current-turn override such as "start
+   anyway" or "start blocked work anyway".
+
+   Closed blockers do not halt. Body-prose fallback relationships such as `Blocked by #N` do not halt. Native `blocking` relationships, meaning issues this target is blocking, do not halt. Native parent or sub-issue relationships do not halt.
+
+3. Compute the branch name:
 
    - Lowercase the title.
    - Replace each run of non-`[a-z0-9]` characters with `-`.
@@ -28,7 +48,7 @@ against the current working directory's default `gh` repository.
    - Limit the full branch name to 60 characters. Prefer the previous hyphen
      boundary and trim any trailing hyphen.
 
-3. Inspect local branch state:
+4. Inspect local branch state:
 
    ```sh
    git branch --show-current
@@ -39,14 +59,14 @@ against the current working directory's default `gh` repository.
    on the computed branch, report success and stop. If on a different
    issue-number-prefixed branch, ask before switching.
 
-4. Resolve and fetch the default branch:
+5. Resolve and fetch the default branch:
 
    ```sh
    gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
    git fetch origin "$default_branch"
    ```
 
-5. Create or update the local branch:
+6. Create or update the local branch:
 
    - If the branch does not exist locally, run:
 
@@ -57,7 +77,7 @@ against the current working directory's default `gh` repository.
    - If the branch exists locally, switch to it and rebase onto
      `origin/$default_branch`.
 
-6. Report:
+7. Report:
 
    ```text
    Branch: <branch>
@@ -68,6 +88,7 @@ against the current working directory's default `gh` repository.
 
 - Issue cannot be resolved.
 - Issue is closed without explicit allowance.
+- Open native `blockedBy` dependencies exist without explicit override.
 - Worktree has uncommitted changes.
 - Default branch cannot be resolved.
 - User asks for a different repository from the current working directory.


### PR DESCRIPTION
## Linked issue

Closes #170

## What changed

Context: standalone - prevent agents from starting branch work for blocked issues

- Added a native `blockedBy` dependency gate to `new-branch` - branch setup now halts before local branch changes when open blockers exist, reports blocker details, paginates every blocker page, and allows only explicit current-turn override.
- Documented failure and non-blocking relationship cases - query failures fail closed with override, while closed blockers, body prose, issues this target blocks, parents, and sub-issues are intentionally ignored for branch-start gating.
- Added `new-branch` workflow assertions to the suite and targeted test guidance - locks the dependency-gate contract into local verification.

## Verification

- `bash scripts/tests/new-branch-workflow.test.sh` before implementation — failed with 14 missing-contract assertions, confirming the red test.
- `bash scripts/tests/new-branch-workflow.test.sh` — passed.
- `pnpm test` — passed.
- `gh api graphql -F owner=patinaproject -F repo=skills -F number=170 -F after=null -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$number){blockedBy(first:100, after:$after){nodes{number title state url} pageInfo { hasNextPage endCursor }}}}}' --jq '.data.repository.issue.blockedBy'` — passed; returned `{"nodes":[],"pageInfo":{"endCursor":null,"hasNextPage":false}}`.
- Local isolated `review-code` pass — no blocking, non-blocking, or low-severity findings.
- `git diff --check` — passed.
- `pnpm exec commitlint --from origin/main --to HEAD` — passed.
