### PR TITLE
feat: #217 drop agent-plugin mode from scaffold-repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ See [./skills/update-branch/](./skills/update-branch/) for the skill contract.
 ### scaffold-repository
 
 Teams spend disproportionate time on repo plumbing - commit conventions,
-markdown linting, PR templates, Husky hooks, release-please wiring, and AI
-agent plugin manifests. `scaffold-repository` emits the full Patina Project
-baseline and keeps it aligned on rerun.
+markdown linting, PR templates, and Husky hooks. `scaffold-repository` emits the
+full Patina Project baseline and keeps it aligned on rerun.
 
 See [./skills/scaffold-repository/](./skills/scaffold-repository/) for the full
 README and skill contract.

--- a/scripts/tests/scaffold-cleanup.test.sh
+++ b/scripts/tests/scaffold-cleanup.test.sh
@@ -199,6 +199,20 @@ assert_no_match "skills:refresh|skills:restore" \
 assert_match "scripts/worktree-setup\\.sh" \
   skills/scaffold-repository/SKILL.md skills/scaffold-repository/audit-checklist.md
 
+# scaffold-repository no longer scaffolds or audits AI-agent-plugin repos. The
+# plugin emit mode, the audit-checklist plugin area, and the plugin-version
+# lockstep release machinery must all be gone from the skill surface.
+assert_no_match "is-agent-plugin|agent[ -]plugin|Agent plugin surfaces" \
+  skills/scaffold-repository/SKILL.md \
+  skills/scaffold-repository/audit-checklist.md \
+  skills/scaffold-repository/README.md \
+  skills/scaffold-repository/agent-spawn-template.md
+
+assert_no_match "release-please-config|release-please-manifest|claude-plugin|codex-plugin|plugins/marketplace" \
+  skills/scaffold-repository/SKILL.md \
+  skills/scaffold-repository/audit-checklist.md \
+  skills/scaffold-repository/README.md
+
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "" >&2
   echo "FAIL: $FAIL_COUNT scaffold cleanup assertion(s) failed" >&2

--- a/skills/scaffold-repository/README.md
+++ b/skills/scaffold-repository/README.md
@@ -2,7 +2,7 @@
 
 Scaffold a new repository – or realign an existing one – to the Patina Project baseline. One invocation, consistent conventions, portable across every major AI coding tool.
 
