### PR TITLE
docs: #1291 teach behavior-focused PR test plans

### DIFF
--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -116,6 +116,13 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "unaddressed findings" "$WORKFLOW"
   assert_match "fix-now.*pending checks" "$WORKFLOW"
   assert_match "explain.*stale.*defer.*before checks" "$WORKFLOW"
+  assert_match "Translate local verification evidence into QA-friendly manual test steps" "$WORKFLOW"
+  assert_match "concrete user action and expected app result" "$WORKFLOW"
+  assert_match "Prefer user flows, routes, screens, forms, filters, buttons, visual states" "$WORKFLOW"
+  assert_match "Do not ask humans to run tests, lint, type-checks, hooks, package commands" "$WORKFLOW"
+  assert_match "no realistic app-level" "$WORKFLOW"
+  assert_match "app behavior or repo contract" "$WORKFLOW"
+  assert_match "Keep generated example checkboxes unchecked" "$WORKFLOW"
 fi
 
 if [ -f "$TRIAGE" ]; then

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -49,8 +49,20 @@ directory's default `gh` repository.
    - Read `.github/pull_request_template.md`.
    - Use the repository's PR title format.
    - Include `Closes #<issue>` or another required closing keyword.
-   - Summarize acceptance criteria and verification evidence in the template's
-     verification section when the linked issue defines acceptance criteria.
+   - Summarize acceptance criteria and local verification evidence outside the
+     human `## Test plan` when the linked issue defines acceptance criteria.
+   - Translate local verification evidence into QA-friendly manual test steps
+     for the real app.
+   - Write each test-plan item as a concrete user action and expected app result.
+   - Prefer user flows, routes, screens, forms, filters, buttons, visual states,
+     and saved data over commands.
+   - Do not ask humans to run tests, lint, type-checks, hooks, package commands,
+     or other checks that CI owns.
+   - Use command-based test-plan items only when no realistic app-level
+     verification path exists.
+   - Name the app behavior or repo contract that any command-based exception
+     verifies.
+   - Keep generated example checkboxes unchecked.
    - Create a ready-for-review PR by default.
 
 7. Enter the readiness loop. Each loop pass starts by capturing the current PR


### PR DESCRIPTION
## Linked issue

Related to patinaproject/patinaproject#1291 - Durable finish-pr skill guidance for the Patina Project issue lives in this repo.

## What changed

Context: patinaproject/patinaproject#1291 - finish-pr source guidance needs the same behavior-focused PR test-plan rule as the consuming repo.

- Updated finish-pr PR authoring guidance - agents translate verification evidence into QA-friendly manual app steps and avoid CI-owned command transcripts.
- Added workflow assertions - future finish-pr guidance must keep human-focused test-plan rules in place.

## Verification

- `bash scripts/tests/finish-pr-workflow.test.sh` - passed.
- `pnpm exec markdownlint-cli2 skills/finish-pr/workflows/ready-for-merge.md` - passed.
- `pnpm lint:md` - failed on unrelated pre-existing `CHANGELOG.md:5 MD012/no-multiple-blanks`; changed skill Markdown passed direct lint.
