### PR TITLE
docs: #231 adopt issue-keyed ADR IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,15 @@ Triage roles map to this repository's existing GitHub labels, without inventing 
 
 This is a single-context repository; domain docs are optional and created lazily when useful. See `docs/agents/domain.md`.
 
+### Architecture decision records
+
+Name and write ADRs by [`docs/adr/README.md`](docs/adr/README.md), the
+single source of truth for ADR naming in this repository. It supersedes the
+sequential `0001`-increment guidance still embedded in the vendored shared
+skills (`grill-with-docs`, `setup-matt-pocock-skills`): name every ADR after its
+originating GitHub issue (`ADR-<issue>-<slug>.md`), never scan-and-increment, and
+do not edit the vendored payloads under `.agents/skills/**`.
+
 ## Build, Test, and Development Commands
 
 - `pnpm install` (alias `pnpm env:setup`): install dev tooling and initialize
@@ -95,7 +104,7 @@ npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@write-a-s
   the folder), symlink resolution, and required-file existence. A documentation
   file's prose body must be freely editable without breaking a test. Markdown
   *linting* (`pnpm lint:md`) is unaffected — linting is not testing. See
-  [docs/adr/0001-no-tests-on-documentation-content.md](docs/adr/0001-no-tests-on-documentation-content.md).
+  [docs/adr/ADR-224-no-tests-on-documentation-content.md](docs/adr/ADR-224-no-tests-on-documentation-content.md).
 - Run `pnpm test` to run the full suite, or use the targeted commands below while iterating.
 - `pnpm test` includes network-backed skills CLI canaries and the
   committed-skill lifecycle check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,4 @@
 - Project-level Claude Code configuration lives in `.claude/settings.json`. Skills enabled for this repo are declared under `enabledPlugins`.
 - When you add Claude-specific teammates, prefer project subagents under `.claude/agents/`.
 - When you need Claude-specific enforcement for teammate creation or completion, prefer project hooks in `.claude/settings.json`.
-- Never write tests that assert on the prose content of documentation files; test code behavior and machine-consumed contracts only (see `AGENTS.md` → Testing Guidelines and `docs/adr/0001-no-tests-on-documentation-content.md`).
+- Never write tests that assert on the prose content of documentation files; test code behavior and machine-consumed contracts only (see `AGENTS.md` → Testing Guidelines and `docs/adr/ADR-224-no-tests-on-documentation-content.md`).

--- a/docs/adr/ADR-224-no-tests-on-documentation-content.md
+++ b/docs/adr/ADR-224-no-tests-on-documentation-content.md
@@ -1,4 +1,4 @@
-# 1. Do not test documentation content
+# ADR-224: Do not test documentation content
 
 - Status: accepted
 - Date: 2026-06-02