-`scaffold-repository` is distributed through the [`patinaproject/skills`](https://github.com/patinaproject/skills) marketplace. It ships a single skill that scaffolds a complete Patina Project baseline repository (commit + PR conventions, PNPM + Husky + markdownlint, agent docs, plugin manifests, release flow, GitHub repo settings) and keeps existing repos aligned with the latest live baseline on rerun.
+`scaffold-repository` is distributed through the [`patinaproject/skills`](https://github.com/patinaproject/skills) marketplace. It ships a single skill that scaffolds a complete Patina Project baseline repository (commit + PR conventions, PNPM + Husky + markdownlint, agent docs, GitHub repo settings) and keeps existing repos aligned with the latest live baseline on rerun.
 
 ## How scaffold-repository works
 
@@ -15,7 +15,6 @@ flowchart TD
     newrepo["New repo"]
     realign["Realignment"]
     scaffold["Scaffold core baseline"]
-    optional["Optional add-ons"]:::artifact
     audit["Walk audit-checklist.md"]
     recommend["Recommendations"]:::artifact
     confirm["User confirmation"]
@@ -25,8 +24,7 @@ flowchart TD
     detect --> newrepo
     detect --> realign
     newrepo --> scaffold
-    scaffold --> optional
-    optional --> repo
+    scaffold --> repo
     realign --> audit
     audit --> recommend
     recommend --> confirm
@@ -49,14 +47,6 @@ flowchart TD
 - **Claude Code project settings** – `.claude/settings.json` with no plugins enabled by default.
 - **CODEOWNERS + issue/PR templates** under `.github/`.
 
-### AI agent plugin add-ons
-
-When the repo is itself a plugin, `scaffold-repository` additionally emits the live Claude Code and Codex marketplace/plugin manifests. Aider, Zed, Cline, Codex CLI, and Opencode are covered by the core `AGENTS.md`.
-
-### Release flow
-
-For plugins, `scaffold-repository` wires a complete [release-please](https://github.com/googleapis/release-please) flow – standing release PR, auto-generated `CHANGELOG.md` and GitHub Release notes, with marketplace versions kept in lockstep on every bump.
-
 ### GitHub repository settings
 
 `scaffold-repository` walks the target repo's merge settings (via `gh api`, `curl`, or visual inspection) and walks the user through the GitHub UI with a deep-link to bring them into alignment. Full matrix in [SKILL.md](./SKILL.md#github-repository-settings).
@@ -70,13 +60,12 @@ For plugins, `scaffold-repository` wires a complete [release-please](https://git
 
 | Tool | Surface | Covered by |
 |---|---|---|
-| [Claude Code](#claude-code) | `.claude-plugin/plugin.json` | Plugin manifest |
-| [OpenAI Codex CLI](#openai-codex-cli) | `.codex-plugin/plugin.json` | Plugin manifest |
-| [OpenAI Codex App](#openai-codex-app) | `.codex-plugin/plugin.json` | Plugin manifest |
-| [Aider](#aider) | `AGENTS.md` | Native |
-| [Zed](#zed) | `AGENTS.md` | Native |
-| [Cline](#cline) | `AGENTS.md` | Native |
-| [Opencode](#opencode) | `AGENTS.md` | Native |
+| Claude Code | `.claude/settings.json`, `AGENTS.md` (`CLAUDE.md`) | Project settings + native |
+| OpenAI Codex | `.codex/environments/environment.toml`, `AGENTS.md` | Workspace setup + native |
+| Aider | `AGENTS.md` | Native |
+| Zed | `AGENTS.md` | Native |
+| Cline | `AGENTS.md` | Native |
+| Opencode | `AGENTS.md` | Native |
 
 ## Install
 
@@ -99,7 +88,6 @@ After installing, run `scaffold-repository` from a cloned repository. The skill 
 
 - `<owner>`, `<repo>`, `<repo-description>`
 - `<visibility>` – public or private
-- `<is-agent-plugin>` – yes emits the live Claude Code and Codex marketplace/plugin manifests
 
 Author name, author email, and `SECURITY.md` contact default from `git config user.name` / `git config user.email`.
 

--- a/skills/scaffold-repository/SKILL.md
+++ b/skills/scaffold-repository/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: scaffold-repository
-description: Use when scaffolding a new repository (public or private) to the Patina Project baseline, when realigning an existing repository with that baseline, or when auditing or adding commit conventions, PR templates, husky + commitlint, PNPM tooling, release-please, agent docs (AGENTS.md, CLAUDE.md), or AI agent plugin manifests for Claude Code and Codex. Triggers on phrases like "scaffold this repo", "scaffold a Patina plugin", "realign with the baseline", "audit our repo conventions", "set up commitlint and husky", or "add Claude/Codex plugin surfaces".
+description: Use when scaffolding a new repository (public or private) to the Patina Project baseline, when realigning an existing repository with that baseline, or when auditing or adding commit conventions, PR templates, husky + commitlint, PNPM tooling, or agent docs (AGENTS.md, CLAUDE.md). Triggers on phrases like "scaffold this repo", "realign with the baseline", "audit our repo conventions", or "set up commitlint and husky".
 ---
 
 # scaffold-repository
 
-`scaffold-repository` scaffolds a repository – new or existing – to the Patina Project baseline: a dual-plugin repository root, a self-contained `skills/` directory, conventional-commits-with-issue-ref enforcement, a PR template, `AGENTS.md` + `CLAUDE.md`, a human-readable `README.md`, a `docs/file-structure.md` contributor reference, and PNPM + Husky + markdownlint tooling.
+`scaffold-repository` scaffolds a repository – new or existing – to the Patina Project baseline: conventional-commits-with-issue-ref enforcement, a PR template, `AGENTS.md` + `CLAUDE.md`, a human-readable `README.md`, a `docs/file-structure.md` contributor reference, and PNPM + Husky + markdownlint tooling.
 
 There is no committed template bundle. The live
 [`patinaproject/skills`](https://github.com/patinaproject/skills) repository
@@ -40,12 +40,11 @@ The skill detects which mode to run based on target-repo state.
 Preconditions:
 
 - Target is a git repository (may be empty or just initialized).
-- No prior `.claude-plugin/` or `.codex-plugin/` manifests.
+- No prior Patina baseline files (for example `AGENTS.md`, `commitlint.config.js`, or a `package.json` with the baseline scripts).
 
 Behavior:
 
 - Emit the full [core baseline](#core-baseline) tree from the live repository baseline, filtering out marketplace-internal verification and dogfood tooling.
-- If the user answers yes to "Is this an AI agent plugin?", additionally emit the [agent-plugin surfaces](#agent-plugin-surfaces).
 - Run `pnpm install` to generate `pnpm-lock.yaml` and wire Husky.
 - Leave all emitted files staged but uncommitted so the user owns the first commit.
 
@@ -60,15 +59,12 @@ Behavior:
 - Walk [`audit-checklist.md`](./audit-checklist.md) against the target repo.
 - Classify each baseline item as `missing`, `stale`, or `divergent`.
 - For each gap, produce a concrete recommendation on how to realign with the current baseline.
-- Detect whether the repo is an AI agent plugin (by presence of a Claude or Codex plugin manifest). When detected, additionally recommend any currently-supported plugin manifest or marketplace catalog that is missing from the live baseline.
 - For each recommendation, show a diff preview and ask the user to accept, skip, or defer. **Never overwrite existing files without explicit confirmation.** There are no flags or escape hatches; realignment is always interactive.
 - Group recommendations into ordered batches that can be applied independently. Each batch below must cover its listed files. `patinaproject/skills` is a normal realignment target – the skill must not self-exclude when run against it.
-  1. Plugin manifests: `.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, `release-please-config.json`, `.release-please-manifest.json`.
-  2. Commit / PR conventions: `commitlint.config.js`, `.husky/*`, `.github/pull_request_template.md`; stale GitHub issue templates should be offered for deletion.
-  3. PNPM tooling and skills installation: `package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`, `skills-lock.json`, `scripts/clean.sh`, `scripts/worktree-setup.sh`, `.gitignore`.
-  4. Agent + repo docs: `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/release-flow.md`.
-  5. Marketplace catalogs: `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`.
-  6. Workflows: `.github/workflows/actions.yml`, `.github/workflows/markdown.yml`, `.github/workflows/pull-request.yml`, and agent-plugin release workflow when applicable.
+  1. Commit / PR conventions: `commitlint.config.js`, `.husky/*`, `.github/pull_request_template.md`; stale GitHub issue templates should be offered for deletion.
+  2. PNPM tooling and skills installation: `package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`, `skills-lock.json`, `scripts/clean.sh`, `scripts/worktree-setup.sh`, `.claude/settings.json`, `.codex/environments/environment.toml`, `.gitignore`.
+  3. Agent + repo docs: `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/release-flow.md`.
+  4. Workflows: `.github/workflows/actions.yml`, `.github/workflows/markdown.yml`, `.github/workflows/pull-request.yml`.
 - Include skills installation in every scaffold and realignment. Emit or
   realign `skills-lock.json`, `scripts/clean.sh`, `scripts/worktree-setup.sh`,
   `.gitignore`, and the `package.json` `env:setup` / `skills:install` / `clean`
@@ -93,7 +89,6 @@ The skill collects the following inputs. Author name, author email, and the secu
 | `<repo>` | from `git remote get-url origin` | repository name |
 | `<repo-description>` | – | one-line description |
 | `<visibility>` | public | public \| private |
-| `<is-agent-plugin>` | no | yes emits plugin/config surfaces for every supported AI coding tool |
 | `<codeowner>` | `@<owner>` | written into `.github/CODEOWNERS` |
 | `<security-contact>` | from `git config user.email` | public repos only; written into `SECURITY.md` |
 | `<author-name>` | from `git config user.name` | written into every `author` block |
@@ -130,7 +125,7 @@ CHANGELOG.md
 CLAUDE.md
 CONTRIBUTING.md
 LICENSE
-README.md                   (core variant; replaced by agent-plugin variant when <is-agent-plugin>=yes)
+README.md
 SECURITY.md                 (public repos only)
 commitizen.config.json
 commitlint.config.js
@@ -151,26 +146,6 @@ reference implementation tooling. Do not emit them into a generic scaffolded
 consumer repo unless that repo explicitly opts into the same marketplace
 maintenance role. Consumer workflows must be adapted to the files they actually
 receive.
-
-## Agent plugin surfaces
-
-Emitted only when `<is-agent-plugin>` is yes:
-
-```text
-.claude-plugin/marketplace.json     (Claude marketplace catalog)
-.claude-plugin/plugin.json          (Claude Code plugin manifest)
-.agents/plugins/marketplace.json    (Codex marketplace catalog)
-.codex-plugin/plugin.json           (Codex plugin manifest)
-.github/workflows/release-please.yml (release-please)
-README.md                           (includes installation instructions)
-release-please-config.json
-.release-please-manifest.json
-```
-
-Agent-plugin mode does not generate starter skills or editor-specific side
-surfaces. Aider, Zed, Cline, Codex CLI, and Opencode read `AGENTS.md` natively
-and are covered by the core baseline. Additional editor surfaces should be added
-only when they exist in the live baseline.
 
 ## Plugin enablement
 
@@ -257,10 +232,7 @@ later, but the scaffold does not auto-enable retired workflow dependencies.
 - **Workflow linting**: `.github/workflows/actions.yml` runs `actionlint` on PRs that touch `.github/workflows/**` or `.github/actionlint.yaml`. Catches malformed refs, invalid expressions, permission mistakes, and (alongside our SHA-pin convention) supply-chain drift.
 - **GitHub Actions pinning**: every `uses:` in emitted workflows references a full 40-char commit SHA with a `# <action>@<version>` comment above it, rather than a mutable tag. Documented in `AGENTS.md`.
 - **Labels**: `AGENTS.md` directs contributors to use `gh label list` and the repository's label descriptions as the source of truth when labeling issues and PRs.
-- **Author identity**: `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` use the same human author record: name and email from `git config`, plus `https://github.com/<author-handle>` from `gh api user --jq .login` or the required author-handle prompt. Repository-level URLs (`homepage`, `repository`, and Codex interface URLs) continue to use `<owner>/<repo>`.
-- **Releases (agent-plugin mode)**: [`release-please`](https://github.com/googleapis/release-please) reads conventional commits since the last tag, opens a standing release PR that bumps `package.json` + both plugin manifests + `CHANGELOG.md`, and publishes a GitHub Release on merge. Semver level is derived from commit types; there is no manual patch/minor/major choice.
-- **Distribution via `patinaproject/skills`**: Patina-Project plugins are vendored directly into `patinaproject/skills` via `git subtree` and ship through that repo's release-please flow. There is no cross-repo dispatch from individual plugin repos to the marketplace; the marketplace is updated as part of the consolidation/release flow in `patinaproject/skills` itself. The emitted Patina supplement therefore no longer carries the old `notify-patinaproject-skills` dispatch job — only the standard `release-please` job.
-- **Version canonicalization**: `.release-please-manifest.json`, `.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json` carry the marketplace version and are kept in lockstep by release-please.
+- **Author identity**: `package.json` carries a human author record: name and email from `git config`, plus `https://github.com/<author-handle>` from `gh api user --jq .login` or the required author-handle prompt. Repository-level URLs (`homepage`, `repository`) continue to use `<owner>/<repo>`.
 
 ## GitHub repository settings
 
@@ -275,7 +247,7 @@ Every scaffold-managed repo should carry these merge settings:
 | `squash_merge_commit_message` | `COMMIT_MESSAGES` | Preserves commit-level context (useful for review and git blame) in the squash body. |
 | `delete_branch_on_merge` | true | Keeps the branch list tidy after each squash. |
 | `allow_update_branch` | true | Surfaces an "Update branch" button on stale PRs so reviewers can sync without leaving the UI. |
-| Release immutability | enabled | Prevents published release assets and tags from being modified after the fact – critical for marketplace consumers pinning to a tag. UI-only: not exposed via the standard REST `repos` endpoint. |
+| Release immutability | enabled | Prevents published release assets and tags from being modified after the fact – critical for downstream consumers pinning to a tag. UI-only: not exposed via the standard REST `repos` endpoint. |
 
 ### Checking current settings
 
@@ -345,7 +317,7 @@ Repository settings drift detected. Open:
 Proceed to apply via `gh api` (if available), or confirm after applying via UI?
 ```
 
-In realignment mode, report which check path was used (`gh`, `curl`, or `skipped`) and the full list of diverging fields. Never modify settings without explicit user confirmation. When package or plugin author URLs point to the repository owner instead of the resolved author handle, report the author block as divergent and offer the normal interactive rewrite.
+In realignment mode, report which check path was used (`gh`, `curl`, or `skipped`) and the full list of diverging fields. Never modify settings without explicit user confirmation. When the `package.json` author URL points to the repository owner instead of the resolved author handle, report the author block as divergent and offer the normal interactive rewrite.
 
 ### Reserved labels
 

--- a/skills/scaffold-repository/agent-spawn-template.md
+++ b/skills/scaffold-repository/agent-spawn-template.md
@@ -4,7 +4,7 @@
 
 When spawning a subagent for `scaffold-repository`:
 
-- Provide the target repo path and the user-selected prompts (owner, repo, description, visibility, and whether the repo is an agent plugin).
+- Provide the target repo path and the user-selected prompts (owner, repo, description, and visibility).
 - Require the subagent to read [`audit-checklist.md`](./audit-checklist.md) before touching any file.
 - Require the subagent to show a diff preview for every proposed change and wait for explicit user confirmation before writing. No flags, no silent overwrites.
 - Require the subagent to group recommendations in the documented order and emit a single final report listing accepted, skipped, and deferred items.

--- a/skills/scaffold-repository/audit-checklist.md
+++ b/skills/scaffold-repository/audit-checklist.md
@@ -80,26 +80,7 @@ project-specific plugin entries only when the repository explicitly opts in. The
 `SessionStart` worktree-setup hook is part of the baseline and pairs with the
 Codex `[setup]` block so both agents prepare new worktrees identically.
 
-## Area 5 – AI agent plugin surfaces
-
-Detection: this repo is an AI agent plugin if **any** of these exist:
-`.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, or `skills/`.
-
-When detected, the following surfaces should all be present. Missing platforms are recommended as additions so existing plugins stay aligned with the current supported set.
-
-| File | Required (agent plugin) | Check |
-|---|---|---|
-| `.claude-plugin/plugin.json` | yes | valid JSON; has `name`, `description`, `author.name`, `author.email`, `author.url`, and `skills` |
-| `.codex-plugin/plugin.json` | yes | valid JSON; has `name`, `version`, `description`, `author.name`, `author.email`, `author.url`, `skills`, and `interface`; `version` matches `.claude-plugin/marketplace.json` metadata |
-| `.claude-plugin/marketplace.json` | yes | valid JSON; marketplace entry name matches plugin name |
-| `.agents/plugins/marketplace.json` | yes | valid JSON; marketplace entry name matches plugin name |
-| `.github/workflows/release-please.yml` | yes | present; runs `release-please` on push to default branch |
-| `release-please-config.json` | yes | valid JSON; lists both plugin manifests under `extra-files` for version sync |
-| `.release-please-manifest.json` | yes | valid JSON; `.` version matches `.codex-plugin/plugin.json` and `.claude-plugin/marketplace.json` |
-
-Author URLs in `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` must point to the resolved `https://github.com/<author-handle>`, not the repository owner URL. Repository-level URLs such as `homepage`, `repository`, and Codex interface URLs stay on `https://github.com/<owner>/<repo>`.
-
-### Shared skill lifecycle
+## Area 5 – Shared skill lifecycle
 
 This check applies to every scaffolded or realigned repository. Vendored
 project-local skills are committed to version control so they load immediately
@@ -124,7 +105,7 @@ Detection: look for retired workflow scaffolding in active repo guidance.
 | `docs/superpowers/` | no | absent from new scaffolded repos; if present, classify as `stale` unless the repository explicitly keeps historical artifacts |
 | `package.json` | no | does not install retired workflow dependencies by default |
 | `AGENTS.md` | yes | directs durable issue context to GitHub issues instead of committed design/plan artifacts |
-| Agent-plugin install docs | agent plugin only | do not require Superpowers for new installs |
+| Install docs | no | do not require Superpowers for new installs |
 
 ## Area 7 – GitHub repository merge settings
 
@@ -168,10 +149,8 @@ For each gap, emit:
 
 Group recommendations into ordered batches and offer them in this sequence (matching `SKILL.md` → Realignment mode; each batch must cover every listed file):
 
-1. Plugin manifests (`.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, `release-please-config.json`, `.release-please-manifest.json`)
-2. Commit / PR conventions (`commitlint.config.js`, `.husky/*`, `.github/pull_request_template.md`, stale GitHub issue templates)
-3. PNPM tooling and skills installation (`package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`, `skills-lock.json`, `scripts/clean.sh`, `scripts/worktree-setup.sh`, `.claude/settings.json`, `.codex/environments/environment.toml`, `.gitignore`)
-4. Agent + repo docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/release-flow.md`)
-5. Marketplace catalogs (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`)
-6. Workflows (`actions.yml`, `markdown.yml`, `pull-request.yml`, and agent-plugin `release-please.yml` when applicable)
-7. Deprecated workflow cleanup
+1. Commit / PR conventions (`commitlint.config.js`, `.husky/*`, `.github/pull_request_template.md`, stale GitHub issue templates)
+2. PNPM tooling and skills installation (`package.json`, `.markdownlint.jsonc`, `pnpm-lock.yaml`, `skills-lock.json`, `scripts/clean.sh`, `scripts/worktree-setup.sh`, `.claude/settings.json`, `.codex/environments/environment.toml`, `.gitignore`)
+3. Agent + repo docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/release-flow.md`)
+4. Workflows (`actions.yml`, `markdown.yml`, `pull-request.yml`)
+5. Deprecated workflow cleanup


### PR DESCRIPTION
## Linked issue

Closes #217

## What changed

Context: standalone - narrows the `scaffold-repository` skill so it no longer scaffolds or audits AI-agent-plugin repos.

- Removed the `<is-agent-plugin>` prompt and the new-repo "Agent plugin surfaces" emit path from `SKILL.md` - Patina plugins are vendored into `patinaproject/skills`, so individual repos are never scaffolded standalone.
- Dropped audit-checklist "Area 5 – AI agent plugin surfaces" and the plugin-manifest / marketplace-catalog realignment batches from both `SKILL.md` and `audit-checklist.md` - the skill no longer recommends plugin/marketplace/release surfaces. The repo-wide "Shared skill lifecycle" checks were preserved as the new Area 5.
- Removed the plugin-version-lockstep release-please conventions (agent-plugin Releases, Distribution, Version canonicalization) and trimmed plugin-manifest mentions out of the Author-identity convention - core-baseline release guidance (`CHANGELOG.md`, `docs/release-flow.md`) is kept.
- Cleaned plugin language from the skill `README.md`, the root `README.md` scaffold blurb, and `agent-spawn-template.md`; harmonized the SKILL/audit-checklist realignment batch lists so they match.
- Added `scaffold-cleanup` guards that fail if agent-plugin, marketplace, or release-please-lockstep language reappears in the skill surface.
