### PR TITLE
docs: #183 require final finish-pr readiness gate

### DIFF
--- a/scripts/tests/finish-pr-workflow.test.sh
+++ b/scripts/tests/finish-pr-workflow.test.sh
@@ -61,6 +61,10 @@ if [ -f "$SKILL" ]; then
   assert_match "not halt the skill by themselves" "$SKILL"
   assert_match "concrete non-ready check dispositions" "$SKILL"
   assert_match "ready-for-review is distinct from" "$SKILL"
+  assert_match "final ready-to-merge" "$SKILL"
+  assert_match "report the PR as not ready-to-merge" "$SKILL"
+  assert_match "human-friendly language" "$SKILL"
+  assert_match "must not call it" "$SKILL"
 fi
 
 if [ -f "$WORKFLOW" ]; then
@@ -124,6 +128,29 @@ if [ -f "$WORKFLOW" ]; then
   assert_match "unaddressed findings" "$WORKFLOW"
   assert_match "fix-now.*pending checks" "$WORKFLOW"
   assert_match "explain.*stale.*defer.*before checks" "$WORKFLOW"
+  assert_match "Mandatory final ready-to-merge check" "$WORKFLOW"
+  assert_match "immediately before the final" "$WORKFLOW"
+  assert_match "gh pr view <pr-number-or-url> --json" "$WORKFLOW"
+  assert_match "gh pr checks <pr-number-or-url>" "$WORKFLOW"
+  assert_match "local worktree is clean" "$WORKFLOW"
+  assert_match 'local branch equals the PR `headRefName`' "$WORKFLOW"
+  assert_match 'local `HEAD` equals the PR `headRefOid`' "$WORKFLOW"
+  assert_match '`mergeStateStatus` is `CLEAN`' "$WORKFLOW"
+  assert_match "PR is not a draft" "$WORKFLOW"
+  assert_match 'every current check has status `COMPLETED` and conclusion `SUCCESS`' "$WORKFLOW"
+  assert_match 'no paginated GraphQL review thread has `isResolved: false`' "$WORKFLOW"
+  assert_match "gh api graphql --paginate" "$WORKFLOW"
+  assert_match 'Replace `<pr-number-or-url>`, `<owner>`, `<repo>`, and `<pr-number>`' "$WORKFLOW"
+  assert_match 'reviewThreads\(first:100, after:\$endCursor\)' "$WORKFLOW"
+  assert_match "comments\\(first:100\\)" "$WORKFLOW"
+  assert_match "pageInfo\\{hasNextPage endCursor\\}" "$WORKFLOW"
+  assert_match "author\\{login\\} body url createdAt path line originalLine diffHunk" "$WORKFLOW"
+  assert_match 'If every gate passes, report `ready-to-merge`' "$WORKFLOW"
+  assert_match 'If any gate fails, report' "$WORKFLOW"
+  assert_match "human-friendly language" "$WORKFLOW"
+  assert_match "Do not dump the full command" "$WORKFLOW"
+  assert_match "Do not describe a blocked outcome" "$WORKFLOW"
+  assert_order "Mandatory final ready-to-merge check" "Final report includes" "$WORKFLOW"
 fi
 
 if [ -f "$TRIAGE" ]; then

--- a/skills/finish-pr/SKILL.md
+++ b/skills/finish-pr/SKILL.md
@@ -20,6 +20,11 @@ eligible conversation resolution, and checks until the PR is ready-to-merge or
 the current check state has been fully triaged and reported. Failing checks do
 not halt the skill by themselves. It never merges the PR.
 
+Before the final response, the workflow must run a strict final ready-to-merge
+check. If any final gate fails, report the PR as not ready-to-merge and list the
+blocker in human-friendly language; do not imply success, and must not call it
+finished.
+
 ## Workflow
 
 1. Read repository guidance, commit rules, and the PR template.

