### PR TITLE
fix: #206 clarify archive fetch retries

### DIFF
--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -77,11 +77,12 @@ function isRetryableFetchError(error) {
 
 function fetchBufferOnce(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
+    const timeoutMs = fetchTimeoutMs();
     const deadlineTimer = setTimeout(() => {
       const error = new Error(`timed out fetching ${url}`);
       error.code = "ETIMEDOUT_FETCH";
       request.destroy(error);
-    }, fetchTimeoutMs());
+    }, timeoutMs);
 
     const request = https.get(
       url,
@@ -89,7 +90,7 @@ function fetchBufferOnce(url, redirectCount = 0) {
         headers: {
           "User-Agent": "patina-skills-install",
         },
-        timeout: fetchTimeoutMs(),
+        timeout: timeoutMs,
       },
       (response) => {
         if (
@@ -252,6 +253,8 @@ function parseTarEntries(buffer) {
 async function fetchGitHubArchive(source, ref) {
   const url = `https://codeload.github.com/${source}/tar.gz/${ref}`;
 
+  // Transport retries happen inside fetchBuffer; this loop only retries
+  // archive decode failures from a truncated or otherwise invalid response.
   for (let attempt = 1; attempt <= fetchAttempts; attempt += 1) {
     try {
       const archive = await fetchBuffer(url);


### PR DESCRIPTION
## Linked issue

Closes #206

## What changed

Context: follow-up to PR #204 hosted review

- Cache the archive fetch timeout once per request - keeps the wall-clock deadline and socket idle timeout aligned for a single HTTPS request.
- Clarify the archive retry loop comment - makes it explicit that transport retries live in `fetchBuffer` and the outer loop only retries archive decode failures.
