### PR TITLE
docs: #174 allow finish-pr to report failing checks

### DIFF
--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -57,6 +57,9 @@ if [ -f "$SKILL" ]; then
   assert_match "currently available PR feedback" "$SKILL"
   assert_match "eligible conversation resolution" "$SKILL"
   assert_match "re-query PR feedback after checks" "$SKILL"
+  assert_match "Failing checks do" "$SKILL"
+  assert_match "not halt the skill by themselves" "$SKILL"
+  assert_match "concrete non-ready check dispositions" "$SKILL"
 fi
 
 if [ -f "$WORKFLOW" ]; then
@@ -100,7 +103,9 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "PR head SHA, or feedback inventory" "$WORKFLOW"
   assert_match "(?i)do not filter to required checks only" "$WORKFLOW"
   assert_match "skipped-problematic, or otherwise non-pass" "$WORKFLOW"
-  assert_match "Fix branch-local blockers" "$WORKFLOW"
+  assert_match "Fix branch-local check causes" "$WORKFLOW"
+  assert_match "Do not halt solely because a check failed" "$WORKFLOW"
+  assert_match "per-failing-check dispositions" "$WORKFLOW"
   assert_match "push follow-up commits when appropriate" "$WORKFLOW"
   assert_match "resolveReviewThread" "$WORKFLOW"
   assert_match "isResolved" "$WORKFLOW"
@@ -148,6 +153,10 @@ if [ -f "$TRIAGE" ]; then
   assert_match "two consecutive 10-minute no-progress windows" "$TRIAGE"
   assert_match "full PR state resync" "$TRIAGE"
   assert_match "failed, canceled, skipped-problematic, or otherwise non-pass" "$TRIAGE"
+  assert_match 'Do not classify a check as `needs-human` solely because it failed' "$TRIAGE"
+  assert_match "needs missing secrets" "$TRIAGE"
+  assert_match "permission failure" "$TRIAGE"
+  assert_match "external outage" "$TRIAGE"
   assert_no_match 'Use `gh pr checks --watch`; do not use fail-fast by default' "$TRIAGE"
 fi
 

--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -60,6 +60,7 @@ if [ -f "$SKILL" ]; then
   assert_match "Failing checks do" "$SKILL"
   assert_match "not halt the skill by themselves" "$SKILL"
   assert_match "concrete non-ready check dispositions" "$SKILL"
+  assert_match "ready-for-review is distinct from" "$SKILL"
 fi
 
 if [ -f "$WORKFLOW" ]; then
@@ -81,6 +82,8 @@ if [ -f "$WORKFLOW" ]; then
   assert_order "tool-enforced 10-minute timeout" "Re-query the full PR feedback surface" "$WORKFLOW"
   assert_order "Re-query the full PR feedback surface" "Final unresolved review-thread gate" "$WORKFLOW"
   assert_order "Final unresolved review-thread gate" "gh pr ready" "$WORKFLOW"
+  assert_match "Ready-for-review is distinct from ready-to-merge" "$WORKFLOW"
+  assert_match "known failing checks remain" "$WORKFLOW"
   assert_match "fail-fast bounded-watch" "$WORKFLOW"
   assert_match "tool-enforced 10-minute timeout" "$WORKFLOW"
   assert_match "timeout 10m gh pr checks --watch --fail-fast" "$WORKFLOW"
@@ -153,6 +156,7 @@ if [ -f "$TRIAGE" ]; then
   assert_match "two consecutive 10-minute no-progress windows" "$TRIAGE"
   assert_match "full PR state resync" "$TRIAGE"
   assert_match "failed, canceled, skipped-problematic, or otherwise non-pass" "$TRIAGE"
+  assert_match "reportable check disposition" "$TRIAGE"
   assert_match 'Do not classify a check as `needs-human` solely because it failed' "$TRIAGE"
   assert_match "needs missing secrets" "$TRIAGE"
   assert_match "permission failure" "$TRIAGE"

--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -157,6 +157,8 @@ if [ -f "$TRIAGE" ]; then
   assert_match "needs missing secrets" "$TRIAGE"
   assert_match "permission failure" "$TRIAGE"
   assert_match "external outage" "$TRIAGE"
+  assert_match "Classify flaky, infrastructure-owned, external-outage, missing-secret, and" "$TRIAGE"
+  assert_match 'permission-limited check failures as `explain`' "$TRIAGE"
   assert_no_match 'Use `gh pr checks --watch`; do not use fail-fast by default' "$TRIAGE"
 fi
 

--- a/skills/finish-pr/SKILL.md
+++ b/skills/finish-pr/SKILL.md
@@ -17,7 +17,8 @@ the ready-for-review PR.
 This skill verifies, commits, pushes, creates or reuses a ready-for-review pull
 request, then loops through mergeability, currently available PR feedback,
 eligible conversation resolution, and checks until the PR is ready-to-merge or
-human input is required. It never merges the PR.
+the current check state has been fully triaged and reported. Failing checks do
+not halt the skill by themselves. It never merges the PR.
 
 ## Workflow
 
