### PR TITLE
feat: #227 add codex pr feedback loop skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity",
-      "description": "Patina Project workflow skills: scaffold-repository, using-github, new-branch, develop-issue, finish-pr, review-code, update-branch, and install-skills."
+      "description": "Patina Project workflow skills."
     }
   ]
 }

--- a/.agents/skills/codex-pr-feedback-loop
+++ b/.agents/skills/codex-pr-feedback-loop
@@ -1,0 +1,1 @@
+../../skills/codex-pr-feedback-loop

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "patinaproject-skills",
-      "description": "Skills used by the Patina Project team — scaffold-repository, using-github, new-branch, develop-issue, finish-pr, review-code, update-branch, and install-skills",
+      "description": "Skills used by the Patina Project team",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
     "./skills/new-branch",
     "./skills/develop-issue",
     "./skills/finish-pr",
+    "./skills/codex-pr-feedback-loop",
     "./skills/review-code",
     "./skills/update-branch",
     "./skills/install-skills"

--- a/.claude/skills/codex-pr-feedback-loop
+++ b/.claude/skills/codex-pr-feedback-loop
@@ -1,0 +1,1 @@
+../../skills/codex-pr-feedback-loop

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,6 +7,7 @@
     "./skills/new-branch",
     "./skills/develop-issue",
     "./skills/finish-pr",
+    "./skills/codex-pr-feedback-loop",
     "./skills/review-code",
     "./skills/update-branch",
     "./skills/install-skills"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/new-branch/`: issue branch preparation skill
 - `skills/develop-issue/`: issue development orchestration skill
 - `skills/finish-pr/`: PR finishing skill
+- `skills/codex-pr-feedback-loop/`: Codex PR review feedback automation skill
 - `skills/review-code/`: isolated local branch-diff review skill
 - `skills/update-branch/`: local branch update skill
 - `skills/install-skills/`: project-local skills CLI installation skill
@@ -19,7 +20,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
   symlink into `../../skills/<name>/`; vendored third-party skills are relative
   symlinks into `../../.agents/skills/<name>`. All entries are tracked.
 - `.claude-plugin/marketplace.json`: repo-local Claude marketplace source of truth (plugin slug: `patinaproject-skills`)
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eight skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing skill paths
 - `.codex/environments/environment.toml`: Codex workspace setup for this repository
 - `docs/`: contributor docs such as `docs/file-structure.md` and
   `docs/release-flow.md`
@@ -63,7 +64,7 @@ This is a single-context repository; domain docs are optional and created lazily
 - `pnpm exec commitlint --edit <path>`: validate commit messages manually
 - `pnpm lint:md`: lint all tracked Markdown files with `markdownlint-cli2`
 - `pnpm test`: run the full local verification suite
-- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the eight skill entry points
+- `find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort`: inspect the skill entry points
 
 ## Coding Style & Naming Conventions
 
@@ -104,7 +105,7 @@ npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@write-a-s
   package scripts.
 - Run `bash scripts/tests/worktree-setup.test.sh` after changing
   `scripts/worktree-setup.sh`.
-- Run `bash scripts/tests/dogfood.test.sh` to confirm all eight in-repo skills pass the flat-layout check
+- Run `bash scripts/tests/dogfood.test.sh` to confirm in-repo skills pass the flat-layout check
 - Run `bash scripts/tests/esm-tooling.test.sh` after changing repo tooling configs or the package module type
 - Run `bash scripts/tests/marketplace.test.sh` to confirm the `.claude-plugin/` catalog is valid
 - Run `bash scripts/tests/code-review-workflow.test.sh` after changing `.github/workflows/code-review.yml`
@@ -165,10 +166,20 @@ an action by tag or branch, giving a hard gate on top of the CI check.
 
 ## Skill Releases
 
-This repo owns eight skills at flat paths: `skills/scaffold-repository/`,
-`skills/using-github/`, `skills/new-branch/`, `skills/develop-issue/`,
-`skills/finish-pr/`, `skills/review-code/`, `skills/update-branch/`,
-and `skills/install-skills/`.
+This repo owns these skills at flat paths:
+
+| Skill | Path |
+| --- | --- |
+| scaffold-repository | `skills/scaffold-repository/` |
+| using-github | `skills/using-github/` |
+| new-branch | `skills/new-branch/` |
+| develop-issue | `skills/develop-issue/` |
+| finish-pr | `skills/finish-pr/` |
+| codex-pr-feedback-loop | `skills/codex-pr-feedback-loop/` |
+| review-code | `skills/review-code/` |
+| update-branch | `skills/update-branch/` |
+| install-skills | `skills/install-skills/` |
+
 `find-skills` is a third-party skill from `vercel-labs/skills` and is not
 a marketplace entry in this repo.
 
@@ -177,10 +188,10 @@ maintains a single standing Release PR for the repo as a whole. Tag form: `v<X.Y
 component prefix. The marketplace only publishes tagged (`v<X.Y.Z>`) releases. See
 [docs/release-flow.md](./docs/release-flow.md).
 