--- a/skills/finish-pr/workflows/ready-for-merge.md
+++ b/skills/finish-pr/workflows/ready-for-merge.md
@@ -239,7 +239,72 @@ directory's default `gh` repository.
 
     Keep the no-merge guardrail: stop when merge is the next action.
 
-17. Final report includes:
+17. Mandatory final ready-to-merge check. Run this immediately before the final
+    response, after all feedback, check, draft, and branch-freshness handling is
+    complete. Re-capture the local checkout, PR identity, GitHub merge state,
+    current checks, and paginated GraphQL review threads; do not reuse earlier
+    readiness-loop evidence as the final answer.
+
+    ```sh
+    pwd
+    git branch --show-current
+    git status --short
+    git rev-parse HEAD
+    gh pr view <pr-number-or-url> --json url,headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,isDraft,reviewDecision,statusCheckRollup
+    gh pr checks <pr-number-or-url>
+    ```
+
+    Also enumerate review threads with paginated GraphQL for the PR immediately
+    before reporting. REST review comments are not sufficient, and replies do
+    not count as resolution. Use this self-contained query shape, preserving the
+    pagination and fields needed to identify unresolved actionable feedback.
+    Replace `<pr-number-or-url>`, `<owner>`, `<repo>`, and `<pr-number>` with
+    the resolved PR identity from this workflow before running these commands:
+
+    ```sh
+    gh api graphql --paginate \
+      -F owner=<owner> -F repo=<repo> -F number=<pr-number> \
+      -f query='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){
+        repository(owner:$owner,name:$repo){
+          pullRequest(number:$number){
+            reviewThreads(first:100, after:$endCursor){
+              nodes{
+                id
+                isResolved
+                path
+                line
+                comments(first:100){
+                  nodes{id author{login} body url createdAt path line originalLine diffHunk}
+                }
+              }
+              pageInfo{hasNextPage endCursor}
+            }
+          }
+        }
+      }'
+    ```
+
+    The PR is `ready-to-merge` only when every final gate below is true:
+
+    - local worktree is clean.
+    - local branch equals the PR `headRefName`.
+    - local `HEAD` equals the PR `headRefOid`.
+    - `mergeStateStatus` is `CLEAN`.
+    - PR is not a draft.
+    - every current check has status `COMPLETED` and conclusion `SUCCESS`.
+    - no paginated GraphQL review thread has `isResolved: false`.
+    - no human blocker or no-progress stop condition remains.
+
+    If every gate passes, report `ready-to-merge`. If any gate fails, report
+    `not ready-to-merge` and list the blocker in human-friendly language, with
+    just enough evidence to make the state clear. Do not dump the full command
+    output or every collected field unless the user asks for it. Check
+    dispositions, stale feedback explanations, and evidence-bearing replies may
+    explain why the workflow is blocked, but they do not permit ready-to-merge
+    wording when a gate is false. Do not describe a blocked outcome as
+    finished.
+
+18. Final report includes:
 
     - PR URL.
     - Latest head SHA.
@@ -249,7 +314,9 @@ directory's default `gh` repository.
       commit pushed during the loop.
     - Check status and per-failing-check dispositions.
     - Feedback status and any no-progress stop reason.
-    - Final unresolved review-thread gate result.
+    - Final ready-to-merge check result, including the final unresolved
+      review-thread gate result and the human-readable blocker when the PR is
+      not ready-to-merge.
     - Feedback handled, deferred, stale, explained, or blocked, including a
       per-finding disposition for every top-level review finding.
     - Human blockers, if any.


### PR DESCRIPTION
## Linked issue

Closes #183

## What changed

Context: standalone - finish-pr could over-report success when the PR still had unresolved blockers

- Added a mandatory final readiness snapshot to the finish-pr workflow - ensures ready-to-merge is only reported from fresh command-backed evidence
- Documented exact pass/fail predicates for ready-to-merge reporting - makes dirty worktrees, stale heads, draft state, non-pass checks, unresolved threads, and human blockers explicit blockers
- Extended finish-pr workflow policy assertions - protects the strict final gate and blocked wording rules from drifting