@@ -33,9 +34,12 @@ human input is required. It never merges the PR.
    available PR feedback, resolve eligible conversations, watch all checks in
    fail-fast bounded observation windows, triage every problematic check,
    re-query PR feedback after checks, re-query again after every watch exit or
-   timeout, fix branch-local issues, push, and repeat.
-9. Mark draft PRs ready when the loop reaches the ready state.
-10. Report ready-to-merge status without merging.
+   timeout, fix branch-local issues, push, and repeat. When a failing check is
+   outside branch scope or cannot be fixed by the agent, record a concrete
+   disposition and continue to final reporting instead of halting.
+9. Mark draft PRs ready only when the loop reaches the ready state.
+10. Report ready-to-merge status or concrete non-ready check dispositions
+    without merging.
 
 ## Guardrails
 
@@ -46,5 +50,9 @@ human input is required. It never merges the PR.
 - Do not use required-check-only watching; optional checks remain in scope.
 - Stop after the documented no-progress threshold instead of watching
   indefinitely.
+- Do not stop solely because a check failed, was canceled, or is out of scope;
+  triage it, fix branch-local causes when possible, and otherwise report the
+  check disposition.
 - Do not add AI or agent attribution unless the repository requires it.
-- Stop for secrets, permissions, product decisions, or ambiguous scope.
+- Stop for non-check secrets, permissions, product decisions, or ambiguous
+  scope.

--- a/skills/finish-pr/SKILL.md
+++ b/skills/finish-pr/SKILL.md
@@ -37,7 +37,9 @@ not halt the skill by themselves. It never merges the PR.
    timeout, fix branch-local issues, push, and repeat. When a failing check is
    outside branch scope or cannot be fixed by the agent, record a concrete
    disposition and continue to final reporting instead of halting.
-9. Mark draft PRs ready only when the loop reaches the ready state.
+9. Mark draft PRs ready for review once all currently visible failing checks
+   have been fixed or dispositioned; ready-for-review is distinct from
+   ready-to-merge.
 10. Report ready-to-merge status or concrete non-ready check dispositions
     without merging.
 
@@ -54,5 +56,5 @@ not halt the skill by themselves. It never merges the PR.
   triage it, fix branch-local causes when possible, and otherwise report the
   check disposition.
 - Do not add AI or agent attribution unless the repository requires it.
-- Stop for secrets, permissions, product decisions, or ambiguous scope that are
-  not check-related.
+- Stop for non-check blockers involving secrets, permissions, product
+  decisions, or ambiguous scope.

--- a/skills/finish-pr/SKILL.md
+++ b/skills/finish-pr/SKILL.md
@@ -54,5 +54,5 @@ not halt the skill by themselves. It never merges the PR.
   triage it, fix branch-local causes when possible, and otherwise report the
   check disposition.
 - Do not add AI or agent attribution unless the repository requires it.
-- Stop for non-check secrets, permissions, product decisions, or ambiguous
-  scope.
+- Stop for secrets, permissions, product decisions, or ambiguous scope that are
+  not check-related.

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -1,7 +1,9 @@
 # Ready for Merge Workflow
 
 **Goal:** Carry completed branch-local work through publication, checks, and
-PR feedback until the pull request is ready to merge or human input is required.
+PR feedback until the pull request is ready to merge or every visible non-ready
+state has a concrete disposition. A failing check is evidence to triage and
+report, not a halt condition by itself.
 
 ## Preconditions
 
@@ -183,10 +185,13 @@ directory's default `gh` repository.
 
 13. Triage every non-pass, canceled, or otherwise problematic check with
     [triage.md](triage.md), using the full PR state snapshot rather than
-    tunneling into only the first failed check. Fix branch-local blockers,
+    tunneling into only the first failed check. Fix branch-local check causes,
     push follow-up commits when appropriate, and restart the readiness loop on
-    the new head. Continue for `explain`, `stale`, and `defer` outcomes only
-    with concrete evidence. Stop only when a check returns `needs-human`.
+    the new head. Continue for `explain`, `stale`, and `defer` outcomes with
+    concrete evidence. Do not halt solely because a check failed, was canceled,
+    is flaky, is infrastructure-owned, lacks agent permissions, depends on
+    missing secrets, or is outside the PR scope; record that disposition and
+    continue to the feedback and final reporting gates.
 
 14. Re-query the full PR feedback surface after checks finish, fail fast, or
     time out because GitHub Actions or review automation may have posted new
@@ -228,7 +233,7 @@ directory's default `gh` repository.
     - Mergeability and conflict-handling evidence, including the base branch,
       merge state, local merge result, and any merge or conflict-resolution
       commit pushed during the loop.
-    - Check status.
+    - Check status and per-failing-check dispositions.
     - Feedback status and any no-progress stop reason.
     - Final unresolved review-thread gate result.
     - Feedback handled, deferred, stale, explained, or blocked, including a
@@ -242,7 +247,10 @@ directory's default `gh` repository.
 - Local verification fails for a reason that is not branch-local or in scope.
 - Merge conflict resolution requires product judgment, secrets, permissions,
   destructive git operations, unrelated scope, or unverifiable semantic choices.
