### PR TITLE
feat: #236 add improve-branch-architecture skill

### DIFF
--- a/.agents/skills/improve-branch-architecture
+++ b/.agents/skills/improve-branch-architecture
@@ -1,0 +1,1 @@
+../../skills/improve-branch-architecture

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,7 @@
     "./skills/review-code",
     "./skills/update-branch",
     "./skills/install-skills",
-    "./skills/write-docs"
+    "./skills/write-docs",
+    "./skills/improve-branch-architecture"
   ]
 }

--- a/.claude/skills/improve-branch-architecture
+++ b/.claude/skills/improve-branch-architecture
@@ -1,0 +1,1 @@
+../../skills/improve-branch-architecture

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -11,6 +11,7 @@
     "./skills/review-code",
     "./skills/update-branch",
     "./skills/install-skills",
-    "./skills/write-docs"
+    "./skills/write-docs",
+    "./skills/improve-branch-architecture"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository is the marketplace surface for Patina Project plugins and relate
 - `skills/update-branch/`: local branch update skill
 - `skills/install-skills/`: project-local skills CLI installation skill
 - `skills/write-docs/`: capture-only CONTEXT.md/ADR documentation skill
+- `skills/improve-branch-architecture/`: branch-scoped deepening recommendation skill
 - `.agents/skills/<name>/`: committed overlay. Repo-owned skills are symlinks
   into `../../skills/<name>/` (dogfood overlay); vendored third-party skills are
   real directories restored by `pnpm skills:install`. All entries are tracked.
@@ -67,7 +68,12 @@ do not edit the vendored payloads under `.agents/skills/**`.
   its source's default branch (latest), so re-running picks up upstream updates.
   When a re-vendor changes `grill-with-docs`'s `CONTEXT-FORMAT.md` or
   `ADR-FORMAT.md`, copy the changed file over the bundled `write-docs` copy by