--- a/docs/adr/ADR-231-adr-id-scheme.md
+++ b/docs/adr/ADR-231-adr-id-scheme.md
@@ -1,0 +1,53 @@
+# ADR-231: Name ADRs by their originating GitHub issue number
+
+## Status
+
+Accepted
+
+## Context
+
+ADRs were named with a sequential, zero-padded counter (`0001-…`). No authority
+allocated the next number — each branch derived it by scanning `docs/adr/` for
+the highest existing number and incrementing, exactly as the vendored
+`grill-with-docs` and `setup-matt-pocock-skills` ADR guidance still instructs.
+
+Under parallel work that guess is unsafe: two branches both see the same number
+as next and both claim it, producing a merge conflict or — worse — two different
+ADRs silently sharing one ID. The counter also carries no information:
+`ADR-0001` does not tell a reader where the decision came from, while the problem
+framing, discussion, and PRs all live in a GitHub issue the filename never
+references.
+
+## Decision
+
+Name an ADR after its originating GitHub issue: `ADR-<issue>-<slug>.md`, with the
+heading `# ADR-<issue>: Title` and the prose reference `ADR-<issue>`.
+
+The issue number is assigned by GitHub, so it is globally unique with no
+cross-branch coordination — collisions are eliminated by construction rather than
+by a scan-and-increment convention. The prefix doubles as a backlink to the
+issue's full history. The slug carries filename uniqueness, so a single issue can
+produce two ADRs with two slugs and no suffix scheme. Every ADR must cite an
+originating issue; a decision with no issue is the signal to file one.
+
+`docs/adr/README.md` is the single source of truth and explicitly supersedes the
+`0001`-increment guidance still embedded in the vendored shared skills, with an
+`AGENTS.md` pointer routing agents to the repo doc first. The vendored payloads
+under `.agents/skills/**` are left untouched so a re-vendor from
+`skills-lock.json` does not clobber this fix.
+
+The existing `0001-no-tests-on-documentation-content.md` (from issue #224) is
+renamed to `ADR-224-no-tests-on-documentation-content.md`, so no legacy
+`0001`-style ID remains.
+
+## Consequences
+
+- ADR IDs cannot collide across parallel branches; merges stay clean.
+- Every ADR ID is a backlink — a reader opens `#<issue>` for full context.
+- IDs still increase roughly with time, since issue numbers are monotonic, so the
+  directory reads in rough decision order.
+- The scheme composes with a future multi-context layout: issue numbers are
+  globally unique, so per-package `docs/adr/` directories could not collide either.
+- Out of scope: CI or pre-commit enforcement of the naming rule, editing the
+  vendored skill payloads, any disambiguation scheme beyond the slug, and
+  retroactively filing issues for past decisions that never had one.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,78 @@
+# Architecture Decision Records
+
+This directory stores architecture decision records for this repository.
+
+Use ADRs for durable decisions that affect architecture, domain boundaries,
+technology direction, workflow contracts, or cross-package integration. Keep
+short-lived implementation plans and issue-specific notes in their existing
+issue or plan locations.
+
+## Naming
+
+Name an ADR after its originating GitHub issue:
+
+```text
+ADR-<issue>-<slug>.md      e.g. ADR-231-adr-id-scheme.md
+```
+
+- **The prefix is the GitHub issue number, verbatim** — no fixed width, no
+  zero-padding, no truncation. The width follows the issue number and grows past
+  `#9999` on its own.
+- **The slug carries uniqueness; the full filename is the key.** The issue-number
+  prefix is not required to be unique on its own. One issue that produces two
+  ADRs uses two different slugs — there is no suffix, letter, or padding scheme.
+- **Every ADR must cite an originating issue.** GitHub assigns the number, so it
+  is globally unique with no cross-branch coordination and ADR IDs cannot collide
+  at merge time. If a decision has no issue yet, that is the signal to file one
+  (which also creates the backlink) — do not invent a number.
+- **The prefix is a backlink.** Open `#<issue>` for the decision's full
+  historical context: the problem framing, discussion, and PRs behind it.
+
+This supersedes the sequential `0001`-increment numbering guidance still embedded
+in the vendored shared skills (e.g. `grill-with-docs`,
+`setup-matt-pocock-skills`). Those payloads are re-installed from
+`skills-lock.json` and are not edited; this doc, and the `AGENTS.md` pointer to
+it, are the authority. Do not scan for the highest number and increment.
+
+## Format
+
+A short ADR is enough. Prefer one to three direct sentences that record what was
+decided and why; add sections only when they make the decision easier to
+understand later.
+
+The heading matches the filename token: `# ADR-<issue>: Title`. Reference an ADR
+in prose as `ADR-<issue>` (it is clear you mean the decision record, not the
+issue thread, even though they share a number). In the rare case where one issue
+produced more than one ADR, add the slug to disambiguate in both the heading and
+prose — `# ADR-<issue>-<slug>: Title` and `ADR-<issue>-<slug>` — so the slug
+carries uniqueness consistently across filename, heading, and prose.
+
+Optional sections:
+
+```markdown
+# ADR-<issue>: Short Decision Title
+
+## Status
+
+Accepted
+
+## Context
+
+What forces, constraints, or problem made this decision necessary?
+
+## Decision
+
+What did we choose?
+
+## Consequences
+
+What becomes easier, harder, required, or intentionally out of scope?
+```
+
+## Worked examples
+
+- [`ADR-224-no-tests-on-documentation-content.md`](ADR-224-no-tests-on-documentation-content.md)
+  — from issue [#224](https://github.com/patinaproject/skills/issues/224).
+- [`ADR-231-adr-id-scheme.md`](ADR-231-adr-id-scheme.md)
+  — from issue [#231](https://github.com/patinaproject/skills/issues/231),
+  the record that adopted this scheme.

--- a/scripts/tests/scaffold-cleanup.test.sh
+++ b/scripts/tests/scaffold-cleanup.test.sh
@@ -120,7 +120,7 @@ for test_file in scripts/tests/*.test.sh; do
   fi
 done
 
-# Per the "no tests on documentation content" rule (docs/adr/0001), this test
+# Per the "no tests on documentation content" rule (ADR-224), this test
 # asserts only on filesystem state and non-`.md` config/code targets. Stale
 # scaffold references inside skill prose are covered by `lint:md`, not here.
 assert_no_match "apply:scaffold-repository|apply-scaffold-repository|scaffold-repository self-apply" \

--- a/scripts/tests/workflow-cleanup.test.sh
+++ b/scripts/tests/workflow-cleanup.test.sh
@@ -21,7 +21,7 @@ assert_no_match() {
   fi
 }
 
-# Per the "no tests on documentation content" rule (docs/adr/0001), this test
+# Per the "no tests on documentation content" rule (ADR-224), this test
 # asserts only on filesystem state and non-`.md` config targets. Retired
 # references inside agent/skill prose are covered by `lint:md`, not here.
 ACTIVE_CONFIG_PATHS=(


### PR DESCRIPTION
## Linked issue

- Closes #231

## What changed

Context: standalone - first repo-wide adoption of issue-keyed ADR IDs, modeled on `patinaproject/patinaproject`'s scheme.

- Added `docs/adr/README.md` as the single source of truth for ADR naming (`ADR-<issue>-<slug>.md`, issue number verbatim, slug carries uniqueness, every ADR cites an originating issue) - gives the repo its own authority that explicitly supersedes the sequential `0001`-increment guidance embedded in the vendored shared skills.
- Added an `AGENTS.md` "Architecture decision records" pointer routing agents to `docs/adr/README.md` and stating it supersedes the vendored sequential guidance - so agents follow the repo authority, not the stale vendored rule.
- Renamed `docs/adr/0001-no-tests-on-documentation-content.md` → `docs/adr/ADR-224-no-tests-on-documentation-content.md` (originating issue #224), updated its heading to `# ADR-224: …`, and fixed inbound references in `AGENTS.md`, `CLAUDE.md`, and two `scripts/tests/*.sh` comments - so no legacy sequential ID or stale reference remains.
- Added `docs/adr/ADR-231-adr-id-scheme.md` recording the scheme's context, decision, and consequences - so a future reader understands why ADR IDs are issue-numbered.

Vendored payloads under `.agents/skills/**` are intentionally untouched so a re-vendor from `skills-lock.json` does not clobber this change. No new test is authored (CI/pre-commit enforcement of the naming rule is out of scope); `dogfood`, `marketplace`, and `lint:md` are the regression guards and pass.