-- Check or feedback triage returns `needs-human`.
+- Feedback triage returns `needs-human`.
+- Check triage uncovers a non-check human blocker, such as a required product
+  decision or ambiguous branch scope. The failing check itself is not the halt
+  condition.
 - Two consecutive 10-minute no-progress check observation windows complete.
 - Review feedback changes requirements, acceptance criteria, or product scope.
 - Another actor pushes to the PR while the readiness loop is running.

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -217,11 +217,17 @@ directory's default `gh` repository.
     fixes or newly pushed commits. Unresolved threads are blockers until they
     are resolved, fixed, or evidence-classified as stale or non-blocking.
 
-16. When the loop reaches the ready state, mark a draft PR ready for review:
+16. When all currently visible failing checks have been fixed or dispositioned,
+    mark a draft PR ready for review:
 
     ```sh
     gh pr ready
     ```
+
+    Ready-for-review is distinct from ready-to-merge. A draft PR can become
+    ready for review even when known failing checks remain, as long as each
+    failing check has a concrete disposition and no human-owned stop condition
+    remains.
 
     Keep the no-merge guardrail: stop when merge is the next action.
 

--- a/skills/finish-pr/workflows/triage.md
+++ b/skills/finish-pr/workflows/triage.md
@@ -75,6 +75,9 @@ executing the state action.
   canceled, needs missing secrets, hit a permission failure, depends on an
   external outage, is flaky infrastructure, or is outside the PR's scope. Use
   `explain`, `stale`, or `defer` with evidence and continue to final reporting.
+- Classify flaky, infrastructure-owned, external-outage, missing-secret, and
+  permission-limited check failures as `explain` when evidence shows they are
+  not branch-local.
 - Only stop when check investigation reveals a separate non-check blocker, such
   as a required product decision, ambiguous branch scope, or conflicting human
   direction.

--- a/skills/finish-pr/workflows/triage.md
+++ b/skills/finish-pr/workflows/triage.md
@@ -9,7 +9,7 @@ review threads, top-level PR comments, and review bodies.
 | `explain` | Valid to answer without code | Reply or report with concise evidence |
 | `stale` | No longer applies to latest head | Reply or report with current-head evidence |
 | `defer` | Valid but outside this PR | Explain the scope decision; do not create an issue |
-| `needs-human` | Requires judgment, permissions, secrets, or conflicting direction | Stop and ask |
+| `needs-human` | Non-check work requires judgment, permissions, secrets, or conflicting direction | Stop and ask |
 
 For merge conflicts, apply the Merge Conflict Rules below when choosing and
 executing the state action.
@@ -71,8 +71,13 @@ executing the state action.
   check result before starting another watch window.
 - Inspect logs before classifying.
 - Fix branch-local failures in normal follow-up commits.
-- Stop for missing secrets, permission failures, external outages, or flaky
-  infrastructure that cannot be proven branch-local.
+- Do not classify a check as `needs-human` solely because it failed, was
+  canceled, needs missing secrets, hit a permission failure, depends on an
+  external outage, is flaky infrastructure, or is outside the PR's scope. Use
+  `explain`, `stale`, or `defer` with evidence and continue to final reporting.
+- Only stop when check investigation reveals a separate non-check blocker, such
+  as a required product decision, ambiguous branch scope, or conflicting human
+  direction.
 - Re-query the full feedback surface after checks finish, fail fast, or time out
   so CI-authored review comments are triaged before final readiness reporting.
 

--- a/skills/finish-pr/workflows/triage.md
+++ b/skills/finish-pr/workflows/triage.md
@@ -6,7 +6,7 @@ review threads, top-level PR comments, and review bodies.
 | State | Meaning | Action |
 | --- | --- | --- |
 | `fix-now` | Branch-local, actionable, in scope | Patch, verify, commit, push, and re-check |
-| `explain` | Valid to answer without code | Reply or report with concise evidence |
+| `explain` | Valid to answer without code, or a reportable check disposition | Reply or report with concise evidence |
 | `stale` | No longer applies to latest head | Reply or report with current-head evidence |
 | `defer` | Valid but outside this PR | Explain the scope decision; do not create an issue |
 | `needs-human` | Non-check work requires judgment, permissions, secrets, or conflicting direction | Stop and ask |


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #174

## What changed

Context: standalone - finish-pr should not halt on unrelated failing checks

- Updated the finish-pr top-level contract and ready-for-merge workflow - failed checks now require triage and concrete dispositions rather than automatic halt behavior.
- Refined check triage rules - branch-local failures still get fixed, while out-of-scope, flaky, infrastructure-owned, secret-dependent, and permission-limited checks are reported with evidence.
- Expanded finish-pr workflow assertions - the top-level skill, workflow, and triage docs now pin the no-auto-halt behavior and non-ready disposition reporting.

## Verification

- `bash scripts/tests/finish-pr-workflow.test.sh` — passed
- `git diff --check` — passed
- `pnpm test` — passed
- `review-code` — first read-only review found one blocking wording issue; second read-only review found no blocking, non-blocking, or low-severity findings