-  hand; `write-docs-format-sync.test.sh` fails until the two match again.
+  hand; `write-docs-format-sync.test.sh` fails until the two match again. The
+  same hand-copy applies to `improve-branch-architecture`'s five bundled copies
+  (`LANGUAGE.md`, `DEEPENING.md`, `INTERFACE-DESIGN.md` from
+  `improve-codebase-architecture`; `CONTEXT-FORMAT.md`, `ADR-FORMAT.md` from
+  `grill-with-docs`); `improve-branch-architecture-format-sync.test.sh` fails
+  until each copy matches its vendored upstream again.
 - `pnpm clean`: remove generated dependency and transient install files
   (`node_modules`, `.skills-install.lock*`); never prunes committed skill overlays
 - `bash scripts/worktree-setup.sh`: shared worktree bootstrap (fast-forward onto
@@ -130,6 +136,12 @@ npm_config_ignore_scripts=true npx skills@latest add mattpocock/skills@write-a-s
   it asserts byte-equality between the two copies (a machine-consumed mirror
   contract, never their prose — see
   [docs/adr/ADR-232-format-sync-mirror-contract.md](docs/adr/ADR-232-format-sync-mirror-contract.md))
+- Run `bash scripts/tests/improve-branch-architecture-format-sync.test.sh` after
+  changing the `improve-branch-architecture` bundled reference files or their
+  vendored upstreams (`improve-codebase-architecture` and `grill-with-docs`); it
+  asserts byte-equality of the five bundled copies against their vendored sources
+  (a machine-consumed mirror contract, never their prose — same ADR-232 carve-out
+  as the `write-docs` sync test)
 
 ## Issue and PR labels
 
@@ -198,6 +210,7 @@ This repo owns these skills at flat paths:
 | update-branch | `skills/update-branch/` |
 | install-skills | `skills/install-skills/` |
 | write-docs | `skills/write-docs/` |
+| improve-branch-architecture | `skills/improve-branch-architecture/` |
 
 `find-skills` is a third-party skill from `vercel-labs/skills` and is not
 a marketplace entry in this repo.

--- a/scripts/tests/dogfood.test.sh
+++ b/scripts/tests/dogfood.test.sh
@@ -23,6 +23,7 @@ SKILLS=(
   review-code
   update-branch
   write-docs
+  improve-branch-architecture
 )
 FAIL_COUNT=0
 

--- a/scripts/tests/improve-branch-architecture-format-sync.test.sh
+++ b/scripts/tests/improve-branch-architecture-format-sync.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# improve-branch-architecture-format-sync.test.sh — Assert the bundled reference
+# files in skills/improve-branch-architecture/ are byte-identical to their
+# vendored upstream originals.
+#
+# This is a machine-consumed mirror contract, NOT a prose assertion: it checks
+# only that the files MATCH, never WHAT they say. See ADR-232
+# (docs/adr/ADR-232-format-sync-mirror-contract.md) for why this coexists with
+# ADR-224 (no tests on documentation content).
+#
+# The copies are kept in sync by hand: when this test fails after a re-vendor of
+# improve-codebase-architecture or grill-with-docs, copy the changed file over
+# the bundled copy.
+#
+# Exit 0: every bundled copy is byte-identical to its vendored original.
+# Exit 1: at least one copy diverged or is missing.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+DST="skills/improve-branch-architecture"
+FAIL_COUNT=0
+
+# Each entry maps a bundled copy to its vendored source: "<file> <vendored-dir>".
+PAIRS=(
+  "LANGUAGE.md .agents/skills/improve-codebase-architecture"
+  "DEEPENING.md .agents/skills/improve-codebase-architecture"
+  "INTERFACE-DESIGN.md .agents/skills/improve-codebase-architecture"
+  "CONTEXT-FORMAT.md .agents/skills/grill-with-docs"
+  "ADR-FORMAT.md .agents/skills/grill-with-docs"
+)
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+for pair in "${PAIRS[@]}"; do
+  f="${pair%% *}"
+  src_dir="${pair#* }"
+  src="$src_dir/$f"
+  dst="$DST/$f"
+
+  if [ ! -f "$src" ]; then
+    fail "vendored original $src is missing (run 'pnpm skills:install')"
+    continue
+  fi
+  if [ ! -f "$dst" ]; then
+    fail "bundled copy $dst is missing (copy it: cp '$src' '$dst')"
+    continue
+  fi
+  if ! cmp -s "$src" "$dst"; then
+    fail "$dst diverged from $src (re-copy it: cp '$src' '$dst')"
+    continue
+  fi
+  echo "OK: $f matches the vendored original in $src_dir"
+done
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "" >&2
+  echo "FAIL: $FAIL_COUNT improve-branch-architecture format file(s) out of sync" >&2
+  exit 1
+fi
+
+echo ""
+echo "OK: improve-branch-architecture format files in sync with vendored upstreams"
+exit 0

--- a/scripts/tests/marketplace.test.sh
+++ b/scripts/tests/marketplace.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/codex-pr-feedback-loop","./skills/review-code","./skills/update-branch","./skills/install-skills","./skills/write-docs"]'
+expected_marketplace_skills='["./skills/scaffold-repository","./skills/using-github","./skills/new-branch","./skills/develop-issue","./skills/finish-pr","./skills/codex-pr-feedback-loop","./skills/review-code","./skills/update-branch","./skills/install-skills","./skills/write-docs","./skills/improve-branch-architecture"]'
 retired_marketplace_skills='review-action|office-hours|plan-ceo-review|superteam|superteam-non-interactive'
 
 # Validate the Claude Code marketplace catalog.

--- a/scripts/tests/suite.test.sh
+++ b/scripts/tests/suite.test.sh
@@ -11,6 +11,7 @@ bash scripts/tests/scaffold-cleanup.test.sh
 bash scripts/tests/code-review-workflow.test.sh
 bash scripts/tests/workflow-cleanup.test.sh
 bash scripts/tests/write-docs-format-sync.test.sh
+bash scripts/tests/improve-branch-architecture-format-sync.test.sh
 
 # CLI compatibility canaries: representative network-backed samples that prove
 # local skill paths are accepted by the current marketplace install protocol.

--- a/skills/improve-branch-architecture/ADR-FORMAT.md
+++ b/skills/improve-branch-architecture/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/skills/improve-branch-architecture/CONTEXT-FORMAT.md
+++ b/skills/improve-branch-architecture/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/skills/improve-branch-architecture/DEEPENING.md
+++ b/skills/improve-branch-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/skills/improve-branch-architecture/INTERFACE-DESIGN.md
+++ b/skills/improve-branch-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/skills/improve-branch-architecture/LANGUAGE.md
+++ b/skills/improve-branch-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/skills/improve-branch-architecture/SKILL.md
+++ b/skills/improve-branch-architecture/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: improve-branch-architecture
+description: Find deepening opportunities scoped to the current branch's changes and the radius that can fold into them, delivered as in-conversation markdown. Use when the user wants an architecture review of this branch or current changes, wants to deepen shallow modules before finishing a PR, or says "improve the architecture of my branch / current changes". For a whole-codebase audit, use improve-codebase-architecture instead.
+---
+
+# Improve Branch Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones — scoped to **the current branch's changes** and the radius that can reasonably fold into this branch. The aim is testability and AI-navigability.
+
+This skill is the branch-scoped sibling of `improve-codebase-architecture`. It runs that skill's **entire approach** — the same three phases, the same vocabulary, the same deepening discipline, the same inline `CONTEXT.md`/ADR side effects — changed in exactly two ways:
+
+1. **Scope** is the current branch's changes plus the foldable radius, not the whole codebase.
+2. **Medium** is in-conversation markdown with ASCII before→after sketches, not a self-contained HTML report.
+
+For a whole-codebase audit, use `improve-codebase-architecture`. For a correctness/bug review of the branch, use `review-code`.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore the branch's changes
+
+Read the project's domain glossary (`CONTEXT.md`, if any) and any ADRs in `docs/adr/` for the area you're touching first, so recommendations use the project's domain language and do not re-litigate recorded decisions.
+
+**Resolve branch scope exactly as `review-code` does:**
+
+1. Resolve the repository default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name` or `git rev-parse --abbrev-ref origin/HEAD`, stripping any leading `origin/`.
+2. Compute the review base with `git merge-base origin/<default-branch> HEAD`.
+3. The change set is the committed diff from that merge-base to `HEAD`, plus staged, unstaged, and untracked changes. Include deleted files.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the change set and gather context. The exploration is bounded by the branch, but you must read past the diff hunks to judge architecture honestly:
+
+- **Read each changed file in full**, not just the changed lines — depth and seams aren't visible from hunks alone.
+- **Read the unchanged seam-partners** of the changed code: the callers and callees the changed code interfaces with, so you can judge the interface and the deletion test against real usage.
+
+Degrade to running inline if subagents are unavailable. This is an advisory skill, not a hard gate — do not halt when no `Explore` subagent surface exists.
+
+Explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the change are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+**The candidate filter is "anything foldable into this branch."** Surface friction whose fix could plausibly ride along in this branch:
+
+- Friction the branch **introduced**.
+- Pre-existing **shallowness in the files the branch touches**.
+- Foldable issues in **unchanged neighbors** (callers/callees), as long as the change set stays reasonable.
+
+Bound recommendations by keeping the change set reasonable — do not hand the contributor a sprawling refactor of unrelated, unchanged code. That is the job of `improve-codebase-architecture`.
+
+### 2. Present candidates as in-conversation markdown
+
+Present candidates directly in the conversation as markdown cards. **Write no HTML file and open nothing.** Markdown renders in any surface, including a terminal where HTML and Mermaid do not.
+
+For each candidate, a card with these fields:
+
+- **Files** — which changed files/modules (and which foldable neighbors) are involved.
+- **Problem** — why the current architecture causes friction, in the [LANGUAGE.md](LANGUAGE.md) vocabulary, with **deletion-test** reasoning.
+- **Solution** — plain-English description of what would change.
+- **Benefits** — explained in terms of **locality** and **leverage**, and how the **test surface** improves, naming the **dependency category** from [DEEPENING.md](DEEPENING.md).
+- **Before → After sketch** — an **ASCII** sketch (not a fenced Mermaid/HTML diagram) illustrating the shallowness and the deepening. Use boxes, arrows, and indentation so the shallow→deep shift is visible in any surface.
+- **Strength** — a badge, one of `Strong`, `Worth exploring`, `Speculative`.
+
+End with a **Top recommendation**: which candidate to tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. After presenting the cards, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Classify the candidate's dependencies (in-process, local-substitutable, remote-but-owned, true-external) and recommend the matching seam/adapter/testing strategy so the deepened module is testable through its interface. See [DEEPENING.md](DEEPENING.md).
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` using [CONTEXT-FORMAT.md](CONTEXT-FORMAT.md). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](ADR-FORMAT.md).
+  - When the repo documents its own ADR file-naming scheme (this repo names ADRs after the originating issue — see `docs/adr/README.md`), follow the repo over the default in [ADR-FORMAT.md](ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** Use the parallel sub-agent interface-design pass in [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).
+
+## Attribution
+
+This skill mirrors the `improve-codebase-architecture` and `grill-with-docs` skills in [`mattpocock/skills`](https://github.com/mattpocock/skills). Its bundled reference files are copied verbatim from those skills:
+
+- [LANGUAGE.md](LANGUAGE.md), [DEEPENING.md](DEEPENING.md), and [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md) from `improve-codebase-architecture`.
+- [CONTEXT-FORMAT.md](CONTEXT-FORMAT.md) and [ADR-FORMAT.md](ADR-FORMAT.md) from `grill-with-docs`.
+
+The parent's `HTML-REPORT.md` is intentionally **not** copied — this skill emits in-conversation markdown, never HTML.


### PR DESCRIPTION
## Linked issue

Closes #236

## What changed

Context: standalone - first implementation of the branch-scoped architecture review skill (depends on #232, which landed the copy + sync-test pattern and the ADR-232 carve-out this skill reuses)

- Added repo-owned skill `skills/improve-branch-architecture/` - the branch-scoped sibling of the vendored `improve-codebase-architecture`, so contributors can get deepening recommendations scoped to their branch's changes instead of a whole-codebase audit.
- Ran the parent's full three-phase approach (explore → present candidates → grilling/deepening loop) with exactly two deltas: scope is the current branch's changes plus the foldable radius (resolved the way `review-code` resolves it), and the medium is in-conversation markdown with ASCII before→after sketches instead of an HTML report.
- Bundled five reference files byte-identical to their vendored upstreams (`LANGUAGE.md`, `DEEPENING.md`, `INTERFACE-DESIGN.md` from `improve-codebase-architecture`; `CONTEXT-FORMAT.md`, `ADR-FORMAT.md` from `grill-with-docs`), so the skill ships to the marketplace without depending on a vendored skill's internal layout. `HTML-REPORT.md` is intentionally not bundled.
- Added `scripts/tests/improve-branch-architecture-format-sync.test.sh` to assert each bundled copy stays byte-identical to its vendored source - a machine-consumed mirror contract under the existing ADR-232 carve-out, mirroring `write-docs-format-sync.test.sh`. Wired it into `suite.test.sh`.
- Wired the skill through the rest of the repo surface the way every other repo-owned skill is: both overlay symlinks, `.claude-plugin/`/`.codex-plugin/` manifests, the `dogfood.test.sh` SKILLS array, the `marketplace.test.sh` expected catalog, and the `AGENTS.md` project-structure list, Skill Releases table, Testing Guidelines, and `skills:install` hand-copy note.