-The eight in-repo skills share the single root `patinaproject-skills` release
-and tag; they are not separate release-please packages. Third-party
-skills such as `find-skills` are installed separately from their source repo's
-default branch or a specific `#<git-ref>`.
+The in-repo skills share the single root `patinaproject-skills` release and
+tag; they are not separate release-please packages. Third-party skills such as
+`find-skills` are installed separately from their source repo's default branch
+or a specific `#<git-ref>`.
 
 Merging a Release PR tags the commit and publishes a GitHub Release. The workflow also
 auto-merges Release PRs after required checks pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,15 @@
 
 ## [2.8.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.7.0...patinaproject-skills-v2.8.0) (2026-06-02)
 
-
 ### Features
 
 * [#221](https://github.com/patinaproject/skills/issues/221) auto-assign issue to current user in develop-issue ([#222](https://github.com/patinaproject/skills/issues/222)) ([f30dc84](https://github.com/patinaproject/skills/commit/f30dc849697f7149dcb66e014abb14e9fc414589))
 
 ## [2.7.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.6.0...patinaproject-skills-v2.7.0) (2026-05-31)
 
-
 ### Features
 
 * [#217](https://github.com/patinaproject/skills/issues/217) drop agent-plugin mode from scaffold-repository ([#220](https://github.com/patinaproject/skills/issues/220)) ([354b461](https://github.com/patinaproject/skills/commit/354b4619d93b27b036e2e03b99b22b990bc68edd))
-
 
 ### Bug Fixes
 
@@ -21,18 +18,15 @@
 
 ## [2.6.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.5.2...patinaproject-skills-v2.6.0) (2026-05-29)
 
-
 ### Features
 
 * [#214](https://github.com/patinaproject/skills/issues/214) commit vendored skills and add shared worktree setup ([#215](https://github.com/patinaproject/skills/issues/215)) ([ce3b17d](https://github.com/patinaproject/skills/commit/ce3b17d21462452c378541d8c99c2284a73d7915))
-
 
 ### Bug Fixes
 
 * [#211](https://github.com/patinaproject/skills/issues/211) make skill output human-relevant ([#212](https://github.com/patinaproject/skills/issues/212)) ([4a1a2f3](https://github.com/patinaproject/skills/commit/4a1a2f3c7bd8f6b2c5a5918426fd1d1722cb3739))
 
 ## [2.5.2](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.5.1...patinaproject-skills-v2.5.2) (2026-05-28)
-
 
 ### Bug Fixes
 
@@ -41,13 +35,11 @@
 
 ## [2.5.1](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.5.0...patinaproject-skills-v2.5.1) (2026-05-28)
 
-
 ### Bug Fixes
 
 * [#203](https://github.com/patinaproject/skills/issues/203) remove transient skill installer files ([#204](https://github.com/patinaproject/skills/issues/204)) ([df532c5](https://github.com/patinaproject/skills/commit/df532c57f26552bc49840aec64a6771a2a5c89f5))
 
 ## [2.5.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.4.2...patinaproject-skills-v2.5.0) (2026-05-26)
-
 
 ### Features
 
@@ -55,20 +47,17 @@
 
 ## [2.4.2](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.4.1...patinaproject-skills-v2.4.2) (2026-05-26)
 
-
 ### Bug Fixes
 
 * [#192](https://github.com/patinaproject/skills/issues/192) clean up stale review subagents ([#195](https://github.com/patinaproject/skills/issues/195)) ([73c7885](https://github.com/patinaproject/skills/commit/73c788540ca32bf76cd070b4947be6f121c99fd6))
 
 ## [2.4.1](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.4.0...patinaproject-skills-v2.4.1) (2026-05-25)
 
-
 ### Bug Fixes
 
 * [#170](https://github.com/patinaproject/skills/issues/170) enforce blocked-by gate exit ([#175](https://github.com/patinaproject/skills/issues/175)) ([9e5f64a](https://github.com/patinaproject/skills/commit/9e5f64a7a53c550e3564de910752e339d15f2492))
 
 ## [2.4.0](https://github.com/patinaproject/skills/compare/patinaproject-skills-v2.3.0...patinaproject-skills-v2.4.0) (2026-05-25)
-
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Skills used by the Patina Project team
 
-Eight installable agent skills for repository scaffolding, project-local skill
+Installable agent skills for repository scaffolding, project-local skill
 installation, GitHub workflows, issue branch setup, issue development, PR
-finishing, isolated local code review, and local branch updating. They are
-available across Claude Code, Codex, and any agent runtime that reads
-`AGENTS.md`.
+finishing, Codex PR feedback polling, isolated local code review, and local
+branch updating. They are available across Claude Code, Codex, and any agent
+runtime that reads `AGENTS.md`.
 
 ## Quickstart
 
@@ -104,6 +104,17 @@ stops at ready-to-merge.
 
 See [./skills/finish-pr/](./skills/finish-pr/) for the skill contract.
 
+### codex-pr-feedback-loop
+
+PR review follow-up should preserve the Codex app chat context after the first
+successful push. `codex-pr-feedback-loop` creates a thread automation that
+polls the current PR, handles actionable review feedback and objective low-risk
+cleanup, pushes verified fixes, replies with evidence, and stops when no
+actionable work remains.
+
+See [./skills/codex-pr-feedback-loop/](./skills/codex-pr-feedback-loop/) for
+the skill contract.
+
 ### update-branch
 
 Keeping a work branch current should be a local git operation unless an
@@ -131,6 +142,7 @@ README and skill contract.
 | [new-branch](./skills/new-branch/) | Prepare local issue branches from the default branch |
 | [develop-issue](./skills/develop-issue/) | Develop one issue through local review and PR readiness |
 | [finish-pr](./skills/finish-pr/) | Finish completed branch work through ready-to-merge PRs |
+| [codex-pr-feedback-loop](./skills/codex-pr-feedback-loop/) | Keep a pushed Codex PR iterating on actionable review feedback |
 | [review-code](./skills/review-code/) | Run isolated local branch-diff review |
 | [update-branch](./skills/update-branch/) | Update a local work branch from the base branch |
 | [install-skills](./skills/install-skills/) | Project-local skills CLI installation workflow |
@@ -155,6 +167,7 @@ npx skills@latest add ./skills/install-skills --list
 npx skills@latest add ./skills/review-code --list
 npx skills@latest add ./skills/update-branch --list
 npx skills@latest add ./skills/develop-issue --list
+npx skills@latest add ./skills/codex-pr-feedback-loop --list
 ```
 
 ### Check b - scaffold-repository cleanup contract
@@ -163,7 +176,7 @@ npx skills@latest add ./skills/develop-issue --list
 bash scripts/tests/scaffold-cleanup.test.sh
 ```
 
-### Check c - dogfood verification, all eight skills
+### Check c - dogfood verification, all in-repo skills
 
 ```sh
 bash scripts/tests/dogfood.test.sh
@@ -179,6 +192,7 @@ skills/
   new-branch/
   develop-issue/
   finish-pr/
+  codex-pr-feedback-loop/
   review-code/
   update-branch/
 .agents/skills/<name>/               Committed overlay: symlinks to ../../skills/<name>/ (owned) or vendored dirs

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,8 +1,8 @@
 # Repository File Structure
 
 This repository is the marketplace surface for Patina Project plugins and
-related install documentation. Eight skills live under `skills/<name>/` in a
-flat layout.
+related install documentation. Skills live under `skills/<name>/` in a flat
+layout.
 
 ## Top level
 
@@ -11,6 +11,7 @@ flat layout.
 - `skills/new-branch/`: issue branch preparation skill
 - `skills/develop-issue/`: issue development orchestration skill
 - `skills/finish-pr/`: PR finishing skill
+- `skills/codex-pr-feedback-loop/`: Codex PR review feedback automation skill
 - `skills/review-code/`: isolated local branch-diff review skill
 - `skills/update-branch/`: local branch update skill
 - `skills/install-skills/`: project-local skills CLI installation skill
@@ -20,8 +21,8 @@ flat layout.
   `../../skills/<name>/`, vendored third-party skills symlink into
   `../../.agents/skills/<name>`
 - `.claude-plugin/marketplace.json`: Claude marketplace catalog
-- `.claude-plugin/plugin.json`: Claude plugin manifest listing all eight skill paths
-- `.codex-plugin/plugin.json`: Codex plugin manifest listing all eight skill paths
+- `.claude-plugin/plugin.json`: Claude plugin manifest listing skill paths
+- `.codex-plugin/plugin.json`: Codex plugin manifest listing skill paths
 - `.agents/plugins/marketplace.json`: Codex marketplace catalog
 - `.codex/environments/environment.toml`: Codex workspace setup for this repository
 - `skills-lock.json`: vercel-labs CLI install lockfile
@@ -33,7 +34,7 @@ flat layout.
 
 ## Flat skill layout
 
-Eight skills are owned by this repository:
+Skills owned by this repository:
 
 | Skill | Canonical path | Description |
 | --- | --- | --- |
@@ -42,6 +43,7 @@ Eight skills are owned by this repository:
 | `new-branch` | `skills/new-branch/` | Issue branch preparation |
 | `develop-issue` | `skills/develop-issue/` | Issue development orchestration |
 | `finish-pr` | `skills/finish-pr/` | Ready-for-merge PR finishing |
+| `codex-pr-feedback-loop` | `skills/codex-pr-feedback-loop/` | Codex app PR review feedback automation |
 | `review-code` | `skills/review-code/` | Isolated local branch-diff review |
 | `update-branch` | `skills/update-branch/` | Local branch update workflow |
 | `install-skills` | `skills/install-skills/` | Project-local skills CLI installation workflow |
@@ -60,7 +62,7 @@ The agent runtime discovers skills through two committed overlay directories.
 Both repo-owned and vendored third-party skills are committed, so they load
 immediately in a fresh clone or worktree with no install step.
 
-Repo-owned skills (the eight in `skills/`) appear as one-hop symlinks:
+Repo-owned skills in `skills/` appear as one-hop symlinks:
 
 | Overlay path | Symlink target | Mode |
 | --- | --- | --- |

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -3,10 +3,9 @@
 The Patina Project skills repo releases via `release-please` with a single root package
 (`release-type: simple`). Tag form: `v<X.Y.Z>` — no component prefix.
 
-Skills live flat at `skills/<name>/` in this repo. Eight in-repo skills ship as
-`patinaproject-skills`: active skills `scaffold-repository`, `using-github`,
-`new-branch`, `develop-issue`, `finish-pr`, `review-code`, `update-branch`, and `install-skills`. All eight are
-versioned together as a single marketplace surface. On each release,
+Skills live flat at `skills/<name>/` in this repo. In-repo skills ship as
+`patinaproject-skills` and are versioned together as a single marketplace
+surface. On each release,
 `release-please` also bumps `metadata.version` in `.claude-plugin/marketplace.json` via the
 `extra-files` block in `release-please-config.json`. `find-skills` is no longer part of
 `patinaproject-skills`; install it separately from `vercel-labs/skills` (see root README).
@@ -72,7 +71,7 @@ The vercel-labs CLI consumer pins a specific tag via `#<git-ref>`:
 npx skills@latest add patinaproject/skills#v1.0.0 --skill scaffold-repository
 ```
 
-The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all eight
+The `v<X.Y.Z>` ref selects the state of the entire repo at that tag. Because all
 skills live under `skills/<name>/SKILL.md` in the same repo, one tag pins the full set.
 `skills-lock.json`'s `computedHash` records per-skill content provenance for reproducible
 re-installs within a given tag.
@@ -81,8 +80,7 @@ re-installs within a given tag.
 
 - An untagged skill is not pinnable. The first `v<X.Y.Z>` tag is what introduces the repo
   to the install path with a pinnable `#<ref>`.
-- In-repo skills (`scaffold-repository`, `using-github`, `new-branch`,
-  `develop-issue`, `finish-pr`, `review-code`, `update-branch`, and `install-skills`) are not separate release-please packages;
+- In-repo skills are not separate release-please packages;
   they share the single root `patinaproject-skills` release and tag.
   Third-party skills such as `find-skills` are installed separately from their
   source repo's default branch or a specific `#<git-ref>`.

--- a/scripts/tests/dogfood.test.sh
+++ b/scripts/tests/dogfood.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# dogfood.test.sh — Asserts that all eight in-repo skills are discoverable
+# dogfood.test.sh — Asserts that all in-repo skills are discoverable
 # via the flat skills/<name>/ layout and the dogfood overlay symlinks.
 # (find-skills is a third-party vendored skill, not an in-repo skill.)
-# Exit 0: all eight skills pass all assertions.
+# Exit 0: all in-repo skills pass all assertions.
 # Exit 1: at least one assertion failed (with a clear FAIL message).
 #
 # Dependencies: bash 3+, realpath (macOS via coreutils) or python3 as fallback.
@@ -19,6 +19,7 @@ SKILLS=(
   new-branch
   develop-issue
   finish-pr
+  codex-pr-feedback-loop
   review-code
   update-branch
 )
@@ -121,5 +122,5 @@ if [ "$FAIL_COUNT" -gt 0 ]; then
 fi
 
 echo ""
-echo "OK: all eight in-repo skills discoverable via flat layout"
+echo "OK: all in-repo skills discoverable via flat layout"
 exit 0

--- a/scripts/tests/marketplace.test.sh
+++ b/scripts/tests/marketplace.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/review-code","./skills/update-branch","./skills/install-skills"]'
+expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/codex-pr-feedback-loop","./skills/review-code","./skills/update-branch","./skills/install-skills"]'
 retired_marketplace_skills='review-action|office-hours|plan-ceo-review|superteam|superteam-non-interactive'
 
 # Validate the Claude Code marketplace catalog.

--- a/scripts/tests/suite.test.sh
+++ b/scripts/tests/suite.test.sh
@@ -41,6 +41,7 @@ run_cli_canary ./skills/install-skills
 run_cli_canary ./skills/review-code
 run_cli_canary ./skills/update-branch
 run_cli_canary ./skills/develop-issue 'develop-issue'
+run_cli_canary ./skills/codex-pr-feedback-loop 'codex-pr-feedback-loop'
 
 run_cli_install_canary() {
   local repo_root tmpdir status

--- a/skills/codex-pr-feedback-loop/SKILL.md
+++ b/skills/codex-pr-feedback-loop/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: codex-pr-feedback-loop
+description: Keeps an issue-linked Codex app PR polling for unresolved review feedback, objective low-risk cleanup, verified fixes, replies, and pushed updates. Use when a Codex app worktree should continue iterating on an existing pull request after the first successful push.
+---
+
+# PR Feedback Loop
+
+Use this skill when the user wants a Codex app worktree chat to develop an
+issue and then keep iterating on PR review feedback after the first push.
+
+## Quick Start
+
+For issue-linked development, start with the repository's normal GitHub
+workflow through `new-branch` and `finish-pr`:
+
+1. Develop, verify, commit, push, and create or update the PR with the normal
+   issue workflow.
+2. After the first successful PR push, follow
+   [workflows/thread-automation.md](workflows/thread-automation.md) to create a
+   Codex app thread automation for the same chat.
+
+Suggested user prompt:
+
+```text
+Use $codex-pr-feedback-loop for issue #123.
+```
+
+## Automation Contract
+
+The automation is a Codex app thread automation attached to the current
+chat/worktree, not a GitHub webhook or CI workflow.
+
+See [workflows/thread-automation.md](workflows/thread-automation.md) for the
+canonical create/fallback procedure, automation name, schedule, scope, stop
+condition, prompt, and guardrails. Keep this file as a routing summary, not a
+second copy of the runtime rules.
+
+At this skill level, the durable boundaries are:
+
+- Stay in the current working directory's default `gh` repository.
+- Preserve this chat's context with a thread automation.
+- Do not merge the PR.

--- a/skills/codex-pr-feedback-loop/workflows/thread-automation.md
+++ b/skills/codex-pr-feedback-loop/workflows/thread-automation.md
@@ -1,0 +1,76 @@
+# Thread Automation Workflow
+
+**Goal:** After the first successful PR push, create a Codex app thread
+automation that polls the current PR, fixes blocking review feedback and
+low-risk cleanup comments worth handling, pushes updates, replies with
+evidence, and stops when no actionable review work remains.
+
+## Preconditions
+
+- A PR exists for the current branch.
+- The branch has been pushed successfully.
+- `gh` is authenticated for the current repository.
+- The Codex app automation tool is available, or the user can create the
+  automation manually from the app's Automations menu.
+
+Before creating the automation, resolve and report:
+
+```sh
+gh repo view --json nameWithOwner --jq .nameWithOwner
+gh pr view --json number,headRefName,headRefOid,url
+```
+
+If no PR exists for the current branch, finish the PR workflow first.
+
+## Canonical Settings
+
+- Name: `PR feedback loop`
+- Kind: thread/heartbeat automation
+- Destination: current thread
+- Polling interval: user-selected minutes; default to 10 minutes when the user
+  gives no preference
+- Schedule: `FREQ=MINUTELY;INTERVAL=<polling-minutes>`
+- Status: `ACTIVE`
+- Stop condition: defined by the final paragraph of the automation prompt below
+
+## Create The Automation
+
+When `codex_app.automation_update` is available, create a heartbeat/thread
+automation using the canonical settings above and the prompt below.
+
+Before creating the automation, ask the user for a polling interval when they
+have not already provided one. Use a positive whole number of minutes. If they
+do not care, use 10 minutes.
+
+Use this prompt exactly except for small repository-specific additions that make
+the current PR easier to resolve:
+
+```text
+Poll the current branch's GitHub PR for new unresolved review feedback. Use the current working directory's default gh repository. Resolve the fields listed in Preconditions with gh before acting.
+
+Enumerate pull request review threads with paginated GraphQL. Do not rely on REST review comments alone. Retain each thread ID, resolution state, outdated state, path, line context, comment URL, numeric review comment database ID, author, body, and comment commit OID.
+
+Classify each unresolved item as actionable/blocking, requirement-changing, scope-changing, low-severity, informational, duplicate, stale, already handled, or not applicable. Low-severity comments are not automatic skips, but only auto-fix objective low-severity classes: typos; broken links; stale names, paths, commands, schedules, or field lists; factual drift from a named canonical source; and duplicated machine-checkable settings or field summaries where the fix is to point at that canonical source. Treat subjective clarity, tone, wording, organization, naming preference, broad redundancy, or style comments as report-only unless the user explicitly asks this thread to handle them.
+
+Automatically fix actionable/blocking feedback and objective low-severity cleanup that preserves accepted requirements, accepted scope, implementation strategy, test strategy, dependency-security conclusions, CI/workflow contracts, and product behavior.
+
+Stop and report human input is required if feedback changes requirements, accepted scope, implementation strategy, test strategy, dependency-security conclusions, CI/workflow contracts, or product behavior. Also stop for secrets, permission blockers, policy blockers, merge conflicts that cannot be resolved cleanly, or if packages/app/fingerprint.json becomes staged or must be committed.
+
+For each actionable/blocking item, inspect the latest head and current file context before editing. Implement the smallest correct root-cause fix. Follow AGENTS.md, docs/project-context.md, package AGENTS.md files, docs/testing-standards.md, docs/commit-style.md, and the first-party mock ban. Prefer offensive fixes over defensive workarounds.
+
+After edits, run the narrowest local verification command that covers the changed behavior. Do not use hidden skip env vars, broad bypass knobs, or --no-verify. If local verification is blocked, report the exact blocker instead of claiming success.
+
+When fixes are verified, commit focused changes with this repo's commit rules and push the PR branch. Reply to each handled review thread using the REST threaded replies endpoint with evidence: fix commit SHA, verification command, and how the latest head addresses the comment. Resolve eligible review threads through GraphQL only after latest-head verification succeeds.
+
+Stop this automation when no unresolved actionable/blocking review feedback remains and every low-severity item is either handled as objective cleanup or explicitly classified as stale, duplicate, already handled, informational, subjective/report-only, or requiring a human decision. Report the PR URL, latest head SHA, handled thread URLs, verification evidence, and any remaining non-blocking items with the reason they were left open.
+```
+
+## Manual Fallback
+
+If the automation tool is unavailable, tell the user to create a Codex app
+thread automation from the Automations menu using the canonical settings and
+the exact prompt above. Include the selected polling interval, or 10 minutes
+when the user gives no preference.
+
+Do not create a standalone project automation as a fallback unless the user
+explicitly asks for independent runs instead of preserving this chat's context.


### PR DESCRIPTION
## Linked issue

Closes #227

## What changed

Context: standalone - move app-local skill into marketplace

- Add `codex-pr-feedback-loop` as a first-party skill - makes the Codex app PR feedback automation installable from the shared skills marketplace.
- Wire Claude/Codex marketplace manifests, overlays, docs, and tests for the first-party skill set - keeps discovery and repository contracts aligned without volatile skill-count prose.
- Normalize existing `CHANGELOG.md` blank lines - restores `pnpm lint:md` for the current release changelog.